### PR TITLE
Changing the definition of sinc()

### DIFF
--- a/@chebfun/sinc.m
+++ b/@chebfun/sinc.m
@@ -16,6 +16,6 @@ if ( nargin == 1 )
 end
 
 % Call the compose method:
-F = compose(F, @(x) sin(pi*x)./(pi*x), pref);
+F = compose(F, @(x) sin(x)./x, pref);
 
 end


### PR DESCRIPTION
In v4 we used sinc(x) = sin(x)/x. In v5 we used sinc(x) = sin(pi_x)/(pi_x).

Switching it to v4 definition of sinc(). This was causing an example to break.
