### PR TITLE
Don't preallocate pass matrices in tests.

### DIFF
--- a/tests/bndfun/test_changeMap.m
+++ b/tests/bndfun/test_changeMap.m
@@ -7,8 +7,6 @@ if ( nargin < 1 )
     pref = chebpref();
 end
 
-pass = zeros(1, 2); % Pre-allocate pass matrix.
-
 % Test with two domains:
 dom1 = [-3 1];
 dom2 = [-2 7];

--- a/tests/bndfun/test_compose.m
+++ b/tests/bndfun/test_compose.m
@@ -10,8 +10,6 @@ end
 dom = [-2 7];
 x = linspace(dom(1), dom(2), 1000);
 
-pass = zeros(1, 9); % Pre-allocate pass matrix.
-
 % Compose a scalar-valued BNDFUN object with sin(x):
 f = bndfun(@(x) x, dom);
 g = compose(f, @sin, [], pref);

--- a/tests/bndfun/test_constructor.m
+++ b/tests/bndfun/test_constructor.m
@@ -10,8 +10,6 @@ end
 % Set the domain
 dom = [-2 7];
 
-pass = zeros(1, 5); % Pre-allocate pass matrix.
-
 %%
 
 % Test on a scalar-valued function for interpolation:

--- a/tests/bndfun/test_createMap.m
+++ b/tests/bndfun/test_createMap.m
@@ -2,8 +2,6 @@
 
 function pass = test_createMap(pref)
 
-pass = zeros(1, 2); % Pre-allocate pass matrix.
-
 dom = [-2 7];
 map = bndfun.createMap(dom);
 

--- a/tests/bndfun/test_cumsum.m
+++ b/tests/bndfun/test_cumsum.m
@@ -15,8 +15,6 @@ a = dom(1);
 seedRNG(6178);
 x = diff(dom) * rand(100, 1) + dom(1);
 
-pass = zeros(1, 10); % Pre-allocate pass matrix
-
 %%
 % Spot-check antiderivatives for a couple of functions. We also check that 
 % feval(cumsum(f), a) == 0 each time.

--- a/tests/bndfun/test_diff.m
+++ b/tests/bndfun/test_diff.m
@@ -14,8 +14,6 @@ dom = [-2 7];
 seedRNG(6178);
 x = diff(dom) * rand(100, 1) + dom(1);
 
-pass = zeros(1, 15); % Pre-allocate pass matrix
-
 %%
 % Spot-check derivatives for a couple of functions.
 

--- a/tests/bndfun/test_feval.m
+++ b/tests/bndfun/test_feval.m
@@ -14,8 +14,6 @@ dom = [-2 7];
 seedRNG(7681);
 x = diff(dom) * rand(1000, 1) + dom(1);
 
-pass = zeros(1, 9); % Pre-allocate pass matrix.
-
 %%
 % Spot-check values for a couple of functions.  We can only expect
 % accuracy on the order of the truncation level, so we use this as our

--- a/tests/bndfun/test_innerProduct.m
+++ b/tests/bndfun/test_innerProduct.m
@@ -17,8 +17,6 @@ dom = [-2 7];
 alpha = -0.194758928283640 + 0.075474485412665i;
 beta = -0.526634844879922 - 0.685484380523668i;
 
-pass = zeros(1, 11); % Pre-allocate pass matrix
-
 %%
 % Spot-check a few known results.
 

--- a/tests/bndfun/test_mldivide.m
+++ b/tests/bndfun/test_mldivide.m
@@ -17,8 +17,6 @@ dom = [-2 7];
 seedRNG(6178);
 x = diff(dom) * rand(100, 1) + dom(1);
 
-pass = zeros(1, 6); % Pre-allocate pass matrix
-
 %%
 % Basic correctness checks.
 

--- a/tests/bndfun/test_mrdivide.m
+++ b/tests/bndfun/test_mrdivide.m
@@ -17,8 +17,6 @@ x = diff(dom) * rand(100, 1) + dom(1);
 % Random number to use as a scalar constant.
 alpha = -0.194758928283640 + 0.075474485412665i;
 
-pass = zeros(1, 9); % Pre-allocate pass matrix
-
 %%
 % Check division of a BNDFUN object by a numeric array.
 

--- a/tests/bndfun/test_poly.m
+++ b/tests/bndfun/test_poly.m
@@ -10,8 +10,6 @@ end
 % Set the domain
 dom = [-2 7];
 
-pass = zeros(1, 5); % Pre-allocate pass matrix
-
 %%
 % Check a few simple examples.
 

--- a/tests/bndfun/test_qr.m
+++ b/tests/bndfun/test_qr.m
@@ -16,8 +16,6 @@ seedRNG(6178);
 % Generate a few random points to use as test values.
 x = diff(dom) * rand(100, 1) + dom(1);
 
