### PR TITLE
Calculate numerical rank of matrix of values in Chebfun2 constructor

### DIFF
--- a/@chebfun2/constructor.m
+++ b/@chebfun2/constructor.m
@@ -76,6 +76,9 @@ if ( isa(op, 'double') )    % CHEBFUN2( DOUBLE )
             fixedRank = 0;
         end
         % Calculate a tolerance and find numerical rank to this tolerance: 
+        % The tolerance assumes the samples are from a function. It depends
+        % on the size of the sample matrix, hscale of domain, vscale of
+        % the samples, and the accuracy target in chebfun2 preferences. 
         pseudoLevel = pref.cheb2Prefs.eps;
         grid = max( size( op ) ); 
         vscale = max( op(:) ); 


### PR DESCRIPTION
The Chebfun2 constructor should compute the numerical rank of sample matrices (rather than rank = min(m,n)).
