### PR TITLE
Better error messages for constructor input parsing.

### DIFF
--- a/@chebfun/chebfun.m
+++ b/@chebfun/chebfun.m
@@ -600,7 +600,7 @@ function [op, dom, data, pref] = parseInputs(op, varargin)
             % Pull out this preference, which is checked for later.
             keywordPrefs.enableBreakpointDetection = true;
             args(1:2) = [];
-        elseif ( isnumeric(args{1}) )
+        elseif ( isnumeric(args{1}) && isscalar(args{1}) )
             % g = chebfun(@(x) f(x), N)
             keywordPrefs.techPrefs.exactLength = args{1};
             args(1) = [];
@@ -660,10 +660,20 @@ function [op, dom, data, pref] = parseInputs(op, varargin)
                     'Invalid value for ''chebkind'' option.');
             end
             args(1:2) = [];
-        else
+        elseif ( ischar(args{1}) )
             % Update these preferences:
             keywordPrefs.(args{1}) = args{2};
             args(1:2) = [];
+        else
+            if ( isnumeric(args{1}) )
+                error('CHEBFUN:parseInputs:badInputNumeric', ...
+                    ['Could not parse input argument sequence.\n' ...
+                     '(Perhaps the construction domain is not the second ' ...
+                     'argument?)']);
+            else
+                error('CHEBFUN:parseInputs:badInput', ...
+                    'Could not parse input argument sequence.');
+            end
         end
     end
 


### PR DESCRIPTION
In particular, something more sensible is printed if we can guess that
someone probably tried to pass the construction domain in a position
other than the second argument.

This closes #844.
