### PR TITLE
Respect vertical scaling of the input function in plateauCheck.

### DIFF
--- a/@chebtech/plateauCheck.m
+++ b/@chebtech/plateauCheck.m
@@ -66,6 +66,7 @@ end
 n90 = ceil( 0.90*n );
 absCoeff = abs( coeff(end:-1:end+1-n90,:) );  % switch to low->high ordering
 vscale = max(absCoeff,[],1);          % scaling in each column
+vscale = max( vscale, f.vscale );
 absCoeff = absCoeff * diag(1./vscale);
 
 


### PR DESCRIPTION
Currently only the intrinsic scale of the coefficients is considered. However, f may have an assigned vscale that is much larger (as in Newton iteration.)