-pass = zeros(1, 17); % Pre-allocate pass matrix
-
 %%
 % Do a few spot-checks.
 

--- a/tests/bndfun/test_restrict.m
+++ b/tests/bndfun/test_restrict.m
@@ -10,8 +10,6 @@ end
 % Set the domain
 dom = [-2 7];
 
-pass = zeros(1, 14); % Pre-allocate pass matrix
-
 %%
 % Check behavior for empty inputs.
 f = bndfun();

--- a/tests/bndfun/test_sum.m
+++ b/tests/bndfun/test_sum.m
@@ -16,8 +16,6 @@ seedRNG(6178);
 % Generate a few random points to use as test values.
 x = diff(dom) * rand(1000, 1) + dom(1);
 
-pass = zeros(1, 11); % Pre-allocate pass matrix
-
 %%
 % Spot-check integrals for a couple of functions.
 f = bndfun(@(x) exp(x) - 1, dom, [], [], pref);

--- a/tests/chebfun/test_abs.m
+++ b/tests/chebfun/test_abs.m
@@ -5,9 +5,6 @@ if ( nargin < 1 )
     pref = chebpref();
 end
 
-% Pre-allocate pass matrix:
-pass = zeros(4, 6); 
-
 % Initialise random vectors:
 seedRNG(6178);
 x = 2 * rand(100, 1) - 1;

--- a/tests/chebfun/test_constructor_basic.m
+++ b/tests/chebfun/test_constructor_basic.m
@@ -9,8 +9,6 @@ end
 % Some basic test functions:
 FF = {@sin, @(x) [sin(x), cos(x)], @(x) [sin(x), cos(x), exp(-x)]};
 
-pass = zeros(3, numel(FF));
-
 for j = 1:numel(FF);
     % Initialise k:
     k = 0;

--- a/tests/chebfun/test_exp.m
+++ b/tests/chebfun/test_exp.m
@@ -16,9 +16,6 @@ xr = 2 * rand(1000, 1) - 1;
 % List of functions to test.
 expFunctions = {@exp, @expm1};
 
-% Preallocate pass matrix.
-pass = zeros(1, numel(expFunctions));
-
 % Function with which we will be composing.
 base_op = @(x) sign(x - 0.1).*abs(x + 0.2).*sin(3*x);
 f = chebfun(base_op, [-1 -0.2 0.1 1], pref);

--- a/tests/chebfun/test_extractColumns.m
+++ b/tests/chebfun/test_extractColumns.m
@@ -4,8 +4,6 @@ if ( nargin == 0 )
     pref = chebpref();
 end
 
-pass = zeros(1, 3);
-
 f = chebfun(@(x) [sin(x), cos(x), exp(x)], pref);
 g = chebfun(@(x) [sin(x), cos(x)], pref);
 h = extractColumns(f, 1:2);

--- a/tests/chebfun/test_sign.m
+++ b/tests/chebfun/test_sign.m
@@ -4,9 +4,6 @@ if ( nargin == 0 )
     pref = chebpref();
 end
 
-% Pre-allocate pass matrix:
-pass = zeros(3, 4); 
-
 % Initialise random vector:
 seedRNG(6178);
 x = 2 * rand(100, 1) - 1;

