### PR TITLE
Fix bug in chebfun.subsref() for evaluating on non-column inputs.

### DIFF
--- a/@chebfun/subsref.m
+++ b/@chebfun/subsref.m
@@ -51,13 +51,13 @@ switch index(1).type
         varin = {};                 % Additional arguments.
         
         % Deal with additional arguments:
-        if ( length(idx) == 2 ) && ...
-                ( any(strcmpi(idx{2}, {'left', 'right', '-', '+'})) )
+        if ( (length(idx) == 2) && ...
+             any(strcmpi(idx{2}, {'left', 'right', '-', '+'})) )
             % f(x, 'left') or f(x, 'right'):
             varin = {idx(2)};
             
         elseif ( (length(idx) == 2) && ...
-                ( max(idx{2}) <= columnIndex(end) || strcmp(idx{2}, ':')) )
+                 ((max(idx{2}) <= columnIndex(end)) || strcmp(idx{2}, ':')) )
             % f(x, m), for array-valued CHEBFUN objects:
             columnIndex = idx{2};         
             
@@ -74,16 +74,29 @@ switch index(1).type
         if ( isnumeric(x) )
             % Call FEVAL():
             out = feval(f, x, varin{:});
-            out = out(:, columnIndex);
-            
+
+            % Figure out which columns of the output we need to select:
+            % (NB:  This code uses the assumption that columnIndex is a row.)
+            evalPointCols = size(x, 2);
+            outCols = bsxfun(@plus, (columnIndex - 1)*evalPointCols + 1, ...
+                (0:1:(evalPointCols - 1)).');
+
+            % Select only the required columns of the output:
+            % (NB:  The cell array of colons is a hack to deal with the fact
+            % that x can have any number of dimensions.)
+            extraDims = ndims(x) - 2;
+            extraColons = repmat(':', 1, extraDims);
+            extraColons = mat2cell(extraColons, 1, ones(1, extraDims));
+            out = out(:, outCols(:), extraColons{:});
+
         elseif ( isa(x, 'chebfun') )
             % Call COMPOSE():
             out = compose(x, f);
             
         elseif ( isequal(x, ':') )
             % Return f:
-            if ( numel(columnIndex) == size(f, 2) && ...
-                    all(columnIndex == 1:size(f, 2)) )
+            if ( (numel(columnIndex) == size(f, 2)) && ...
+                 all(columnIndex == 1:size(f, 2)) )
                 out = f;
             else
                 % Extract the required columns:
@@ -97,8 +110,10 @@ switch index(1).type
         end
         
         % Deal with row CHEBFUN objects:
+        % (NB:  We call PERMUTE instead of TRANSPOSE in case OUT is
+        % multidimensional).
         if ( isTransposed )
-            out = out.';
+            out = permute(out, [2 1 3:ndims(out)]);
         end
     
 %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% GET %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/tests/chebfun/test_subsref.m
+++ b/tests/chebfun/test_subsref.m
@@ -29,52 +29,66 @@ catch ME
     pass(6) = strcmp(ME.identifier, 'CHEBFUN:subsref:nonnumeric');
 end
 
+x_mtx = reshape(xr, [100 10]);
+pass(7) = isequal(feval(f, x_mtx), f(x_mtx));
+x_3mtx = reshape(xr, [5 20 10]);
+pass(8) = isequal(feval(f, x_3mtx), f(x_3mtx));
+x_4mtx = reshape(xr, [5 4 5 10]);
+pass(9) = isequal(feval(f, x_4mtx), f(x_4mtx));
+
 f.isTransposed = 1;
-pass(7) = isequal(feval(f, xr), f(xr));
+pass(10) = isequal(feval(f, xr), f(xr)) && isequal(feval(f, x_4mtx), f(x_4mtx));
 
 % Test () syntaxes with an array-valued chebfun.
 f = chebfun(@(x) [sin(x - 0.1) cos(x - 0.2)]);
-pass(8) = isequal(feval(f, xr), f(xr));
+pass(11) = isequal(feval(f, xr), f(xr));
 y1 = feval(f, xr);
 y1 = y1(:, 2);
 y2 = f(xr, 2);
-pass(9) = isequal(y1, y2);
+pass(12) = isequal(y1, y2);
+
+x_mtx = reshape(xr, [100 10]);
+pass(13) = isequal(feval(f, x_mtx), f(x_mtx));
+x_3mtx = reshape(xr, [5 20 10]);
+pass(14) = isequal(feval(f, x_3mtx), f(x_3mtx));
+x_4mtx = reshape(xr, [5 4 5 10]);
+pass(15) = isequal(feval(f, x_4mtx), f(x_4mtx));
 
 f.isTransposed = 1;
-pass(10) = isequal(feval(f, xr), f(xr));
+pass(16) = isequal(feval(f, xr), f(xr)) && isequal(feval(f, x_4mtx), f(x_4mtx));
 
 % Test {} syntaxes.
 f = chebfun(@(x) sin(x - 0.1));
-pass(11) = isequal(f, f{:});
-pass(12) = isequal(f{-1, -0.1, 0.2, 1}, restrict(f, [-1 -0.1 0.2 1]));
+pass(17) = isequal(f, f{:});
+pass(18) = isequal(f{-1, -0.1, 0.2, 1}, restrict(f, [-1 -0.1 0.2 1]));
 
 try
     y = f{'X'};
-    pass(13) = false;
+    pass(19) = false;
 catch ME
-    pass(13) = strcmp(ME.identifier, 'CHEBFUN:subsref:baddomain');
+    pass(19) = strcmp(ME.identifier, 'CHEBFUN:subsref:baddomain');
 end
 
 try
     index.subs = {[1 2], [3 4]}.';
     index.type = '{}';
     y = subsref(f, index);
-    pass(14) = false;
+    pass(20) = false;
 catch ME
-    pass(14) = strcmp(ME.identifier, 'CHEBFUN:subsref:dimensions');
+    pass(20) = strcmp(ME.identifier, 'CHEBFUN:subsref:dimensions');
 end
 
 try
     index.subs = [];
     index.type = '[]';
     y = subsref(f, index);
-    pass(15) = false;
+    pass(21) = false;
 catch ME
-    pass(15) = strcmp(ME.identifier, 'CHEBFUN:subsref:unexpectedType');
+    pass(21) = strcmp(ME.identifier, 'CHEBFUN:subsref:unexpectedType');
 end
 
 % Test {} syntaxes with an array-valued chebfun.
 f = chebfun(@(x) [sin(x - 0.1) cos(x - 0.2)]);
-pass(16) = isequal(f{-1, -0.1, 0.2, 1}, restrict(f, [-1 -0.1 0.2 1]));
+pass(22) = isequal(f{-1, -0.1, 0.2, 1}, restrict(f, [-1 -0.1 0.2 1]));
 
 end


### PR DESCRIPTION
The code supporting, e.g., the syntax f(x, colIndex) was returning just the
columns colIndex of the result.  This works fine if x is a column vector, but
it fails if x is a row vector or array.  This commit fixes this issue by
properly calculating which columns need to be selected based on the size of the
input.

The test for subsref() has been updated accordingly.
