### PR TITLE
Fix dimensions of feval(f, x) when x is an empty matrix.

### DIFF
--- a/@chebfun/feval.m
+++ b/@chebfun/feval.m
@@ -28,8 +28,12 @@ function fx = feval(f, x, varargin)
 % preceding text accordingly.
 
 % If F or x are empty, there's nothing to do.
-if ( isempty(f) || isempty(x) )
-    fx = [];
+if ( isempty(f) )
+    fx = []
+    return
+elseif ( isempty(x) )
+    % Return empty matrix with dimensions of the appropriate size.
+    fx = zeros(size(x));
     return
 end
 

--- a/tests/chebfun/test_feval.m
+++ b/tests/chebfun/test_feval.m
@@ -13,8 +13,8 @@ xr = 2 * rand(1000, 1) - 1;
 
 % Test empty input.
 f = chebfun(@(x) x, pref);
-fx = feval(f, []);
-pass(1) = isempty(fx);
+fx = feval(f, zeros(0, 4));
+pass(1) = isequal(size(fx), [0 4]);
 
 % Test endpoint evaluation.
 pref.enableBreakpointDetection = 0;


### PR DESCRIPTION
This closes #55 on the GitHub issues tracker.  The idea is that MATLAB
functions like sin(), cos(), etc. return empty matrices of the same size as the
input when the input is empty, and therefore so should chebfun.
