### PR TITLE
Fix chebfun.cf() for chebfuns on domains other than [-1, 1].

### DIFF
--- a/@chebfun/cf.m
+++ b/@chebfun/cf.m
@@ -247,7 +247,7 @@ rho = 1/max(abs(z));
 z = .5*(z + 1./z);
 
 % Compute q from the roots for stability reasons.
-qt = chebfun(@(x) real(prod(x - z)/prod(-z)), 'vectorize');
+qt = newDomain(chebfun(@(x) real(prod(x - z)/prod(-z)), 'vectorize'), dom);
 q = chebfun;
 q = defineInterval(q, dom, qt);
 

--- a/tests/chebfun/test_cf.m
+++ b/tests/chebfun/test_cf.m
@@ -30,4 +30,10 @@ f = exp(exp(x));
 xx = linspace(-1, 1, 17);
 pass(5) = norm(f(xx) - r(xx)) < 1e-4;
 
+% Test an example that is not based on the domain [-1, 1].
+f = chebfun(@exp, [2 6]);
+[p, q, r] = cf(f, 5, 5);
+xx = linspace(2, 6, 100);
+pass(6) = norm(feval(f, xx) - r(xx), inf) < 1e-6;
+
 end


### PR DESCRIPTION
We need to remap the domain of the chebfun qt in rationalCF();
otherwise, the subdomain check in restrict() (which is called by
defineInterval()) will fail, causing an error.
