### PR TITLE
Fix chebpoly

### DIFF
--- a/chebpoly.m
+++ b/chebpoly.m
@@ -1,7 +1,8 @@
 function f = chebpoly(n, d, kind)
 %CHEBPOLY   Chebyshev polynomial.
 %   F = CHEBPOLY(N) returns the CHEBFUN corresponding to the Chebyshev
-%   polynomials T_N(x) on [-1,1], where N may be a vector of positive integers.
+%   polynomials T_N(x) on [-1,1], where N may be a vector of nonnegative
+%   integers.
 %
 %   F = CHEBPOLY(N, D), where D is an interval or a domain, gives the same
 %   result scaled accordingly.
@@ -21,9 +22,9 @@ function f = chebpoly(n, d, kind)
 defaultKind = 1;
 
 % Parse input
-if ( n < 0 || (n - round(n)) >= eps(n) )
+if ( any(n < 0) || any(mod(n, 1) ~= 0) )
     error('CHEBFUN:chebpoly:integern', ...
-    'The first argument must be a non-negative integer.');
+    'The first argument must be a vector of nonnegative integers.');
 end
 
 if ( nargin == 1 )


### PR DESCRIPTION
This fixes a minor bug in chebpoly. We now throw an error when chebpoly is called with non-integers or negative arguments.
