### PR TITLE
Fix to #490. (Parsing options to 'jumpline' plot).

### DIFF
--- a/@chebfun/parseJumpStyle.m
+++ b/@chebfun/parseJumpStyle.m
@@ -19,7 +19,13 @@ for idx = 1:numel(varargin)
     tmp = varargin{idx+1};
     varargin(idx:(idx+1)) = [];
     if ( iscell(tmp) )
-        jumpStyle = tmp;
+        cc = regexp(tmp{1},'[bgrcmykw]', 'match');
+        if ( ~isempty(cc) )
+            % Forgive " 'jumpline', {'b', ...} " by inserting a 'color'.
+            jumpStyle = ['Color', cc, tmp{2:end}];
+        else
+            jumpStyle = tmp;
+        end
         return
     end
 


### PR DESCRIPTION
The problem was that the plotting options were previously passed to plot in such a way that {'b', LW, lw}. We must now insert a 'color' before the 'b'.

This is done automatically in parseJumpStyle, but PLOT() even lists {'color', 'b', ...} as the correct syntax.

Closes #490.