--- a/tests/chebfun/test_trig.m
+++ b/tests/chebfun/test_trig.m
@@ -21,9 +21,6 @@ trigFunctions = {@acos, @acosd, @acosh, @acot, @acotd, @acoth, @acsc, ...
 
 % [TODO]: Add tests for ATAN2() and ATAN2D().
 
-% Preallocate pass matrix.
-pass = zeros(1, numel(trigFunctions));
-
 % Function with which we will be composing.  (The reason for the shift and
 % scaling, etc. is to prevent any problems with the functions under test from
 % evaluating to Inf.)

--- a/tests/chebtech/test_abs.m
+++ b/tests/chebtech/test_abs.m
@@ -4,8 +4,6 @@ if ( nargin == 0 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 4);
-
 for type = 1:2
     
     if ( type == 1 )

--- a/tests/chebtech/test_bary.m
+++ b/tests/chebtech/test_bary.m
@@ -10,7 +10,6 @@ end
 
 tol = 20*pref.eps;
 
-pass = zeros(2, 2); % Pre-allocate pass matrix.
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_cell2mat.m
+++ b/tests/chebtech/test_cell2mat.m
@@ -6,8 +6,6 @@ if ( nargin < 2 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 1); % Pre-allocate pass matrix.
-
 for n = 1:2
     
     if (n == 1);

--- a/tests/chebtech/test_clenshaw.m
+++ b/tests/chebtech/test_clenshaw.m
@@ -5,8 +5,6 @@ function pass = test_clenshaw(varargin)
 % Set a tolerance (pref.eps doesn't matter)
 tol = 10*eps;
 
-pass = zeros(1, 5); % Pre-allocate pass matrix.
-
 %%
 % Test that a single coefficient is evaluated correctly:
 % For a scalar evaluation:

--- a/tests/chebtech/test_compose.m
+++ b/tests/chebtech/test_compose.m
@@ -7,7 +7,6 @@ if ( nargin < 1 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 12); % Pre-allocate pass matrix.
 for n = 1:4
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_conj.m
+++ b/tests/chebtech/test_conj.m
@@ -6,7 +6,6 @@ if ( nargin < 1 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 2); % Pre-allocate pass matrix
 for n = 1:2
     if (n == 1)
         testclass = chebtech1();

--- a/tests/chebtech/test_cumsum.m
+++ b/tests/chebtech/test_cumsum.m
@@ -14,7 +14,6 @@ end
 seedRNG(6178);
 x = 2 * rand(100, 1) - 1;
 
-pass = zeros(2, 10); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_diff.m
+++ b/tests/chebtech/test_diff.m
@@ -11,7 +11,6 @@ end
 seedRNG(6178);
 x = 2 * rand(100, 1) - 1;
 
-pass = zeros(2, 15); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_extractBoundaryRoots.m
+++ b/tests/chebtech/test_extractBoundaryRoots.m
@@ -8,7 +8,6 @@ end
 seedRNG(6178);
 x = 2 * rand(100, 1) - 1;
 
-pass = zeros(2, 7); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_feval.m
+++ b/tests/chebtech/test_feval.m
@@ -11,7 +11,6 @@ end
 seedRNG(7681);
 x = 2 * rand(1000, 1) - 1;
 
-pass = zeros(2, 9); % Pre-allocate pass matrix.
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_fliplr.m
+++ b/tests/chebtech/test_fliplr.m
@@ -7,7 +7,6 @@ if ( nargin < 1 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2,  2); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_flipud.m
+++ b/tests/chebtech/test_flipud.m
@@ -6,7 +6,6 @@ if ( nargin < 1 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 4); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_happinessCheck.m
+++ b/tests/chebtech/test_happinessCheck.m
@@ -7,7 +7,6 @@ if ( nargin < 1 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 6); % Pre-allocate pass matrix.
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_imag.m
+++ b/tests/chebtech/test_imag.m
@@ -6,7 +6,6 @@ if ( nargin < 1 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 4); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_innerProduct.m
+++ b/tests/chebtech/test_innerProduct.m
@@ -11,7 +11,6 @@ end
 alpha = -0.194758928283640 + 0.075474485412665i;
 beta = -0.526634844879922 - 0.685484380523668i;
 
-pass = zeros(2, 11); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_isempty.m
+++ b/tests/chebtech/test_isempty.m
@@ -2,7 +2,6 @@
 
 function pass = test_isempty(varargin)
 
-pass = zeros(2, 4); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_isequal.m
+++ b/tests/chebtech/test_isequal.m
@@ -7,7 +7,6 @@ if ( nargin < 1 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 5); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_isfinite.m
+++ b/tests/chebtech/test_isfinite.m
@@ -7,7 +7,6 @@ if ( nargin < 1 )
 end
 p = pref;
 
-pass = zeros(2, 4); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_isinf.m
+++ b/tests/chebtech/test_isinf.m
@@ -7,7 +7,6 @@ if ( nargin < 1 )
 end
 p = pref;
 
-pass = zeros(2, 4); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_isnan.m
+++ b/tests/chebtech/test_isnan.m
@@ -7,7 +7,6 @@ if ( nargin < 1 )
 end
 p = pref;
 
-pass = zeros(2, 6); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_isreal.m
+++ b/tests/chebtech/test_isreal.m
@@ -6,7 +6,6 @@ if ( nargin < 1 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 6); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_iszero.m
+++ b/tests/chebtech/test_iszero.m
@@ -6,7 +6,6 @@ if ( nargin == 0 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 5); % Pre-allocate pass matrix.
 for n = 1:2
     if ( n == 1)
         testclass = chebtech1();

--- a/tests/chebtech/test_length.m
+++ b/tests/chebtech/test_length.m
@@ -6,7 +6,6 @@ if ( nargin < 1 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 3); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_mat2cell.m
+++ b/tests/chebtech/test_mat2cell.m
@@ -6,7 +6,6 @@ if ( nargin < 2 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 2); % Pre-allocate pass matrix.
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_max.m
+++ b/tests/chebtech/test_max.m
@@ -7,7 +7,6 @@ if ( nargin < 1 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 8); % Pre-allocate pass matrix.
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_min.m
+++ b/tests/chebtech/test_min.m
@@ -7,7 +7,6 @@ if ( nargin < 1 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 8); % Pre-allocate pass matrix.
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_minandmax.m
+++ b/tests/chebtech/test_minandmax.m
@@ -7,7 +7,6 @@ if ( nargin < 1 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 8); % Pre-allocate pass matrix.
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_minus.m
+++ b/tests/chebtech/test_minus.m
@@ -14,7 +14,6 @@ x = 2 * rand(100, 1) - 1;
 % A random number to use as an arbitrary additive constant.
 alpha = randn() + 1i*randn();
 
-pass = zeros(2, 21); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_mldivide.m
+++ b/tests/chebtech/test_mldivide.m
@@ -7,7 +7,6 @@ if (nargin < 1)
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 6); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_mrdivide.m
+++ b/tests/chebtech/test_mrdivide.m
@@ -14,7 +14,6 @@ x = 2 * rand(100, 1) - 1;
 % Random number to use as a scalar constant.
 alpha = -0.194758928283640 + 0.075474485412665i;
 
-pass = zeros(2, 9); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_mtimes.m
+++ b/tests/chebtech/test_mtimes.m
@@ -14,7 +14,6 @@ x = 2 * rand(100, 1) - 1;
 % A random number to use as an arbitrary scalar multiplier.
 alpha = randn() + 1i*randn();
 
-pass = zeros(2, 12); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_plus.m
+++ b/tests/chebtech/test_plus.m
@@ -14,7 +14,6 @@ x = 2 * rand(100, 1) - 1;
 % A random number to use as an arbitrary additive constant.
 alpha = -0.194758928283640 + 0.075474485412665i;
 
-pass = zeros(2, 21); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_poly.m
+++ b/tests/chebtech/test_poly.m
@@ -7,7 +7,6 @@ if ( nargin < 1 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 5); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_prolong.m
+++ b/tests/chebtech/test_prolong.m
@@ -6,7 +6,6 @@ if ( nargin < 1 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 16); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_qr.m
+++ b/tests/chebtech/test_qr.m
@@ -11,7 +11,6 @@ end
 seedRNG(6178);
 x = 2 * rand(100, 1) - 1;
 
-pass = zeros(2, 17); % Pre-allocate pass matrix
 for n = 1:4
     switch ( n )
         case 1

--- a/tests/chebtech/test_quadpts.m
+++ b/tests/chebtech/test_quadpts.m
@@ -4,8 +4,6 @@ if ( nargin == 1 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 9);
-
 for m = 1:2
     if ( m == 1 )
         testTech = chebtech1();

--- a/tests/chebtech/test_rdivide.m
+++ b/tests/chebtech/test_rdivide.m
@@ -15,7 +15,6 @@ x = 2 * rand(100, 1) - 1;
 alpha = -0.194758928283640 + 0.075474485412665i;
 beta = -0.526634844879922 - 0.685484380523668i;
 
-pass = zeros(2, 15); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_real.m
+++ b/tests/chebtech/test_real.m
@@ -6,7 +6,6 @@ if ( nargin < 1 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 4); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_restrict.m
+++ b/tests/chebtech/test_restrict.m
@@ -7,7 +7,6 @@ if (nargin < 1)
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 12); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_roots.m
+++ b/tests/chebtech/test_roots.m
@@ -6,7 +6,6 @@ if ( nargin < 1 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 9); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_scaleInvariance.m
+++ b/tests/chebtech/test_scaleInvariance.m
@@ -7,8 +7,6 @@ if ( nargin == 0 )
 end
 
 % Initialise pass matrix:
