### PR TITLE
Re-fixed piecewise eigenvalue problems

### DIFF
--- a/functionalBlock.m
+++ b/functionalBlock.m
@@ -203,11 +203,12 @@ classdef functionalBlock < linBlock
             %   FUNCTIONALBLOCK.INNER(F, DOMAIN) returns the functional on the
             %   interval DOMAIN that maps a function to its inner product with
             %   the chebfun F.
-            if ( nargin == 1 )
-                F = functionalBlock(f.domain);
-            else
-                F = functionalBlock(domain);
+            if ( nargin < 2 )
+                domain = f.domain;
+             else
+                domain = chebfun.mergeDomains(f.domain,domain);
             end
+            F = functionalBlock(domain);
             F.stack = @(z) inner(z, f);
             F.diffOrder = 0;
         end

--- a/operatorBlock.m
+++ b/operatorBlock.m
@@ -232,6 +232,8 @@ classdef (InferiorClasses = {?chebfun}) operatorBlock < linBlock
             % Check whether domain information was passed
             if ( nargin < 2 )
                 dom = u.domain;
+            else
+                dom = chebfun.mergeDomains(u.domain,dom);
             end
 
             % Create the OPERATORBLOCK with information now available.


### PR DESCRIPTION
Functional/operator blocks need to preserve breakpoints when creating a block based on a chebfun. 

This should not have happened: a working chebtest was broken by a submitted and approved pull request. 
