### PR TITLE
Remove the final test for chebfun/any

### DIFF
--- a/tests/chebfun/test_any.m
+++ b/tests/chebfun/test_any.m
@@ -82,7 +82,4 @@ fval = feval(h2, x);
 err = fval - 1;
 pass(14) = ~any( err );
 
-r = roots(f);
-pass(15) = ~any( h2(r) );
-
 end


### PR DESCRIPTION
Due to rounding errors, the test cannot be expected to consistently pass.
