### PR TITLE
Allow construction from logical (convert to double).

### DIFF
--- a/@chebtech1/refine.m
+++ b/@chebtech1/refine.m
@@ -51,6 +51,9 @@ else
     % User defined refinement function:
     [values, giveUp] = refFunc(op, values, pref);
 end
+
+% Ensure that doubles are returned:
+values = double(values);
     
 end
 

--- a/@chebtech2/refine.m
+++ b/@chebtech2/refine.m
@@ -51,6 +51,9 @@ else
     % User defined refinement function:
     [values, giveUp] = refFunc(op, values, pref);
 end
+
+% Ensure that doubles are returned:
+values = double(values);
     
 end
 

--- a/tests/chebfun/test_constructor_splitting.m
+++ b/tests/chebfun/test_constructor_splitting.m
@@ -47,6 +47,12 @@ pass(5) = (norm(f5.domain - [-1 -0.2 0.1 1], inf) < 10*eps) && ...
     (norm(feval(f5, xx5) - feval(F5, xx5), inf) < ...
     tol*max(f5.epslevel.*f5.vscale));
 
+%% Test a logical function:
+f = chebfun(@(x) x > 0, [-1 1], 'splitting', 'on', pref);
+x = chebfun('x', [-1 1], pref);
+h = heaviside(x);
+pass(6) = norm(f - h) < f.epslevel;
+
 %% Test for function defined on unbounded domain:
 
 % Function defined on [0 Inf]:
@@ -63,7 +69,7 @@ f = chebfun(op, dom, 'splitting', 'on');
 fVals = feval(f, x);
 fExact = op(x);
 err = fVals - fExact;
-pass(6) = norm(err, inf) < 1e1*epslevel(f)*vscale(f);
+pass(7) = norm(err, inf) < 1e1*epslevel(f)*vscale(f);
 
 % % Test X*LOG(X) on [0 1]:
 % F4 = @(x) x.*log(x);

--- a/tests/chebtech1/test_constructor.m
+++ b/tests/chebtech1/test_constructor.m
@@ -69,3 +69,14 @@ try
 catch
     pass(7) = false;
 end
+
+% Test logical-valued functions:
+f = chebtech1(@(x) x > -2);
+g = chebtech1(1);
+pass(8) = normest(f - g) < f.epslevel;
+
+f = chebtech1(@(x) x < -2);
+g = chebtech1(0);
+pass(9) = normest(f - g) < f.epslevel;
+
+end

--- a/tests/chebtech2/test_constructor.m
+++ b/tests/chebtech2/test_constructor.m
@@ -123,4 +123,14 @@ catch
     pass(16) = false;
 end
 
+%%
+% Test logical-valued functions:
+f = chebtech2(@(x) x > -2);
+g = chebtech2(1);
+pass(17) = normest(f - g) < f.epslevel;
+
+f = chebtech2(@(x) x < -2);
+g = chebtech2(0);
+pass(18) = normest(f - g) < f.epslevel;
+
 end


### PR DESCRIPTION
```
>> f = chebfun(@(x) x > 0, 'splitting', 'on')
f = 
   chebfun column (2 smooth pieces)
       interval       length   endpoint values  
[      -1,       0]        1         0        0 
[       0,       1]        1         1        1 
Epslevel = 6.492624e-16.  Vscale = 1.  Total length = 2.
```

Closes #786.
