### PR TITLE
Fix vscale updates for constant chebtechs.

### DIFF
--- a/@chebtech/imag.m
+++ b/@chebtech/imag.m
@@ -9,7 +9,7 @@ function f = imag(f)
 
 % Compute the imaginary part of the values:
 f.values = imag(f.values);
-f.vscale = max(abs(f.values));
+f.vscale = max(abs(f.values), [], 1);
 
 if ( ~any(f.values(:)) )
     % Input was real, so output a zero CHEBTECH:

--- a/@chebtech/real.m
+++ b/@chebtech/real.m
@@ -9,7 +9,7 @@ function f = real(f)
 
 % Compute the real part of the values:
 f.values = real(f.values);
-f.vscale = max(abs(f.values));
+f.vscale = max(abs(f.values), [], 1);
 
 if ( ~any(f.values(:)) )
     % Input was imaginary, so output a zero CHEBTECH:

--- a/@chebtech/simplify.m
+++ b/@chebtech/simplify.m
@@ -55,7 +55,7 @@ end
 
 % Update values and epslevel:
 f.values = f.coeffs2vals(f.coeffs);
-f.vscale = max(abs(f.values));
+f.vscale = max(abs(f.values), [], 1);
 f.epslevel = max(f.epslevel, tol);
 
 end


### PR DESCRIPTION
Without these extra arguments, the vscale update will do the wrong thing for constant chebtechs, whose values fields are row vectors.
