### PR TITLE
Fix issues with external dependencies in some tests.

### DIFF
--- a/tests/chebfun/test_airy.m
+++ b/tests/chebfun/test_airy.m
@@ -27,7 +27,13 @@ for im = [0 1]
         % [TODO] Implement scale = 1 (requires SINGFUNS)
         for scale = 0
 
-            F = @(x) airy(K, (1+im*1i)*x, scale);
+            % AIRY does not support the "scale" input prior to R2013a.
+            if ( verLessThan('matlab', '8.1') )
+                F = @(x) airy(K, (1+im*1i)*x);
+            else
+                F = @(x) airy(K, (1+im*1i)*x, scale);
+            end
+
             f = F(x);
             pass(im+1,k) = norm(feval(f,xx) - F(xx), inf) < 20*max(f.epslevel.*f.vscale);
             k = k + 1;

--- a/tests/chebfun/test_sign.m
+++ b/tests/chebfun/test_sign.m
@@ -7,6 +7,7 @@ end
 % Initialise random vector:
 seedRNG(6178);
 x = 2 * rand(100, 1) - 1;
+hvsde = @(x) .5*(sign(x) + 1);
 
 %% Simple tests
 pref.enableBreakpointDetection = 0;
@@ -120,7 +121,7 @@ op = @(x) (1-exp(-x.^2))./x;
 f = chebfun(op, dom);
 s = sign(f);
 sVals = feval(s, x);
-op = @(x) 2*heaviside(x) - 1;
+op = @(x) 2*hvsde(x) - 1;
 sExact = op(x);
 err = sVals - sExact;
 pass(8,:) = all( ~norm(err, inf) );

--- a/tests/unbndfun/test_sum.m
+++ b/tests/unbndfun/test_sum.m
@@ -121,7 +121,8 @@ pass(12) = err < tol;
 op = @(x) (1-exp(x))./x.^2;
 f = unbndfun(op, dom);
 I = sum(f);
-IExact = (exp(-3*pi)*(exp(3*pi)-1))/(3*pi)-ei(-3*pi);
+% This exact value is obtained using Matlab's symbolic toolbox:
+IExact = 0.106102535711326;
 err = abs(I - IExact);
 tol = 1e5*get(f,'epslevel')*get(f,'vscale');
 pass(13) = err < tol;


### PR DESCRIPTION
- chebfun/test_ariy:  Prior to R2013a, airy() did not have a "scale" input
  parameter.  We need to check that this parameter works on platforms that
  support it, but we also need the test to pass on platforms that don't, so we
  add an ugly version check to ensure that this is the case.
- chebfun/test_sign:  Removed call to heaviside() from the Symbolic Toolbox.
- unbndfun/test_sum:  Removed call to  ei() from the Symbolic Toolbox.
