### PR TITLE
Fixing a failing test.

### DIFF
--- a/tests/chebop/test_nonlinearSystemDampingBreakpoints.m
+++ b/tests/chebop/test_nonlinearSystemDampingBreakpoints.m
@@ -33,7 +33,7 @@ bcFunRight = chebfun(A.rbc(u1,u2));
 u1jump = jump(u1, 0);
 u2jump = jump(u2, 0);
 
-pass(1) = info.error < tol;
+pass(1) = abs(info.error) < tol;
 pass(2) = norm(bcFunLeft(d(1))) < tol && norm(bcFunRight(d(end))) < tol;
 pass(3) = norm(u1jump) < tol && norm(u2jump) < tol;
 
@@ -56,7 +56,7 @@ bcFunRight = chebfun(A.rbc(u3,u4));
 u5jump = jump(u3, 0);
 u6jump = jump(u4, 0);
 
-pass(4) = info.error < tol;
+pass(4) = abs(info.error) < tol;
 pass(5) = norm(bcFunLeft(d(1))) < tol && norm(bcFunRight(d(end))) < tol;
 pass(6) = norm(u5jump) < tol && norm(u6jump) < tol;
 
@@ -74,7 +74,7 @@ bcFunRight = chebfun(A.rbc(u5,u6));
 u7jump = jump(u5, 0);
 u8jump = jump(u6, 0);
 
-pass(7) = info.error < tol;
+pass(7) = abs(info.error) < tol;
 pass(8) = norm(bcFunLeft(d(1))) < tol && norm(bcFunRight(d(end))) < tol;
 pass(9) = norm(u7jump) < tol && norm(u8jump) < tol;
 


### PR DESCRIPTION
Fixing a failing CHEBOP test, by checking the error estimate, rather than the norm of the residual.
