### PR TITLE
Fix to CHEBPOLYPLOT() relating to changes in GET() behaviour.

### DIFF
--- a/@chebfun/chebpolyplot.m
+++ b/@chebfun/chebpolyplot.m
@@ -33,6 +33,11 @@ holdState = ishold;
 numfuns = numel(f.funs);
 n = cell(numfuns, 1);
 c = get(f, 'coeffs');
+% [TODO]: GET('coeffs') should not be used. We proably need chebpolyplotData()
+% methods, similar to those used by the PLOT() funtion.
+if ( ~iscell(c) )
+    c = {c};
+end
 c = cellfun(@abs, c, 'UniformOutput', false);
 for k = 1:numfuns
     n{k} = (size(c{k}, 1)-1:-1:0).';

--- a/@chebfun/get.m
+++ b/@chebfun/get.m
@@ -1,6 +1,6 @@
 function out = get(f, prop)
 %GET   GET method for the CHEBFUN class
-%   P = GET(F,PROP) returns the property P specified in the string PROP from
+%   P = GET(F, PROP) returns the property P specified in the string PROP from
 %   the CHEBFUN F. Valid entries for the string PROP are:
 %       'DOMAIN'         - The domain of definintion of F.
 %       'FUNS'           - The piecewise smooth components of F.


### PR DESCRIPTION
GET(f, 'coeffs') returns a vector when f has a single FUN and
a cell array otherwise. CHEBPOLYPLOT() needs to deal with this.

However, I don't think we should be using GET('coeffs') anyway,
rather a CHEBPOLYPLOTDATA() method like in PLOTDATA().
