### PR TITLE
Missing parenthesis is breaking chebfun2 constructor.

### DIFF
--- a/@chebfun2/constructor.m
+++ b/@chebfun2/constructor.m
@@ -54,7 +54,7 @@ if ( isa(op, 'double') )    % CHEBFUN2( DOUBLE )
         op = chebfun2.coeffs2vals( op );
         g = chebfun2( op, varargin{:} );
         return
-    elseif ( (nargin > 3) && (any(strcmpi(varargin{1}, 'coeffs')) )
+    elseif ( (nargin > 3) && (any(strcmpi(varargin{1}, 'coeffs'))) )
         op = chebfun2.coeffs2vals( op );
         g = chebfun2( op, domain );
         return


### PR DESCRIPTION
A missing paren in the chebfun2 constructor is causing a syntax error that is causing all except one of the chebfun2 and chebfun2v tests to crash or fail.
