### PR TITLE
Take Hermitian adjoint of C matrix in ratinterp() instead of transpose.

### DIFF
--- a/ratinterp.m
+++ b/ratinterp.m
@@ -302,7 +302,7 @@ else                                 % Other nodes.
     end
 
     [C, R] = qr(C);
-    Z = C.' * diag(f) * C(:, 1:(n+1));
+    Z = C' * diag(f) * C(:, 1:(n+1));
 end
 
 end

--- a/tests/misc/test_ratinterp.m
+++ b/tests/misc/test_ratinterp.m
@@ -10,7 +10,6 @@ x = chebfun(@(x) x, dom);
 cf = f(x);
 N = 100;
 
-
 % Approximate on different point sets using the anonymous function.
 [p, q, r, mu, nu, poles, res] = ratinterp(dom, f, 10, 10, [], 'type0');
 pass(1) = (mu == 4) && (nu == 2) && ...
@@ -82,5 +81,12 @@ pass(17) = max(abs((f(xx) - r(xx)))) < 0.6;
 f = @(x) 1./(x - 1.7);
 [p, q, r, mu, nu, pol] = ratinterp(f, 128, 1, [], 'type0', 1e-14);
 pass(18) = (nu == 0);
+
+% Check interpolation in arbitrary complex nodes.  (Use roots of unity but
+% don't inform ratinterp().)
+f = @(x) sin(x)./(x - 0.1);
+zk = exp(2*pi*1i*(0:1:31).'/32);
+[p, q, r, mu, nu, pol] = ratinterp(f, 30, 1, [], zk, 1e-14);
+pass(19) = abs(pol - 0.1) < 1e-10;
 
 end


### PR DESCRIPTION
We need to take conjugates here; otherwise, things go wrong when interpolating
in grids consisting of arbitrary nodes in the complex plane.  A test has been
added to check an example for such a grid.

NB:  This issue also affects ratinterp in Chebfun v4.
