### PR TITLE
Fix to 'periodic' BC assignment.

### DIFF
--- a/@chebop/chebop.m
+++ b/@chebop/chebop.m
@@ -230,6 +230,8 @@ classdef (InferiorClasses = {?double}) chebop
                 end
                 
             elseif ( strcmpi(val, 'periodic') )
+                N.lbc = [];
+                N.rbc = [];
                 N.bc = 'periodic';
                 
                 


### PR DESCRIPTION
Have to clear out the lbc and rbc fields when setting bc='periodic'. This came up in guide7. 
