### PR TITLE
Fix chebfun2 pretty functions

### DIFF
--- a/@chebfun2/constructor.m
+++ b/@chebfun2/constructor.m
@@ -170,7 +170,8 @@ while ( ~isHappy )
     [pivotValue, pivotPosition, rowValues, colValues, iFail] = CompleteACA(vals, tol);
     
     strike = 1;
-    while ( iFail && grid <= maxRank && strike < 3)
+    % grid <= 4*(maxRank-1)+1, see Chebfun2 paper. 
+    while ( iFail && grid <= 4*(maxRank-1)+1 && strike < 3)
         % Double sampling on tensor grid:
         grid = 2^( floor( log2( grid ) ) + 1) + 1;
         [xx, yy] = chebfun2.chebpts2(grid, grid, domain);
@@ -187,7 +188,7 @@ while ( ~isHappy )
     end
     
     % If the rank of the function is above maxRank then stop.
-    if ( grid > maxRank )
+    if ( grid > 4*(maxRank-1)+1 )
         error('CHEBFUN2:CTOR', 'Not a low-rank function.');
     end
     

--- a/chebpref.m
+++ b/chebpref.m
@@ -365,7 +365,7 @@ classdef chebpref
                 outPref.techPrefs.extrapolate = false;
                 outPref.techPrefs.sampleTest = true;
             outPref.cheb2Prefs = struct(); 
-                outPref.cheb2Prefs.maxRank = 2049; 
+                outPref.cheb2Prefs.maxRank = 513; 
                 outPref.cheb2Prefs.maxLength = 65537; 
                 outPref.cheb2Prefs.eps = 2^(-52); 
                 outPref.cheb2Prefs.exactLength = false;
@@ -758,7 +758,7 @@ classdef chebpref
                 factoryPrefs.techPrefs.extrapolate = false;
                 factoryPrefs.techPrefs.sampleTest = true;
             factoryPrefs.cheb2Prefs = struct(); 
-                factoryPrefs.cheb2Prefs.maxRank = 2049;   
+                factoryPrefs.cheb2Prefs.maxRank = 513;   
                 factoryPrefs.cheb2Prefs.maxLength = 65537;   
                 factoryPrefs.cheb2Prefs.eps = 2^(-52);   
                 factoryPrefs.cheb2Prefs.exactLength = 0; 


### PR DESCRIPTION
The Chebfun2 code 

```
g3 = @(x,y) 1./(1+100*(x - y).^2); 
G3 = chebfun2(g3)  
```

was issuing a warning "not a low rank function" because there was a typo in the default factory preference setting for maxRank in chebpref().  This has now been corrected.   
