### PR TITLE
Fix chebfun2 surf

### DIFF
--- a/@chebfun2/surf.m
+++ b/@chebfun2/surf.m
@@ -105,7 +105,7 @@ if ( isa(f,'chebfun2') )
             end
             
             h = surf(x, y, vals, C, defaultOpts{:}, argin{3:end});
-            xlabel('x'), ylabel('y') % xlim(dom(1:2)), ylim(dom(3:4))
+            xlabel('x'), ylabel('y')
             
             % There is a bug in matlab surf plot when vals are very nearly a
             % constant. Fix this manually by resetting axis scaling.

--- a/@chebfun2v/surf.m
+++ b/@chebfun2v/surf.m
@@ -99,10 +99,6 @@ else
     h = surf(F.components{1}, F.components{2}, F.components{3}, varargin{:});
 end
 
-% xlim([min2( F.components{1} ), max2( F.components{1} )] )
-% ylim([min2( F.components{2} ), max2( F.components{2} )] )
-% zlim([min2( F.components{3} ), max2( F.components{3} )] )
-
 if ( ~ish )
     hold off
 end


### PR DESCRIPTION
Chebfun2 should not decide its own xlim, ylim, zlim in surf commands. 
