### PR TITLE
Persitently store some matrices in @CHEBTECH/QR().

### DIFF
--- a/@chebtech/qr.m
+++ b/@chebtech/qr.m
@@ -98,6 +98,11 @@ end
 
 function [f, R, E] = qr_builtin(f, outputFlag)
 
+persistent WP invWP
+% Persistently store these matrices, which only depend on the length of the
+% input, not the data. This is very helpful for CHEBFUN2 which relies heavily on
+% QR.
+
 % We must enforce that f.coeffs has at least as many rows as columns:
 [n, m] = size(f);
 if ( n < m )
@@ -107,17 +112,23 @@ end
 
 % Project the values onto a Legendre grid: (where integrals of polynomials
 % p_n*q_n will be computed exactly and on an n-point grid)
-[n, m] = size(f);
-xc = f.chebpts(n);
-vc = f.barywts(n);
-[xl, wl, vl] = legpts(n);
-P = barymat(xl, xc, vc);
-W = spdiags(sqrt(wl.'), 0, n, n);
+if ( length(WP) ~= n )
+    xc = f.chebpts(n);
+    vc = f.barywts(n);
+    [xl, wl, vl] = legpts(n);
+    P = barymat(xl, xc, vc);     % Map from Chebyshev values to Legendre values.
+    W = spdiags(sqrt(wl.'), 0, n, n); % Weighted QR with Gauss-Legendre weights.
+    Winv = spdiags(1./sqrt(wl.'), 0, n, n);    % Undo the weighting used for QR.
+    Pinv = barymat(xc, xl, vl); % Revert to Chebyshev grid (from Legendre grid).
+    % Persistent storage:
+    WP = W*P;
+    invWP = Pinv*Winv;
+end
 
 % Compute the weighted QR factorisation:
 values = f.coeffs2vals(f.coeffs);
 if ( nargout == 3 )
-    [Q, R, E] = qr(W * P * values, 0);
+    [Q, R, E] = qr(WP * values, 0);
     % For consistency with the MATLAB QR behavior:
     if ( (nargin == 1) || ...
         ~(strcmpi(outputFlag, 'vector') || isequal(outputFlag, 0)) )
@@ -126,23 +137,19 @@ if ( nargout == 3 )
         E = I(:,E);
     end
 else
-    [Q, R] = qr(W * P * values, 0);
+    [Q, R] = qr(WP * values, 0);
 end
 
 % Revert to the Chebyshev grid (and remove the weight and enforce diag(R) >= 0).
-Winv = diag(1./sqrt(wl));   % Undo the weighting used for QR.
-Pinv = barymat(xc, xl, vl); % Revert to Chebyshev grid (from Legendre grid).
-
-% Enforce diag(R) >= 0.
 s = sign(diag(R));
 s(~s) = 1;
 S = spdiags(s, 0, m, m);
-Q = Pinv*Winv*Q*S;          % Fix Q.
-R = S*R;                    % Fix R.
+Q = invWP*Q*S;                 % Fix Q.
+R = S*R;                       % Fix R.
 
 % Apply data to chebtech:
-f.coeffs = f.vals2coeffs(Q);            % Compute new coefficients.
-f.vscale = max(abs(Q), [], 1);
+f.coeffs = f.vals2coeffs(Q);   % Compute new coefficients.
+f.vscale = max(abs(Q), [], 1); % Update vscale
 
 end
 

--- a/barymat.m
+++ b/barymat.m
@@ -7,8 +7,8 @@ function B = barymat(y, x, w)
 %   supplied it is assumed to be the weights for polynomial interpolation at a
 %   2nd-kind Chebyshev grid: W(j) = (-1)^j, W([1, N]) = 0.5*W([1, N]).
 
-%  Copyright 2014 by The University of Oxford and The Chebfun Developers.
-%  See http://www.chebfun.org for Chebfun information.
+% Copyright 2014 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org for Chebfun information.
 
 if ( isempty(y) || isempty(x) )
     % Nothing to do here!


### PR DESCRIPTION
One of the biggest clients of `@CHEBTECH/QR()` is `@CHEBFUN2/PLUS()`, which often calls `QR()` consecutively with functions of the same length.

This fix stores the two weighted `BARYMATS` needed in `QR` for the previously used value of n to save computing it again if the next value of n is the same.

This results in some speed up in `CHEBFUN2` computations, particularly the one discussed [here](https://github.com/chebfun/chebfun/issues/554#issuecomment-43858881).
