### PR TITLE
Remove degradation in performance in CHEBFUN/OVERLAP().

### DIFF
--- a/@chebfun/overlap.m
+++ b/@chebfun/overlap.m
@@ -16,12 +16,26 @@ if ( ~domainCheck(f, g) )
         'Inconsistent domains; domain(f) ~= domain(g).')
 end
 
-% Obtain the domain for the output:
+% Grab the domains:
 fDom = domain(f);
-g = tweakDomain(g, fDom);
 gDom = domain(g);
-f = tweakDomain(f, gDom);
-fDom = domain(f);
+
+if ( (numel(f) == 1) && (numel(g) == 1) )
+    if ( (numel(fDom) == numel(gDom)) && all(fDom == gDom) )
+        % Trivial case: Nothing to do!
+        return
+    end
+    [f, g] = tweakDomain(f, g);
+    fDom = domain(f);
+    gDom = domain(g);
+else
+    g = tweakDomain(g, fDom);
+    gDom = domain(g);
+    f = tweakDomain(f, gDom);
+    fDom = domain(f);
+end
+
+% Obtain the domain for the output:
 newDom = union(fDom, gDom);
 
 % Restrict f and g:


### PR DESCRIPTION
This pull request fixes the performance degradation introduced by recent changes to `overlap()`. 

Running `profile` on a few select tests suggests the problem actually lies in `tweakDomain()` and more specifically in the construction of `chebfun(0, dom)`, which is entirely dominated by overheads.

```
>> tic, for k=1:1000, chebfun(0); end, toc
Elapsed time is 5.622553 seconds.
```

This change avoids unnecessary calls to `tweakDomain()`, but we might look for a better way initialising a dummy/zero `chebfun`.
