### PR TITLE
Flip columns of output of chebfun.vander() to comply with MATLAB.

### DIFF
--- a/@chebfun/vander.m
+++ b/@chebfun/vander.m
@@ -20,5 +20,7 @@ for j = 1:n-1
 end
 % Concatenate the columns to create an array-valued CHEBFUN:
 A = horzcat(A{:});
+% Reverse the columns to be consistent with MATLAB's built-in vander():
+A = fliplr(A);
 
 end


### PR DESCRIPTION
This closes #86 on the GitHub issues tracker.
