### PR TITLE
Changes to fix #437.

### DIFF
--- a/@chebfun/chebfun.m
+++ b/@chebfun/chebfun.m
@@ -486,7 +486,7 @@ classdef chebfun
         f = tidyImpulses(f)
         
         % Adjust nearby common break points in domains of CHEBFUN objects.
-        [f, g, newBreaksLocF, newBreaksLocG] = tweakDomain(f, g, tol)
+        [f, g, newBreaksLocF, newBreaksLocG] = tweakDomain(f, g, tol, pos)
         
     end
     

--- a/@chebfun/quasi2cheb.m
+++ b/@chebfun/quasi2cheb.m
@@ -9,7 +9,7 @@ function F = quasi2cheb(F)
 % See http://www.chebfun.org/ for Chebfun information.
 
 if ( numel(F) < 2 )
-    % F must already be a quasimatrix!
+    % F is already be a quasimatrix!
     return
 end
 

--- a/@chebfun/restrict.m
+++ b/@chebfun/restrict.m
@@ -18,6 +18,12 @@ function F = restrict(F, newDomain)
 % Copyright 2014 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
+% Tweak the domain of a quasimatrix input:
+if ( numel(F) > 1 )   
+    F = tweakDomain(F);
+end
+
+% Loop over the columns:
 for k = 1:numel(F)
     F(k) = columnRestrict(F(k), newDomain);
 end

--- a/tests/chebfun/test_mldivide.m
+++ b/tests/chebfun/test_mldivide.m
@@ -43,6 +43,26 @@ C(1, 3) = .25;
 C(2, 4) = .375;
 pass(5) = norm(X - C, inf) < 10*epslevel(L);
 
+%% Test a bug from #437
+
+x = chebfun('x'); 
+A = [];
+for j = 0:6
+   xj = -1 + j/4;
+   A = [ A , max(0, 1-4*abs(x-xj)) ];
+end
+u = A\x;
+expected = [...
+  -0.999851249504164
+  -0.750297500991670
+  -0.498958746529156
+  -0.253867512891710
+   0.014428798095994
+   0.196152320507735
+   0.700961919873066];
+err = norm(u - expected, inf);
+pass(6) = err < 10*epslevel(A);
+
 %% Test on SINGFUN:
 
 % scalar * [1 x INF] = [1 x INF] => scalar\row SINGFUN:
@@ -53,14 +73,14 @@ op = @(x) sin(20*x)./(3*(x+1));
 g_vals = feval(g, xr);
 g_exact = op(xr).';
 err = g_vals - g_exact;
-pass(6) = norm(err, inf) < 1e4*vscale(g)*epslevel(g);
+pass(7) = norm(err, inf) < 1e4*vscale(g)*epslevel(g);
 
 % [1 x INF] * [INF x 1] = scalar => row SINGFUN\scalar:
 f = chebfun(@(x)(sin(100*x).^2+1)./((x+1).^0.25), 'exps', [-0.25 0], 'splitting', 'on');
 f = f.';
 g = f\3;
 err = f*g - 3;
-pass(7) = abs(err) < vscale(g)*epslevel(g);
+pass(8) = abs(err) < vscale(g)*epslevel(g);
 
 % [INF x 1] * SCALAR = [INF x 1] => column SINGFUN\column SINGFUN:
 
@@ -68,7 +88,9 @@ f = chebfun(@(x)3*(x.^2+3)./(x+1).^0.4, 'exps', [-0.4 0], 'splitting', 'on');
 g = chebfun(@(x)(x.^2+3)./(x+1).^0.4, 'exps', [-0.4 0], 'splitting', 'on');
 h = f\g;
 err = h - 1/3;
-pass(8) = norm(err, inf) < vscale(f)*epslevel(f);
+pass(9) = norm(err, inf) < vscale(f)*epslevel(f);
+
+
 
 % [TODO]: Revive the following test.
 
@@ -90,7 +112,7 @@ pass(8) = norm(err, inf) < vscale(f)*epslevel(f);
 % X = A\B;
 % res = A*X - B;
 % err = feval(res, x);
-% pass(9) = norm(err(:), inf) < max([get(A,'epslevel').*get(A,'vscale') ...
+% pass(10) = norm(err(:), inf) < max([get(A,'epslevel').*get(A,'vscale') ...
 %     get(B,'epslevel').*get(B,'vscale')]);
 
 end


### PR DESCRIPTION
The problem in #437 was that some breakpoints in a quasimatrix were close to each other, and when trying to merge them in order to create an array-valued CHEBFUN (which is the default strategy for computing QR of a quasimatrix when possible) tiny intervals were breaking RESTRICT().

This fix extends the TWEAKDOMAIN() method to support tweaking of quasimatrix breakpoints.

A new tets was added, and all existing tests pass.
