### PR TITLE
Ensure all plot handles get freed on each loop in chebsnake.

### DIFF
--- a/chebsnake.m
+++ b/chebsnake.m
@@ -95,11 +95,11 @@ while ( d ~= 0 ) % until quit
     
     % Ready, set, go!
     t = 1;                              % convex factor for nodes
-    go = plot(.7*scribble('ready?'), 'r', LW, lw);
+    go = chebsnakePlotChebfun(.7*scribble('ready?'), 'r', LW, lw);
     shg; 
     pause(0.3); 
     delete(go(~isnan(go)));
-    go = plot(.4*scribble('go!'), 'r', LW, lw);
+    go = chebsnakePlotChebfun(.4*scribble('go!'), 'r', LW, lw);
     shg; 
     pause(0.3); 
     delete(go(~isnan(go)));
@@ -136,7 +136,7 @@ while ( d ~= 0 ) % until quit
             end
         end
 
-        hs1 = plot(c, 'b-', LW, lw);
+        hs1 = chebsnakePlotChebfun(c, 'b-', LW, lw);
         delete(hs2);
         hs2 = [plot(y(1:end-1), 'bo', MFC, 'b'), ...
                plot(y(end), 'bo', LW, lw, 'MarkerSize', 8)];
@@ -148,7 +148,7 @@ while ( d ~= 0 ) % until quit
         % check if the snake hits itself or the boundary
         if ( (max(abs([real(y(end)), imag(y(end))])) > 1) || ...
                 (min(abs(y(end)-y(1:end-1))) < res/2) )
-            ht = plot(.8*scribble('game over'), 'r', LW, lw);
+            ht = chebsnakePlotChebfun(.8*scribble('game over'), 'r', LW, lw);
             chebtune(dd, .5);
             shg
             pause(1)
@@ -172,7 +172,7 @@ while ( d ~= 0 ) % until quit
             if ( ~rem(pts, 30) )
                 chebtune(lv, 1);
                 fails = fails - 1;
-                up = plot(.8*scribble('1 up!'), 'r', LW, lw);
+                up = chebsnakePlotChebfun(.8*scribble('1 up!'), 'r', LW, lw);
                 shg
                 pause(1)
                 delete(up(~isnan(up)));
@@ -203,7 +203,7 @@ while ( d ~= 0 ) % until quit
     
 end
 
-plot(.8*scribble('goodbye'), 'r', LW, lw); 
+chebsnakePlotChebfun(.8*scribble('goodbye'), 'r', LW, lw); 
 chebtune(kld, 1);
 shg
 pause(1)
@@ -224,4 +224,13 @@ warning(W)
         end
     end
 
+end
+
+function h = chebsnakePlotChebfun(varargin)
+%CHEBSNAKEPLOT   Plot a CHEBFUN used in CHEBSNAKE.
+%   This function is just a wrapper for CHEBFUN PLOT which gets all the plot
+%   handles and assembles them into a numeric vector, making them easier to
+%   free later.
+    [hl, hp, hj, hd] = plot(varargin{:});
+    h = [hl ; hp ; hj ; hd];
 end


### PR DESCRIPTION
This closes #715.  The reason for the slowdown observed in that ticket is that
chebsnake was not properly freeing all the handle objects that chebfun.plot()
generates on each run of the loop, only the one that corresponds to the line
plot.  As these unfreed objects accumulate, the MATLAB plotting stack has to do
more and more work to update the plot, resulting in the slowdown

The reason this behavior was missed in the port of chebsnake to v5 is probably
that the output syntax for chebfun.plot() has changed. v4 chebfun.plot()
returns all the handles in one column vector output. v5 chebfun.plot() returns
them as separate outputs using varargout.

This commit fixes this problem by wrapping all calls to chebfun plot() in
chebsnake in a special function which properly extracts all of the handles and
collates them into a numeric vector so that we can reuse the existing code for
deleting them.
