### PR TITLE
Adding place holders for SVDS and POLYEIGS methods.

### DIFF
--- a/@chebop/polyeigs.m
+++ b/@chebop/polyeigs.m
@@ -1,0 +1,26 @@
+function varargout = polyeigs(varargin)
+%POLYEIGS   Polynomial CHEBOP eigenvalue problem.
+%   POLYEIGS of a CHEBOP is not yet supported for p > 1.
+%
+% See also EIGS.
+
+% Copyright 2014 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+% Find CHEBOP inputs:
+isChebop = cellfun(@(v) isa(v, 'chebop'));
+
+if ( nargin > 2 && any(isChebop(3:end)) )
+    
+    % POLYEIGS is not yet supported.
+    error('CHEBFUN:chebop:polyeigs:nosupport', ...
+        'CHEBOP/POLYEIGS() is not currently supported.');
+    
+else
+    
+    % Simply call EIGS for this problem:
+    [varargout{1:nargout}] = eigs(varargin{:});
+    
+end
+
+end

--- a/@chebop/svds.m
+++ b/@chebop/svds.m
@@ -1,0 +1,11 @@
+function [U, S, V] = svds(L, k, sigma)
+%SVDS  Find some singular values and vectors of a compact linear CHEBOP.
+%   SVDS of a CHEBOP is currently not supported.
+
+% Copyright 2014 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+error('CHEBFUN:chebop:svds:nosupport', ...
+    'CHEBOP/SVDS() is not currently supported.');
+
+end

--- a/@linop/polyeigs.m
+++ b/@linop/polyeigs.m
@@ -1,0 +1,26 @@
+function varargout = polyeigs(varargin)
+%POLYEIGS   Polynomial LINOP eigenvalue problem.
+%   POLYEIGS of a LINOP is not yet supported for p > 1.
+%
+% See also EIGS.
+
+% Copyright 2014 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+% Find LINOP inputs:
+isLinop = cellfun(@(v) isa(v, 'linop'));
+
+if ( nargin > 2 && any(isLinop(3:end)) )
+    
+    % POLYEIGS is not yet supported.
+    error('CHEBFUN:linop:polyeigs:nosupport', ...
+        'CHEBOP/POLYEIGS() is not currently supported.');
+    
+else
+    
+    % Simply call EIGS for this problem:
+    [varargout{1:nargout}] = eigs(varargin{:});
+    
+end
+
+end

--- a/@linop/svds.m
+++ b/@linop/svds.m
@@ -1,0 +1,11 @@
+function [U, S, V] = svds(L, k, sigma)
+%SVDS  Find some singular values and vectors of a compact LINOP.
+%   SVDS of a LINOP is currently not supported.
+
+% Copyright 2014 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+error('CHEBFUN:linop:svds:nosupport', ...
+    'LINOP/SVDS() is not currently supported.');
+
+end


### PR DESCRIPTION
These methods are not yet implemented in V5. These place holders give more descriptive errors than the default `Method 'svds' is not defined for class 'chebop' or is removed from MATLAB's search path.`

See #278 and #390.
