### PR TITLE
Fix crash in ratinterp() when using roots of unity with constant denominator.

### DIFF
--- a/ratinterp.m
+++ b/ratinterp.m
@@ -371,7 +371,7 @@ function a = computeNumeratorCoeffs(f, m, n, xi_type, Z, b, fEven, fOdd, N, N1)
 
 if ( strncmpi(xi_type, 'type', 4) )
     if ( xi_type(5) == '0' )      % Roots of unity.
-        a = fft(ifft(b, N1) .* f);
+        a = fft(ifft(b, N1, 1) .* f);
         a = a(1:(m+1));
     elseif ( xi_type(5) == '1' )  % 1st-kind Chebyshev points.
         a = dct1(idct1([b ; zeros(N - n, 1)]) .* f);

--- a/tests/misc/test_ratinterp.m
+++ b/tests/misc/test_ratinterp.m
@@ -78,4 +78,9 @@ pass(15) = max(abs((f(xx) - r(xx)))) < 0.6;
 pass(16) = norm(f - p./q,inf) < 0.6;
 pass(17) = max(abs((f(xx) - r(xx)))) < 0.6;
 
+% Robustness will get rid of the denominator in this scenario.
+f = @(x) 1./(x - 1.7);
+[p, q, r, mu, nu, pol] = ratinterp(f, 128, 1, [], 'type0', 1e-14);
+pass(18) = (nu == 0);
+
 end


### PR DESCRIPTION
If the length of the denominator coefficient vector (b) is 1, then MATLAB's
conventions for ifft() mean that the call to ifft() in the line changed will
produce a row vector as its output, causing the code to crash with a dimension
mismatch error.  The change in this commit fixes this by forcing the vector
returned by this call to be a column.

This sounds useless, as it is unlikely that anyone would want to use ratinterp
with a degree-zero denominator over just calling the chebfun constructor;
however if robustness is on, and the if the poles of the function being
approximated are far enough from the interpolation points), it may happen that
the robustness features of ratinterp() decide to set the denominator degree to
zero anyway.  A test has been added which deliberately triggers this behavior
to help prevent this problem from resurfacing later on.

This issue does not appear to affect interpolation in other types of nodes.

NB:  This issue is also present in ratinterp() in Chebfun v4.
