### PR TITLE
Allow ASSIGNCOLUMNS() to assign to empty CHEBFUN objects.

### DIFF
--- a/@chebfun/assignColumns.m
+++ b/@chebfun/assignColumns.m
@@ -17,7 +17,7 @@ function f = assignColumns(f, colIdx, g)
 %
 % See also EXTRACTCOLUMNS, MAT2CELL.
 
-% Copyright 2013 by The University of Oxford and The Chebfun Developers.
+% Copyright 2014 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
 % This shouldn't happen:
@@ -62,7 +62,18 @@ end
 
 % Check dimensions of f:
 if ( max(colIdx) > numColsF )
-    error('CHEBFUN:assignColumns:dims', 'Index exceeds CHEBFUN dimensions.')
+%     error('CHEBFUN:assignColumns:dims', 'Index exceeds CHEBFUN dimensions.')
+
+    if ( isempty(f) )
+        dom = g.domain;
+    else
+        dom = f.domain;
+    end
+    
+    % Pad with zeros so that f has sufficiently many columns:
+    z = chebfun(zeros(1, max(colIdx) - numColsF), dom);
+    f = [f z];
+
 end
 
 if ( numel(f) == 1 && numel(g) == 1)

--- a/tests/chebfun/test_assignColumns.m
+++ b/tests/chebfun/test_assignColumns.m
@@ -13,7 +13,7 @@ for k = 1:2
     
     % Generate a few random points to use as test values.
     seedRNG(6178);
-    x = 2 * rand(100, 1) - 1;
+    x = 2 * rand(10, 1) - 1;
 
     % Check a few examples.
     f = myfun(@(x) [sin(x) cos(x) exp(x)], [-1 0 1], pref);
@@ -84,13 +84,12 @@ for k = 1:2
         pass(k,11) = strcmp(ME.identifier, 'CHEBFUN:assignColumns:domain');
     end
 
-    try
-        h = assignColumns(f, [1 2 4], g);
-        pass(k,12) = false;
-    catch ME
-        pass(k,12) = strcmp(ME.identifier, 'CHEBFUN:assignColumns:dims');
-    end
-    
+    % Test assign outside of dimension of f:
+    h = assignColumns(f, [1 2 4], g);
+    h_exact = @(x) [x x.^2 exp(x) x.^3];
+    err = feval(h, x) - h_exact(x);
+    pass(k,12) = norm(err(:), inf) < 10*vscale(h)*epslevel(h);
+
     %% Test for function defined on unbounded domain:
     
     % Functions on [-inf b]:


### PR DESCRIPTION
Closes #40.
