### PR TITLE
Feature improve inv

### DIFF
--- a/tests/chebfun/test_inv.m
+++ b/tests/chebfun/test_inv.m
@@ -52,20 +52,6 @@ catch ME
     end
 end
 
-% Check that things still fail if we give inv() a non-monotonic function
-% without 'monocheck' enabled.
-try
-    f = chebfun(@(x) x.^2);
-    f_inv = inv(f, pref, 'splitting', 'on');
-    pass(:,7) = false;
-catch ME
-    if ( strcmpi(ME.identifier, 'CHEBFUN:inv:notmonotonic2') )
-        pass(:,7) = true;
-    else
-        pass(:,7) = false;
-    end
-end
-
 end
 
 function g = sausagemap(s,d)


### PR DESCRIPTION
For ages we have described the INV() command as experimental and slow.  These commits attempt to make the algorithm for INV() much faster.  In particular, the INV() command now has an algorithm based on the _very_ simple bisection method (instead of Newton or colleague matrix).  Bisection has two benefits: (1) Super-fast (53 function evaluations per evaluation of the inverse), (2) Robust (for monotonic functions bisection never fails). 

As a demonstration of the speed checkout: 

```
f = chebfun(@(x) (x.^4 + 2*x.^3+.01*x)/3,[-.5,.5]); 
tic, g1 = inv(f,'algorithm','bisection'); toc
Elapsed time is 1.077946 seconds.

g1
g1 = 
   chebfun column (1 smooth piece)
       interval       length   endpoint values  
[  -0.064,    0.11]    19286      -0.5      0.5 
Epslevel = 5.684342e-14.  Vscale = 5.000000e-01.

x = linspace(-.5,.5,1000);
norm(g1(f(x)) - x, inf)
ans =
     1.924571613187709e-13
```

In comparison `inv(f,'algorithm','roots')` and `inv(f,'algorithm','newton')` are still running on my work station. 

In my mind this potentially solves the terrible trio: (1) `conv()`, (2) `abs()`, and now (3) `inv()`.  These were set as commands with efficiency issues way back when. 
