### PR TITLE
Adding an END method for the CHEBMATRIX class.

### DIFF
--- a/@chebmatrix/chebmatrix.m
+++ b/@chebmatrix/chebmatrix.m
@@ -117,8 +117,29 @@ classdef (InferiorClasses = {?chebfun, ?operatorBlock, ?functionalBlock}) chebma
             end
         end
         
+        function e = end(A, k, n)
+        %END   Last index of a CHEBMATRIX.
+        %   END(A, K, N) is called for indexing expressions involving a
+        %   CHEBMATRIX A when end is part of the K-th index out of N indices.
+        %   For example, the expression A(end-1,:) calls A's end method with
+        %   END(A, 1, 2). Note that N must be less than or equal to two.
+
+            if ( n > 2 )
+                error('CHEBFUN:end:ngt2', ...
+                    'Index exceeds CHEBMATRIX dimensions.');
+            end
+            
+            s = size(A.blocks);
+            if ( n == 1 )
+                e = prod(s);
+            else
+                e = s(k);
+            end
+            
+        end
+        
         function out = isFunVariable(A, k)
-        %ISFUNVARIABLE  Which variables of the chebmatrix are functions?
+        %ISFUNVARIABLE  Which variables of the CHEBMATRIX are functions?
         %
         %   A chebmatrix can operate on other chebmatrices. Operator and
         %   function blocks are applied to function components, whereas
@@ -131,6 +152,28 @@ classdef (InferiorClasses = {?chebfun, ?operatorBlock, ?functionalBlock}) chebma
             if ( nargin > 1 )
                 out = out(k);
             end
+        end
+        
+        function A = ctranspose(A)
+        %CTRANSPOSE   Transpose a CHEBMATRIX.
+        %   CTRANSPOSE(A) transposes A.BLOCKS and each of the entries in
+        %   A.BLOCKS. Note the block entries are transposed, not conjugate
+        %   tranposed.
+        
+            for k = 1:numel(A.blocks)
+                % TODO: TRANSPOSE() or CTRANSPOSE()?
+                A.blocks{k} = transpose(A.blocks{k});
+            end
+            A.blocks = transpose(A.blocks);
+            
+        end
+        
+        function A = transpose(A)
+        %TRANSPOSE   Transpose a CHEBMATRIX.
+        %   TRANSPOSE(A) transposes A.BLOCKS, but _not_ its entries.
+        
+            A.blocks = ctranspose(A.blocks);
+            
         end
         
     end


### PR DESCRIPTION
Closes #378.

```
>> u = chebfun(@(x)cos(x));
>> A = [u ; pi];
```

```
>> A{end}
ans =
   3.141592653589793
>> A{end,1}
ans =
   3.141592653589793
>> A{1,end}
ans = 
   chebfun column (1 smooth piece)
       interval       length   endpoint values  
[      -1,       1]       15      0.54     0.54 
Epslevel = 6.492624e-16.  Vscale = 1.
```

I also added TRANSPOSE() and CTRANSPOSE().

```
>> B = A.';
>> B.blocks
ans = 
    [Infx1 chebfun]    [3.141592653589793]
>> B{end}
ans =
   3.141592653589793
>> B{end,1}
ans = 
   chebfun column (1 smooth piece)
       interval       length   endpoint values  
[      -1,       1]       15      0.54     0.54 
Epslevel = 6.492624e-16.  Vscale = 1.
>> B{1,end}
ans =
   3.141592653589793
```
