### PR TITLE
Output a more sensible epslevel from unhappy constructions.

### DIFF
--- a/@chebtech/classicCheck.m
+++ b/@chebtech/classicCheck.m
@@ -2,9 +2,9 @@ function [ishappy, epslevel, cutoff] = classicCheck(f, values, pref)
 %CLASSICCHECK   Attempt to trim trailing Chebyshev coefficients in a CHEBTECH.
 %   [ISHAPPY, EPSLEVEL, CUTOFF] = CLASSICCHECK(F, VALUES) returns an estimated
 %   location, the CUTOFF, at which the CHEBTECH F could be truncated to maintain
-%   an accuracy of EPSLEVEL relative to F.VSCALE and F.HSCALE. ISHAPPY is
-%   TRUE if CUTOFF < MIN(LENGTH(VALUES),2) or F.VSCALE = 0, and FALSE
-%   otherwise.
+%   an accuracy of EPSLEVEL relative to F.VSCALE and F.HSCALE. ISHAPPY is TRUE
+%   if CUTOFF < MIN(LENGTH(VALUES),2) or F.VSCALE = 0, and FALSE otherwise.
+%   If ISHAPPY is false, EPSLEVEL returns an estimate of the accuracy achieved.
 %
 %   [ISHAPPY, EPSLEVEL, CUTOFF] = CLASSICCHECK(F, PREF) allows additional
 %   preferences to be passed. In particular, one can adjust the target accuracy
@@ -34,9 +34,8 @@ function [ishappy, epslevel, cutoff] = classicCheck(f, values, pref)
 %                      gradient of the function from F.VALUES.).
 %   However, the final two estimated values can be no larger than 1e-4.
 %
-%
-%   Note that the accuracy check implemented in this function is the same as
-%   that employed in Chebfun v4.x.
+%   Note that the accuracy check implemented in this function is the (roughly)
+%   same as that employed in Chebfun v4.x.
 %
 % See also STRICTCHECK, LOOSECHECK.
 
@@ -156,6 +155,9 @@ else
 
     % We're unhappy. :(
     cutoff = n;
+    
+    % Estimate the epslevel:
+    epslevel = mean(ac(1:testLength, :));
 
 end
 

--- a/@chebtech/happinessCheck.m
+++ b/@chebtech/happinessCheck.m
@@ -1,14 +1,13 @@
 function  [ishappy, epslevel, cutoff] = happinessCheck(f, op, values, pref)
 %HAPPINESSCHECK   Happiness test for a CHEBTECH
-%   [ISHAPPY, EPSLEVEL, CUTOFF] = HAPPINESSCHECK(F, OP, VALUES) tests if the 
+%   [ISHAPPY, EPSLEVEL, CUTOFF] = HAPPINESSCHECK(F, OP, VALUES) tests if the
 %   CHEBTECH with values VALUES and coefficients F.COEFFS would be a 'happy'
 %   approximation (in the sense defined below and relative to F.VSCALE and
 %   F.HSCALE) to the function handle OP. If the approximation is happy, the
-%   output ISHAPPY is TRUE, the happiness level is returned in EPSLEVEL,
-%   and CUTOFF indicates the point to which the coefficients COEFFS may be
-%   truncated. Even if ISHAPPY is FALSE, the attempted happiness level is still
-%   returned in EPSLEVEL (i.e., we attempted to be happy at EPSLEVEL but failed)
-%   and CUTOFF is returned as size(F.COEFFS, 1).
+%   output ISHAPPY is TRUE, the happiness level is returned in EPSLEVEL, and
+%   CUTOFF indicates the point to which the coefficients COEFFS may be
+%   truncated. If ISHAPPY is false, EPSLEVEL returns an estimate of the accuracy
+%   achieved.
 %
 %   HAPPINESSCHECK(F) computes VALUES used above from F.COEFFS2VALS(F.COEFFS).
 %

--- a/@chebtech/strictCheck.m
+++ b/@chebtech/strictCheck.m
@@ -1,11 +1,12 @@
 function [ishappy, epslevel, cutoff] = strictCheck(f, values, pref)
 %STRICTCHECK   Attempt to trim trailing Chebyshev coefficients in a CHEBTECH.
-%   [ISHAPPY, CUTOFF, EPSLEVEL] = STRICTCHECK(F) returns an estimated 
-%   location CUTOFF at which the CHEBTECH F could be truncated to maintain an 
-%   accuracy of EPSLEVEL relative to F.VSCALE and F.HSCALE. ISHAPPY is TRUE if
-%   CUTOFF < MIN(LENGTH(F.COEFFS), 2) or F.VSCALE = 0, and FALSE otherwise.
+%   [ISHAPPY, EPSLEVEL, CUTOFF] = STRICTCHECK(F) returns an estimated location
+%   CUTOFF at which the CHEBTECH F could be truncated to maintain an accuracy of
+%   EPSLEVEL relative to F.VSCALE and F.HSCALE. ISHAPPY is TRUE if CUTOFF <
+%   MIN(LENGTH(F.COEFFS), 2) or F.VSCALE = 0, and FALSE otherwise. If ISHAPPY is
+%   false, EPSLEVEL returns an estimate of the accuracy achieved.
 %
-%   [ISHAPPY, CUTOFF, EPSLEVEL] = STRICTCHECK(F, VALUES, PREF) allows additional
+%   [ISHAPPY, EPSLEVEL, CUTOFF] = STRICTCHECK(F, VALUES, PREF) allows additional
 %   preferences to be passed. In particular, one can adjust the target accuracy
 %   with PREF.EPS. The VALUES field is ignored, but included for consistency
 %   with other happiness checks.
@@ -66,6 +67,7 @@ if ( max(f.vscale) == 0 )
 elseif ( any(isinf(f.vscale)) )
     % Inf located. No cutoff.
     cutoff = n;
+    epslevel = inf*epslevel;
     return
 end
 
@@ -92,6 +94,8 @@ if ( ~any(tail(:)) )
     ishappy = true;
 else
     cutoff = n;
+    % Estimate the epslevel:
+    epslevel = mean(abs(tail));
 end
 
 end


### PR DESCRIPTION
Closes #268.

``` matlab
>> f = chebfun(@(x) sqrt(1+x))
Warning: Function not resolved using 65537 pts. Have you tried 'splitting on'? 
> In chebfun.constructor>constructorNoSplit at 103
  In chebfun.constructor at 53
  In chebfun.chebfun>chebfun.chebfun at 187 
f = 
   chebfun column (1 smooth piece)
       interval       length   endpoint values  
[      -1,       1]    65537         0      1.4 
Epslevel = 1.852400e-10.  Vscale = 1.414214e+00.
>> f = chebfun(@abs)
Warning: Function not resolved using 65537 pts. Have you tried 'splitting on'? 
> In chebfun.constructor>constructorNoSplit at 103
  In chebfun.constructor at 53
  In chebfun.chebfun>chebfun.chebfun at 187 
f = 
   chebfun column (1 smooth piece)
       interval       length   endpoint values  
[      -1,       1]    65537         1        1 
Epslevel = 3.704567e-10.  Vscale = 1.
```
