### PR TITLE
Enabling specifying discretization via strings.

### DIFF
--- a/@chebguiExporterBVP/printOptions.m
+++ b/@chebguiExporterBVP/printOptions.m
@@ -39,9 +39,14 @@ else
 end
 
 % Option for discretization:
-fprintf(fid, '\n%% Option for discretization (either @colloc2 or @ultraS).\n');
-fprintf(fid, 'options.discretization = @%s;\n', ...
-    func2str(discretization));
+fprintf(fid, ['\n%% Option for discretization (either ''collocation'' ' ...
+    'or ''ultraspherical'').\n']);
+if ( strcmp(func2str(discretization), 'colloc2') )
+    discString = 'collocation';
+else
+    discString = 'ultraspherical';
+end
+fprintf(fid, 'options.discretization = ''%s'';\n', discString);
 
 % Plot during Newton iteration?
 if ( ~strcmp(plotting, 'off') )

--- a/@chebguiExporterEIG/printOptions.m
+++ b/@chebguiExporterEIG/printOptions.m
@@ -20,10 +20,14 @@ fprintf(fid, '\n%% Create a CHEBOPPREF object for passing preferences: \n');
 fprintf(fid, 'options = cheboppref();\n');
 
 % Option for discretization:
-fprintf(fid, '\n%% Option for discretization (either @colloc2 or @ultraS).\n');
-fprintf(fid, 'options.discretization = @%s;\n', ...
-    func2str(discretization));
-
+fprintf(fid, ['\n%% Option for discretization (either ''collocation'' ' ...
+    'or ''ultraspherical'').\n']);
+if ( strcmp(func2str(discretization), 'colloc2') )
+    discString = 'collocation';
+else
+    discString = 'ultraspherical';
+end
+fprintf(fid, 'options.discretization = ''%s'';\n', discString);
 fprintf(fid, '\n%% Number of eigenvalue and eigenmodes to compute.\n');
 fprintf(fid, 'k = %s;\n', K);
 

--- a/@cheboppref/cheboppref.m
+++ b/@cheboppref/cheboppref.m
@@ -194,8 +194,25 @@ classdef cheboppref < chebpref
                 prefList.minDimension);
             fprintf([padString('    plotting:') '%s\n'], ...
                 prefList.plotting);
-        end
+       end
 
+        function pref = subsasgn(pref, ind, val)
+        %SUBSASGN   Subscripted assignment for CHEBOPPREF.
+        %   P.PROP = VAL, where P is a CHEBOPPREF object, assigns the value
+        %   VAL to the CHEBOPPREF property PROP stored in P.  If PROP is not a
+        %   CHEBOPPREF property, an error will be thrown.
+        %
+        %   CHEBOPPREF does not support any other subscripted assignment types,
+        %   including '()' and '{}'.
+            
+            % Support user-friendlier syntax for specifying discretization
+            % choice:
+            val = cheboppref.parseDiscretization(val);
+            
+            % Call the superclass method.
+            pref = subsasgn@chebpref(pref, ind, val);
+        end 
+       
     end
 
     methods ( Static = true )
@@ -295,6 +312,10 @@ classdef cheboppref < chebpref
                     while ( ~isempty(varargin) )
                         prefName = varargin{1};
                         prefValue = varargin{2};
+                        
+                        % Support user-friendlier syntax for specifying discretization
+                        % choice:
+                        prefValue = cheboppref.parseDiscretization(prefValue);
                         if ( isfield(defaultPrefs, prefName) )
                             defaultPrefs.(prefName) = prefValue;
                         else
@@ -325,6 +346,24 @@ classdef cheboppref < chebpref
             factoryPrefs.maxIter = 25;
             factoryPrefs.minDimension = 32;
             factoryPrefs.plotting = 'off';
+        end
+        
+        function val = parseDiscretization(val)
+        %PARSEDISCRETIZATION    Allow different syntax for specifying
+        %                       discretization.
+            
+            % We want to allow user-friendly syntax for specifying the
+            % discretization (#433). So check whether we have some of the
+            % strings we want to allow, and convert them to the correct function
+            % handle:
+            if ( any(strcmpi(val, {'ultraspherical', 'ultraS'})) )
+                val = @ultraS;
+            elseif ( any(strcmpi(val, {'collocation', 'colloc2'})) )
+                val = @colloc2;
+            elseif ( strcmpi(val, 'colloc1') )
+                val = @colloc1;
+            end
+                
         end
 
     end

--- a/tests/chebpref/test_cheboppref.m
+++ b/tests/chebpref/test_cheboppref.m
@@ -49,6 +49,15 @@ cheboppref.setDefaults(savedPrefs);
 % Test getting defaults:
 pass(8) = isnumeric(cheboppref().errTol);
 
+% Test specifying discretization via strings
+cheboppref.setDefaults('factory');
+cheboppref.setDefaults('discretization', 'ultraspherical');
+pref = cheboppref;
+pass(9) = strcmp(func2str(pref.discretization), 'ultraS');
+pref.discretization = 'collocation';
+pass(10) = strcmp(func2str(pref.discretization), 'colloc2');
+
+
 end
 
 function out = isequalNaN(a, b)


### PR DESCRIPTION
Closes #433.

The following syntax is now supported:

```
pref = cheboppref.
pref.discretization = @colloc1;
pref.discretization = @colloc2;
pref.discretization = @ultraS;
pref.discretization = 'colloc1';
pref.discretization = 'colloc2';
pref.discretization = 'ultras';
pref.discretization = 'collocation';
pref.discretization = 'ultraspherical';
```

Also, the same input is allowed for `cheboppref.setDefaults('discretization', ...)`. By default, `pref.discretization = 'collocation';` selects `colloc2` as the discretization.
