### PR TITLE
Fixing plot.m so y-limits adjust properly.

### DIFF
--- a/@chebfun/plot.m
+++ b/@chebfun/plot.m
@@ -73,14 +73,16 @@ end
 
 % Store the hold state of the current axis:
 holdState = ishold;
-if ( holdState == true )
-    % Respect current limits:
-    yLim = get(gca, 'ylim');
-else
-    yLim = [inf, -inf];
+
+% Store the current Y-limits:
+if ( holdState )
+    yLimCurrent = get(gca, 'ylim');
 end
+
+% Initialize flags:
 isComplex = false;
 intervalIsSet = false;
+yLim = [inf, -inf];
 
 % Initialise storage:
 lineData = {};
@@ -278,8 +280,14 @@ else
     set(h3, jumpStyle{:});
 end
 
-% Set the y limits if appropriate values have been suggested:
+% Set the Y-limits if appropriate values have been suggested:
 if ( all(isfinite(yLim)) )
+
+    % If holding, then make sure not to shrink the Y-limits.
+    if ( holdState )
+        yLim = [min(yLimCurrent(1), yLim(1)), max(yLimCurrent(2), yLim(2))];
+    end
+
     set(gca, 'ylim', yLim)
 end
 


### PR DESCRIPTION
This will close #159.

The logic was going wrong inside plot.m.

`plot()` sets the Y-limits only if suggested values are finite, since the various `plotData` functions return `data.yLim = [inf, -inf]` if they decide to be Y-limit-agnostic. However, if the `hold` state is `on`, then the `yLim` variable is initialized to current Y-limits, in which case those values are always used — even if `plotData` was agnostic — because they're finite, overriding MATLAB's auto-adjustment.