-pass = zeros(2, 2);
-
 for n = 1:2
     
     % Test for both chebtech1 and chetech2

--- a/tests/chebtech/test_sign.m
+++ b/tests/chebtech/test_sign.m
@@ -4,8 +4,6 @@ if ( nargin == 0 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 4);
-
 for type = 1:2
     
     if ( type == 1 )

--- a/tests/chebtech/test_simplify.m
+++ b/tests/chebtech/test_simplify.m
@@ -11,7 +11,6 @@ end
 seedRNG(6178);
 x = 2 * rand(100, 1) - 1;
 
-pass = zeros(2, 19); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_size.m
+++ b/tests/chebtech/test_size.m
@@ -6,7 +6,6 @@ if ( nargin < 1 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 3); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_sum.m
+++ b/tests/chebtech/test_sum.m
@@ -7,7 +7,6 @@ if ( nargin < 1 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(2, 11); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech/test_times.m
+++ b/tests/chebtech/test_times.m
@@ -15,7 +15,6 @@ x = 2 * rand(100, 1) - 1;
 alpha = -0.194758928283640 + 0.075474485412665i;
 beta = -0.526634844879922 - 0.685484380523668i;
 
-pass = zeros(2, 23); % Pre-allocate pass matrix
 for n = 1:2
     if ( n == 1 )
         testclass = chebtech1();

--- a/tests/chebtech1/test_alias.m
+++ b/tests/chebtech1/test_alias.m
@@ -5,8 +5,6 @@ function pass = test_alias(varargin)
 % Set a tolerance (pref.eps doesn't matter)
 tol = 2e2*eps;
 
-pass = zeros(1, 11); % Pre-allocate pass matrix
-
 %%
 % Testing a vector of coefficients.
 c0 = (1:10)';

--- a/tests/chebtech1/test_chebpts.m
+++ b/tests/chebtech1/test_chebpts.m
@@ -5,8 +5,6 @@ function pass = test_chebpts(varargin)
 % Set a tolerance (pref.eps doesn't matter)
 tol = 10*eps;
 
-pass = zeros(1, 11); % Pre-allocate pass matrix
-
 % Test that n = 0 returns empty results:
 [x, w, v] = chebtech1.chebpts(0);
 pass(1) = ( isempty(x) && isempty(w) && isempty(v) );

--- a/tests/chebtech1/test_coeffs2vals.m
+++ b/tests/chebtech1/test_coeffs2vals.m
@@ -5,8 +5,6 @@ function pass = test_coeffs2vals(varargin)
 % Set a tolerance (pref.eps doesn't matter)
 tol = 100*eps;
 
-pass = zeros(1, 7); % Pre-allocate pass matrix
-
 %%
 % Test that a single coefficient is converted correctly
 c = sqrt(2);

--- a/tests/chebtech1/test_constructor.m
+++ b/tests/chebtech1/test_constructor.m
@@ -7,8 +7,6 @@ if ( nargin < 1 )
     pref = chebtech.techPref();
 end
 
-pass = zeros(1, 4); % Pre-allocate pass matrix
-
 %%
 % Test on a scalar-valued function:
 pref.refinementFunction = 'default';

--- a/tests/chebtech1/test_extrapolate.m
+++ b/tests/chebtech1/test_extrapolate.m
@@ -11,7 +11,6 @@ end
 tol = 100*pref.eps;
 
 % Initialise:
-pass = zeros(1, 4);
 s = 0;
 
 n = 17;

--- a/tests/chebtech1/test_vals2coeffs.m
+++ b/tests/chebtech1/test_vals2coeffs.m
@@ -5,8 +5,6 @@ function pass = test_vals2coeffs(varargin)
 % Set a tolerance (pref.eps doesn't matter)
 tol = 100*eps;
 
-pass = zeros(1, 7); % Pre-allocate pass matrix
-
 %%
 % Test that a single value is converted correctly
 v = sqrt(2);

--- a/tests/chebtech2/test_alias.m
+++ b/tests/chebtech2/test_alias.m
@@ -5,8 +5,6 @@ function pass = test_alias(varargin)
 % Set a tolerance (pref.eps doesn't matter)
 tol = 100*eps;
 
-pass = zeros(1, 11); % Pre-allocate pass matrix.
-
 %%
 % Testing a vector of coefficients.
 c0 = (1:10)';

--- a/tests/chebtech2/test_chebpts.m
+++ b/tests/chebtech2/test_chebpts.m
@@ -5,8 +5,6 @@ function pass = test_chebpts(varargin)
 % Set a tolerance (pref.eps doesn't matter)
 tol = 10*eps;
 
-pass = zeros(1, 11); % Pre-allocate pass matrix.
-
 % Test that n = 0 returns empty results:
 [x, w, v] = chebtech2.chebpts(0);
 pass(1) = ( isempty(x) && isempty(w) && isempty(v) );

--- a/tests/chebtech2/test_coeffs2vals.m
+++ b/tests/chebtech2/test_coeffs2vals.m
@@ -5,8 +5,6 @@ function pass = test_coeffs2vals(varargin)
 % Set a tolerance (pref.eps doesn't matter)
 tol = 100*eps;
 
-pass = zeros(1, 7); % Pre-allocate pass matrix.
-
 %%
 % Test that a single coefficient is converted correctly
 c = sqrt(2);

--- a/tests/chebtech2/test_constructor.m
+++ b/tests/chebtech2/test_constructor.m
@@ -9,8 +9,6 @@ end
 % Set the tolerance:
 tol = 100*pref.eps;
 
-pass = zeros(1, 19); % Pre-allocate pass matrix.
-
 %%
 % Test on a scalar-valued function:
 pref.extrapolate = 0;

--- a/tests/chebtech2/test_extrapolate.m
+++ b/tests/chebtech2/test_extrapolate.m
@@ -11,7 +11,6 @@ end
 tol = 100*pref.eps;
 
 % Initialise:
-pass = zeros(1, 12);
 s = 0;
 
 n = 17;

--- a/tests/chebtech2/test_vals2coeffs.m
+++ b/tests/chebtech2/test_vals2coeffs.m
@@ -5,8 +5,6 @@ function pass = test_vals2coeffs(varargin)
 % Set a tolerance (pref.eps doesn't matter)
 tol = 100*eps;
 
-pass = zeros(1, 7); % Pre-allocate pass matrix.
-
 %%
 % Test that a single value is converted correctly
 v = sqrt(2);

--- a/tests/fun/test_isempty.m
+++ b/tests/fun/test_isempty.m
@@ -2,7 +2,6 @@
 
 function pass = test_isempty(varargin)
 
-pass = zeros(1, 4); % Pre-allocate pass matrix
 for n = 1:1 %[TODO]: unbndfun
     if ( n == 1 )
         testclass = bndfun();

--- a/tests/fun/test_isequal.m
+++ b/tests/fun/test_isequal.m
@@ -7,7 +7,6 @@ if ( nargin < 1 )
     pref = chebpref();
 end
 
-pass = zeros(1, 5); % Pre-allocate pass matrix
 for n = 1:1 %[TODO]: unbndfun
     
     if ( n == 1 )

--- a/tests/fun/test_mat2cell.m
+++ b/tests/fun/test_mat2cell.m
@@ -6,7 +6,6 @@ if ( nargin < 2 )
     pref = chebpref();
 end
 
-pass = zeros(1, 2); % Pre-allocate pass matrix.
 for n = 1:1 %[TODO]: unbndfun
     if ( n == 1 )
         testclass = bndfun();

--- a/tests/fun/test_max.m
+++ b/tests/fun/test_max.m
@@ -7,7 +7,6 @@ if ( nargin < 1 )
     pref = chebpref();
 end
 
-pass = zeros(1, 7); % Pre-allocate pass matrix.
 for n = 1:1 %[TODO]: unbndfun
     if ( n == 1 )
         testclass = bndfun();

--- a/tests/fun/test_min.m
+++ b/tests/fun/test_min.m
@@ -7,7 +7,6 @@ if ( nargin < 1 )
     pref = chebpref();
 end
 
-pass = zeros(1, 7); % Pre-allocate pass matrix.
 for n = 1:1 %[TODO]: unbndfun
     if ( n == 1 )
         testclass = bndfun();

--- a/tests/fun/test_minandmax.m
+++ b/tests/fun/test_minandmax.m
@@ -7,7 +7,6 @@ if ( nargin < 1 )
     pref = chebpref();
 end
 
-pass = zeros(1, 6); % Pre-allocate pass matrix.
 for n = 1:1 %[TODO]: unbndfun
     if ( n == 1 )
         testclass = bndfun();

--- a/tests/fun/test_minus.m
+++ b/tests/fun/test_minus.m
@@ -13,7 +13,6 @@ seedRNG(6178);
 % A random number to use as an arbitrary additive constant.
 alpha = randn() + 1i*randn();
 
-pass = zeros(1, 21); % Pre-allocate pass matrix
 for n = 1:1 %[TODO]: unbndfun
     if ( n == 1 )
         testclass = bndfun();

--- a/tests/fun/test_mtimes.m
+++ b/tests/fun/test_mtimes.m
@@ -13,7 +13,6 @@ seedRNG(6178);
 % A random number to use as an arbitrary scalar multiplier.
 alpha = randn() + 1i*randn();
 
-pass = zeros(1, 12); % Pre-allocate pass matrix
 for n = 1:1 %[TODO]: unbndfun
     if ( n == 1 )
         testclass = bndfun();

--- a/tests/fun/test_plus.m
+++ b/tests/fun/test_plus.m
@@ -17,8 +17,6 @@ x = diff(dom) * rand(100, 1) + dom(1);
 % A random number to use as an arbitrary additive constant.
 alpha = -0.194758928283640 + 0.075474485412665i;
 
-pass = zeros(1, 21); % Pre-allocate pass matrix
-
 %%
 % Check operation in the face of empty arguments.
 

--- a/tests/fun/test_rdivide.m
+++ b/tests/fun/test_rdivide.m
@@ -14,7 +14,6 @@ seedRNG(6178);
 alpha = -0.194758928283640 + 0.075474485412665i;
 beta = -0.526634844879922 - 0.685484380523668i;
 
-pass = zeros(1, 13); % Pre-allocate pass matrix
 for n = 1:1 %[TODO]: unbndfun
     if ( n == 1 )
         testclass = bndfun();

--- a/tests/fun/test_roots.m
+++ b/tests/fun/test_roots.m
@@ -6,7 +6,6 @@ if ( nargin < 1 )
     pref = chebpref();
 end
 
-pass = zeros(1, 9); % Pre-allocate pass matrix
 for n = 1:1  %[TODO]: unbndfun
     if ( n == 1 )
         testclass = bndfun();

--- a/tests/fun/test_times.m
+++ b/tests/fun/test_times.m
@@ -18,8 +18,6 @@ x = diff(dom) * rand(1000, 1) + dom(1);
 alpha = -0.194758928283640 + 0.075474485412665i;
 beta = -0.526634844879922 - 0.685484380523668i;
 
-pass = zeros(1, 23); % Pre-allocate pass matrix
-
 %%
 % Check operation in the face of empty arguments.
 

--- a/tests/singfun/test_conj.m
+++ b/tests/singfun/test_conj.m
@@ -7,9 +7,6 @@ if ( nargin < 1 )
     pref = chebpref();
 end
 
-% Pre-allocate pass matrix
-pass = zeros(1, 6);
-
 %%
 % Empty
 f = singfun();

--- a/tests/singfun/test_cumsum.m
+++ b/tests/singfun/test_cumsum.m
@@ -19,9 +19,6 @@ c = 1.28;
 d = -1.28;
 e = -2.56;
 
-% Pre-allocate pass matrix
-pass = zeros(1, 9);
-
 %%
 % Tests with exact solution:
 

--- a/tests/singfun/test_diff.m
+++ b/tests/singfun/test_diff.m
@@ -18,9 +18,6 @@ b = -0.56;
 c = 1.28;
 d = -1.28;
 
-% Pre-allocate pass matrix
-pass = zeros(1, 9);
-
 % Check for empty cases
 f = singfun();
 pass(1) = isempty(diff(f));

--- a/tests/singfun/test_feval.m
+++ b/tests/singfun/test_feval.m
@@ -11,8 +11,6 @@ end
 seedRNG(786);
 x = -1 + 2*rand(100, 1);
 
-pass = zeros(1, 4); % Pre-allocate pass vector
-
 %% 
 % Check feval on empty set of points
 f = singfun(@(x) x, [0, 0], {'none', 'none'});

--- a/tests/singfun/test_flipud.m
+++ b/tests/singfun/test_flipud.m
@@ -18,9 +18,6 @@ b = -0.64;
 c = 1.28;
 d = -1.28;
 
-% Pre-allocate pass matrix
-pass = zeros(1, 7);
-
 %%
 % Spot-check derivatives for a couple of functions.
 

--- a/tests/singfun/test_imag.m
+++ b/tests/singfun/test_imag.m
@@ -7,9 +7,6 @@ if ( nargin < 1 )
     pref = chebpref();
 end
 
-% Pre-allocate pass matrix
-pass = zeros(1, 6);
-
 % Check for empty cases:
 f = singfun();
 pass(1) = isempty(imag(f));

--- a/tests/singfun/test_innerProduct.m
+++ b/tests/singfun/test_innerProduct.m
@@ -15,9 +15,6 @@ d = -1.28;
 p = -0.2;
 q = -0.3;
 
-% Pre-allocate pass matrix
-pass = zeros(1, 8);
-
 % fractional pole at the left endpoint
 f = singfun(@(x) (1+x).^p, [p 0], {'sing', 'none'}, [], [], pref);
 g = singfun(@(x) (1+x).^q, [q 0], {'sing', 'none'}, [], [], pref);

--- a/tests/singfun/test_isequal.m
+++ b/tests/singfun/test_isequal.m
@@ -9,7 +9,6 @@ end
 
 %%
 % declare pass vector
-pass = zeros(1,5);
 %%
 % create an empty SINGFUN
 f = singfun();

--- a/tests/singfun/test_isfinite.m
+++ b/tests/singfun/test_isfinite.m
@@ -13,9 +13,6 @@ b = -0.64;
 c = 1.28;
 d = -1.28;
 
-% Pre-allocate pass matrix
-pass = zeros(1, 2);
-
 %%
 % Check a few cases.
 

--- a/tests/singfun/test_isnan.m
+++ b/tests/singfun/test_isnan.m
@@ -13,9 +13,6 @@ b = -0.64;
 c = 1.28;
 d = -1.28;
 
-% Pre-allocate pass matrix
-pass = zeros(1, 2);
-
 %%
 % Check a few cases.
 

--- a/tests/singfun/test_make.m
+++ b/tests/singfun/test_make.m
@@ -7,8 +7,6 @@ if ( nargin < 1 )
     pref = chebpref();
 end
 
-pass = zeros(1, 6); % Pre-allocate pass matrix
-
 % tests on different calling sequences:
 
 %%

--- a/tests/singfun/test_minandmax.m
+++ b/tests/singfun/test_minandmax.m
@@ -13,9 +13,6 @@ b = -0.64;
 c = 1.28;
 d = -1.28;
 
-% Pre-allocate pass matrix
-pass = zeros(1, 5);
-
 % fractional root at the left endpoint and the function value is bounded.
 f = singfun(@(x) (1+x).^a.*exp(x), [a 0], {'root', 'none'}, [], [], pref);
 [y, x] = minandmax(f);

--- a/tests/singfun/test_plus.m
+++ b/tests/singfun/test_plus.m
@@ -14,8 +14,6 @@ x = 2 * rand(100, 1) - 1;
 % A random number to use as an arbitrary additive constant.
 alpha = -0.194758928283640 + 0.075474485412665i;
 
-pass = zeros(1, 14); % Pre-allocate pass vector
-
 %%
 % Check operation in the case of empty arguments.
 f = singfun();

--- a/tests/singfun/test_rdivide.m
+++ b/tests/singfun/test_rdivide.m
@@ -12,8 +12,6 @@ seedRNG(666);
 x = 2 * rand(100, 1) - 1;
 x = sort(x);
 
-pass = zeros(1, 9);   % Pre-allocate pass vector
-
 %%
 % Check operation in the case of empty arguments.
 f = singfun();

--- a/tests/singfun/test_real.m
+++ b/tests/singfun/test_real.m
@@ -7,9 +7,6 @@ if ( nargin < 1 )
     pref = chebpref();
 end
 
-% Pre-allocate pass matrix
-pass = zeros(1, 4);
-
 % Check for empty cases:
 f = singfun();
 pass(1) = isempty(real(f));

--- a/tests/singfun/test_restrict.m
+++ b/tests/singfun/test_restrict.m
@@ -13,9 +13,6 @@ b = -0.64;
 c = 1.28;
 d = -1.28;
 
-% Pre-allocate pass matrix
-pass = zeros(1, 6);
-
 % Fractional root at the left endpoint and the smooth part has no roots in 
 % [-1 1]. We restrict f to a subinterval which is far enough from the endpoint
 % singularities or roots.

--- a/tests/singfun/test_roots.m
+++ b/tests/singfun/test_roots.m
@@ -13,9 +13,6 @@ b = -0.56;
 c = 1.28;
 d = -1.28;
 
-% Pre-allocate pass matrix
-pass = zeros(1, 6);
-
 % fractional root at the left endpoint and the smooth part has no roots in 
 % [-1 1].
 f = singfun(@(x) (1+x).^a.*exp(x), [a 0], {'root', 'none'}, [], [], pref);

--- a/tests/singfun/test_singfun_constructor.m
+++ b/tests/singfun/test_singfun_constructor.m
@@ -7,8 +7,6 @@ if ( nargin < 1 )
     pref = chebpref();
 end
 
-pass = zeros(1, 18); % Pre-allocate pass matrix
-
 %%
 % Select some random points as sample points
 % These random points are in [-1, 1]

--- a/tests/singfun/test_sum.m
+++ b/tests/singfun/test_sum.m
@@ -13,9 +13,6 @@ b = -0.64;
 c = 1.28;
 d = -1.28;
 
-% Pre-allocate pass matrix
-pass = zeros(1, 7);
-
 % fractional root at the left endpoint
 f = singfun(@(x) (1+x).^a.*exp(x), [a 0], {'root', 'none'}, [], [], pref);
 I = sum(f);

--- a/tests/singfun/test_times.m
+++ b/tests/singfun/test_times.m
@@ -20,9 +20,6 @@ d = -1.28;
 p = -0.2;
 q = -0.3;
 
-% Pre-allocate pass matrix
-pass = zeros(1, 10);
-
 % Check operation in the case of empty arguments.
 f = singfun();
 g = singfun(@(x) 1./(1+x), [-1, 0]);

--- a/tests/singfun/test_zeroSingFun.m
+++ b/tests/singfun/test_zeroSingFun.m
@@ -7,9 +7,6 @@ if ( nargin < 1 )
     pref = chebpref();
 end
 
-% Pre-allocate pass matrix
-pass = zeros(1, 2);
-
 %%
 % Construct the zero SINGFUN:
 f = singfun.zeroSingFun();


### PR DESCRIPTION
We decided against this in the meeting on 10/23/2013.  It doesn't gain us
anything significant in terms of test performance while creating the
possibility for confusion when people go to modify the tests.
