### PR TITLE
Replace A.domain with domain(A) in quasimatrix case for chebfun.qr().

### DIFF
--- a/@chebfun/qr.m
+++ b/@chebfun/qr.m
@@ -53,7 +53,7 @@ if ( numel(A) > 1 )
         
     else
         % Legendre matrix:
-        E = legpoly(0:numCols-1, A.domain, 'norm', 1);
+        E = legpoly(0:numCols-1, domain(A), 'norm', 1);
         E = restrict(E, get(A, 'domain'));
         % Convert the Legendre-Vandermonde matrix to a quasimatrix:
         E = cheb2quasi(E);


### PR DESCRIPTION
More specifically, we replace it in the part of the code that can't
really be tested yet since we can't make any "non-simple" chebfuns other
than by using singfuns, and calling qr() of a chebfun fails even under
v4.

The reason this needs to be domain(A) is that A.domain, when A is a
quasimatrix and when invoked from within a chebfun class method (so that
the overloaded chebfun.subsref() is not invoked), will, via the MATLAB
structure array field access rules, return a cell array of the domain
fields of all the columns in the quasimatrix.  This causes legpoly() to
crash with a "too many input arguments" error, which is extremely
confusing.  Replacing it with a call to chebfun.domain(), which is
properly equipped to handle quasimatrices, fixes the problem.

More explicitly, suppose we do

```
  >> f = chebfun(@(x) x);
  >> g = chebfun(@(x) 1./x, [-1 0 1], 'blowup', 1, 'exponents', [0 1 0]);
```

Before applying this patch, we get the following error, which is
mysterious:

```
  >> [Q, R] = qr([f g]);
  Error using legpoly
  Too many input arguments.
  Error in chebfun/qr (line 56)
          E = legpoly(0:numCols-1, A.domain, 'norm', 1);
```

After the patch, we get the following error, which we expect, since qr()
of a chebfun based on singfun doesn't work:

```
  >> [Q, R] = qr([f g]);
  Error using chebtech/extrapolate (line 35)
  Too many NaNs/Infs to handle.
  Error in chebtech/populate (line 127)
      [f.values, maskNaN, maskInf] = extrapolate(f);

  (Rest of error text suppressed.)
```
