### PR TITLE
Remove some duplicated preferences for CHEBFUN2

### DIFF
--- a/@blockFunction/fred.m
+++ b/@blockFunction/fred.m
@@ -47,5 +47,5 @@ nrmu = norm(u);
 % opt = {'resampling',false,'splitting',true,'scale',nrmu};
 int = @(x) sum( chebfun(@(y) feval(u,y).*kernel(x,y),d)); %, opt{:} );
 Fu = chebfun( int, d, 'sampletest', false, 'resampling', false, ...
-    'vectorize', 'scale', nrmu);
+    'vectorize', 'vscale', nrmu);
 end

--- a/@blockFunction/volt.m
+++ b/@blockFunction/volt.m
@@ -52,7 +52,6 @@ function v = applyVolt(u, dom, kernel)
     
     nrmu = max(1, norm(u));
     p.techPrefs.sampleTest = false;
-    p.scale = nrmu;
     
     % TODO: Explore the correct preferences for best behavior.
     %    p.techPrefs.eps = nrmu*eps;
@@ -61,7 +60,6 @@ function v = applyVolt(u, dom, kernel)
     
     breaks = dom(2:end-1);
     
-     
     v = chebfun(@integral, [dom(1) breaks dom(end)], ...
         'vectorize', 'sampletest', 0, 'chebkind', 1 );
     
@@ -70,7 +68,7 @@ function v = applyVolt(u, dom, kernel)
             h = 0;
         else
             tmp = chebfun(@(y) feval(u,y).*kernel(x,y), ...
-                [dom(1) breaks(breaks<x) x], p);
+                [dom(1) breaks(breaks<x) x], p, 'vscale', nrmu);
             h = sum( tmp );
         end
     end

--- a/@chebfun/chebfun.m
+++ b/@chebfun/chebfun.m
@@ -535,8 +535,11 @@ function [op, dom, data, pref] = parseInputs(op, varargin)
     % might be useful in the future.
 
     % Initialize data output.
+    data.hscale = [];
+    data.vscale = [];
     data.exponents = [];
     data.singType = [];
+    
     args = varargin;
 
     % An op-only constructor call.
@@ -636,10 +639,18 @@ function [op, dom, data, pref] = parseInputs(op, varargin)
                 end
             end
             args(1:2) = [];
+        elseif ( strcmpi(args{1}, 'vscale') )
+            % Store vscale types.
+            data.vscale = args{2};
+            args(1:2) = [];
+        elseif ( strcmpi(args{1}, 'hscale') )
+            % Store vscale types.
+            data.vscale = args{2};
+            args(1:2) = [];            
         elseif ( strcmpi(args{1}, 'singType') )
             % Store singularity types.
             data.singType = args{2};
-            args(1:2) = [];
+            args(1:2) = [];            
         elseif ( strcmpi(args{1}, 'exps') )
             % Store exponents.
             data.exponents = args{2};

--- a/@chebfun/constructor.m
+++ b/@chebfun/constructor.m
@@ -46,7 +46,9 @@ data.hscale = norm(dom, inf);
 if ( isinf(data.hscale) )
     data.hscale = 1;
 end
-data.vscale = pref.scale;
+if ( isempty(data.vscale) )
+    data.vscale = 0;
+end
 
 % Sanity check:
 if ( iscell(op) && (numel(op) ~= numIntervals) )

--- a/@chebfun/quantumstates.m
+++ b/@chebfun/quantumstates.m
@@ -64,7 +64,7 @@ L.op = @(x,u) -h^2*diff(u,2) + V.*u;               % Schroedinger operator
 [U, D] = eigs(L, n, 'sr');                         % compute evals/efuns
 d = diag(D);                                       % vector of evals
 [d, ii] = sort(d);                                 % sort them
-U = extractColumns(U, ii);                    
+U = U(:,ii);                    
 
 %% Outputs:
 if ( nargout == 2 )

--- a/@chebfun2/constructor.m
+++ b/@chebfun2/constructor.m
@@ -44,6 +44,21 @@ else
     pref = chebfunpref();
 end
 
+% Get default preferences from chebfunpref:
+prefStruct = pref.cheb2Prefs;
+sampleTest = prefStruct.sampleTest;
+maxRank = prefStruct.maxRank;
+
+% Go find out what tech I'm based on:
+tech = pref.tech();
+
+% Get default preferences from the techPref:
+tpref = chebfunpref.mergePrefs(pref, tech.techPref);
+minSample = tpref.minPoints; 
+maxSample = tpref.maxPoints;
+pseudoLevel = tpref.eps;
+
+
 if ( isa(op, 'double') )    % CHEBFUN2( DOUBLE )
     if ( numel( op ) == 1 )
         % LNT wants this:
@@ -81,7 +96,6 @@ if ( isa(op, 'double') )    % CHEBFUN2( DOUBLE )
         % The tolerance assumes the samples are from a function. It depends
         % on the size of the sample matrix, hscale of domain, vscale of
         % the samples, and the accuracy target in chebfun2 preferences. 
-        pseudoLevel = pref.cheb2Prefs.eps;
         grid = max( size( op ) ); 
         vscale = max( op(:) ); 
         tol = grid.^(2/3) * max( max( abs(domain(:))), 1) * vscale * pseudoLevel;
@@ -141,26 +155,6 @@ elseif ( numel(domain) ~= 4 )
     error('CHEBFUN2:CONSTRUCTOR:DOMAIN', 'Domain not fully determined.');
 end
 
-% Get default preferences from chebfunpref:
-prefStruct = pref.cheb2Prefs;
-maxRank = prefStruct.maxRank;
-maxLength = prefStruct.maxLength;
-pseudoLevel = prefStruct.eps;
-sampleTest = prefStruct.sampleTest;
-% TODO: This should probably be taken from the techPref prefences?
-minsample = 17;   % minsample
-
-% Go find out what tech I'm based on:
-tech = chebfunpref().tech();
-
-factor = 4;  % grid to rank ratio.
-if ( isa(tech, 'fourtech') ) 
-    minsample = 8; 
-end
-if ( isa(tech, 'chebtech1') )
-    factor = 5; 
-end
-
 % If the vectorize flag is off, do we need to give user a warning?
 if ( vectorize == 0 ) % another check
     % Check for cases: @(x,y) x*y, and @(x,y) x*y'
@@ -183,9 +177,9 @@ end
 
 factor = 4;  % ratio between size of matrix and no. pivots. 
 isHappy = 0; % If we are currently unresolved. 
-Failure = 0; % Reached max discretization size without being happy. 
-while ( ~isHappy && ~Failure )
-    grid = minsample; 
+failure = 0; % Reached max discretization size without being happy. 
+while ( ~isHappy && ~failure )
+    grid = minSample; 
     
     % Sample function on a Chebyshev tensor grid:
     [xx, yy] = points2D(grid, grid, domain);
@@ -227,7 +221,7 @@ while ( ~isHappy && ~Failure )
     % If the rank of the function is above maxRank then stop.
     if ( grid > factor*(maxRank-1)+1 )
         warning('CHEBFUN2:CTOR', 'Not a low-rank function.');
-        Failure = 1; 
+        failure = 1; 
     end
     
     % Check if the column and row slices are resolved.
@@ -300,9 +294,10 @@ while ( ~isHappy && ~Failure )
         isHappy = resolvedRows & resolvedCols;
         
         % STOP if degree is over maxLength:
-        if ( max(m, n) >= maxLength )
-            warning('CHEBFUN2:CTOR', 'Unresolved with maximum CHEBFUN length: %u.', maxLength);
-            Failure = 1;
+        if ( max(m, n) >= maxSample )
+            warning('CHEBFUN2:CTOR', ...
+                'Unresolved with maximum CHEBFUN length: %u.', maxSample);
+            failure = 1;
         end
         
     end
@@ -310,7 +305,7 @@ while ( ~isHappy && ~Failure )
     % For some reason, on some computers simplify is giving back a scalar zero.
     % In which case the function is numerically zero. Artifically set the
     % columns and rows to zero.
-    if ( norm(colValues) == 0 || norm(rowValues) == 0)
+    if ( (norm(colValues) == 0) || (norm(rowValues) == 0) )
         colValues = 0;
         rowValues = 0;
         pivotValue = Inf;
@@ -334,7 +329,7 @@ while ( ~isHappy && ~Failure )
         pass = g.sampleTest( sampleOP, tol, vectorize);
         if ( ~pass )
             % Increase minsamples and try again.
-            minsample = gridRefine( minsample );
+            minSample = gridRefine( minSample );
             isHappy = 0;
         end
     end
@@ -346,7 +341,8 @@ g = fixTheRank( g , fixedRank );
 
 end
 
-function [pivotValue, pivotElement, rows, cols, ifail] = CompleteACA(A, tol, factor)
+function [pivotValue, pivotElement, rows, cols, ifail] = ...
+    CompleteACA(A, tol, factor)
 % Adaptive Cross Approximation with complete pivoting. This command is
 % the continuous analogue of Gaussian elimination with complete pivoting.
 % Here, we attempt to adaptively find the numerical rank of the function.
@@ -383,7 +379,7 @@ else
     cols(:,1) = zeros(size(A, 1), 1);
 end
 
-while ( ( infNorm > tol ) && ( zRows < width / factor)...
+while ( ( infNorm > tol ) && ( zRows < width / factor) ...
         && ( zRows < min(nx, ny) ) )
     rows(zRows+1,:) = A(row,:);
     cols(:,zRows+1) = A(:,col);              % Extract the columns.
@@ -414,12 +410,11 @@ end
 if ( infNorm <= tol )
     ifail = 0;                               % We didn't fail.
 end
-if (zRows >= width / factor)
+if ( zRows >= (width/factor) )
     ifail = 1;                               % We did fail.
 end
 
 end
-
 
 
 function [row, col] = myind2sub(siz, ndx)
@@ -464,6 +459,7 @@ op = eval(['@(' depvar{1} ',' depvar{2} ')' op]);
 
 end
 
+
 function g = fixTheRank( g , fixedRank )
 % Fix the rank of a CHEBFUN2. Used for nonadaptive calls to the constructor.
 
@@ -491,6 +487,7 @@ end
 
 end
 
+
 function [xx, yy] = points2D(m, n, dom)
 % Get the sample points that correspond to the right grid for a particular
 % technology.
@@ -515,6 +512,7 @@ else
 end
 
 end
+
 
 function x = mypoints(n, dom)
 % Get the sample points that correspond to the right grid for a particular
@@ -557,4 +555,5 @@ elseif ( isa(tech, 'chebtech1' ) )
 else
     error('CHEBFUN2:TECHTYPE','Technology is unrecognized.');
 end
+
 end

--- a/@chebfunpref/chebfunpref.m
+++ b/@chebfunpref/chebfunpref.m
@@ -73,14 +73,6 @@ classdef chebfunpref < chebpref
 %         If two delta functions are located closer than this tolerance, they 
 %         will be merged.
 %
-%   scale                      - The vertical scale constructor should use.
-%    [0]
-%
-%      Typically the CHEBFUN constructor will resolve relative to a vertical
-%      scale determined by it's own function evaluations. However, in some
-%      situations one would like to the resolve relative to a fixed vertical
-%      scale. This can be set using this preference.
-%
 %   singPrefs                  - Preferences for singularity detection.
 %
 %      exponentTol             - Tolerance for exponents.
@@ -98,14 +90,6 @@ classdef chebfunpref < chebpref
 %         
 %         The default singularity type to be used when singularity detection is
 %         enabled and no singType is provided.
-%
-%   scale                      - The vertical scale the constructor should use.
-%    [0]
-%
-%      Typically the CHEBFUN constructor will resolve relative to a vertical
-%      scale determined by it's own function evaluations. However, in some
-%      situations one would like to the resolve relative to a fixed vertical
-%      scale. This can be set using this preference.
 %
 %   tech                       - Representation technology.
 %    ['chebtech2']
@@ -454,12 +438,6 @@ classdef chebfunpref < chebpref
             fprintf('    cheb2Prefs\n');
             fprintf([padString('        maxRank:') '%d\n'], ...
                 prefList.cheb2Prefs.maxRank');
-            fprintf([padString('        maxLength:') '%d\n'], ...
-                prefList.cheb2Prefs.maxLength');            
-            fprintf([padString('        eps:') '%d\n'], ...
-                prefList.cheb2Prefs.eps');            
-            fprintf([padString('        exactLength:') '%d\n'], ...
-                prefList.cheb2Prefs.exactLength');            
             fprintf([padString('        sampleTest:') '%d\n'], ...
                 prefList.cheb2Prefs.sampleTest');            
             fprintf([padString('    scale:') '%d\n'], ...
@@ -693,7 +671,6 @@ classdef chebfunpref < chebpref
             factoryPrefs.enableDeltaFunctions = true;
                 factoryPrefs.deltaPrefs.deltaTol = 1e-9;
                 factoryPrefs.deltaPrefs.proximityTol = 1e-11;
-            factoryPrefs.scale = 0;
             factoryPrefs.tech = @chebtech2;
             factoryPrefs.techPrefs = struct();
                 factoryPrefs.techPrefs.eps = 2^(-52);
@@ -703,9 +680,6 @@ classdef chebfunpref < chebpref
                 factoryPrefs.techPrefs.sampleTest = true;
             factoryPrefs.cheb2Prefs = struct(); 
                 factoryPrefs.cheb2Prefs.maxRank = 513;   
-                factoryPrefs.cheb2Prefs.maxLength = 65537;   
-                factoryPrefs.cheb2Prefs.eps = 2^(-52);   
-                factoryPrefs.cheb2Prefs.exactLength = 0; 
                 factoryPrefs.cheb2Prefs.sampleTest = 1;
         end
 

--- a/tests/chebfun/test_chebfun_lu.m
+++ b/tests/chebfun/test_chebfun_lu.m
@@ -5,7 +5,7 @@ if ( nargin == 0)
     pref = chebfunpref; 
 end
 
-tol = pref.cheb2Prefs.eps; 
+tol = pref.eps; 
 j = 1;
 
 % Check accuracy on [-1,1]

--- a/tests/chebfun/test_volt.m
+++ b/tests/chebfun/test_volt.m
@@ -9,7 +9,7 @@ f = chebfun(@sin, pref);        % A simple chebfun.
 F = volt(K, f);                 % Call volt().
 
 % Test against some V4 results:
-pass(1) = abs(F(.5) - (-0.013808570536509)) < vscale(F)*epslevel(F);
+pass(1) = abs(F(.5) - (-0.013808570536509)) < 10*vscale(F)*epslevel(F);
 pass(2) = abs(norm(F) - 0.334612395278957) < vscale(F)*epslevel(F);
 
 % Test 3rd input argument. (Simply make sure we don't crash!)

--- a/tests/chebfun2/test_CLA.m
+++ b/tests/chebfun2/test_CLA.m
@@ -5,7 +5,7 @@ function pass = test_basicCLA( pref )
 if ( nargin < 1 )
     pref = chebfunpref; 
 end
-tol = 100*pref.cheb2Prefs.eps; 
+tol = 100*pref.eps; 
 
 seedRNG(0)
 gam = 10;

--- a/tests/chebfun2/test_abs.m
+++ b/tests/chebfun2/test_abs.m
@@ -5,7 +5,7 @@ if ( nargin == 0)
     pref = chebfunpref; 
 end
 
-tol = 1000*pref.cheb2Prefs.eps; 
+tol = 1000*pref.eps; 
 j = 1; 
 
 

--- a/tests/chebfun2/test_battery.m
+++ b/tests/chebfun2/test_battery.m
@@ -4,7 +4,7 @@ function pass = test_battery( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e8 * pref.cheb2Prefs.eps; 
+tol = 1e8 * pref.eps; 
 
 Battery = {@(x,y) cos(pi*x.*y),...                                        % 1
     @(x,y) cos(2*pi*x.*y), ...                                            % 2

--- a/tests/chebfun2/test_cdr.m
+++ b/tests/chebfun2/test_cdr.m
@@ -5,7 +5,7 @@ if ( nargin == 0)
     pref = chebfunpref; 
 end
 
-tol = 1000*pref.cheb2Prefs.eps; 
+tol = 1000*pref.eps; 
 j = 1; 
 
 f = chebfun2(@(x,y) cos(x.*y));

--- a/tests/chebfun2/test_chebpoly2.m
+++ b/tests/chebfun2/test_chebpoly2.m
@@ -5,7 +5,7 @@ if ( nargin == 0)
     pref = chebfunpref; 
 end
 
-tol = 1000*pref.cheb2Prefs.eps; 
+tol = 1000*pref.eps; 
 j = 1; 
 
 % Rank-2 function

--- a/tests/chebfun2/test_chebpolyval2.m
+++ b/tests/chebfun2/test_chebpolyval2.m
@@ -4,7 +4,7 @@ function pass = test_chebpolyval2()
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 100 * pref.cheb2Prefs.eps; 
+tol = 100 * pref.eps; 
 
 % check the trunk chebpolyval2 command.
 T = chebpoly(20); 

--- a/tests/chebfun2/test_chebpts2.m
+++ b/tests/chebfun2/test_chebpts2.m
@@ -5,7 +5,7 @@ if ( nargin == 0 )
     pref = chebfunpref; 
 end
 
-tol = 10*pref.cheb2Prefs.eps; 
+tol = 10*pref.eps; 
 
 % One arguments: 
 n = 10; 

--- a/tests/chebfun2/test_chol.m
+++ b/tests/chebfun2/test_chol.m
@@ -5,7 +5,7 @@ if ( nargin == 0 )
     pref = chebfunpref; 
 end 
 
-tol = 100*pref.cheb2Prefs.eps; 
+tol = 100*pref.eps; 
 j = 1; 
 
 % Decomposition on [-1,1,-1,1]: 

--- a/tests/chebfun2/test_coefficients.m
+++ b/tests/chebfun2/test_coefficients.m
@@ -5,7 +5,7 @@ function pass = test_coefficients( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 100 * pref.cheb2Prefs.eps; 
+tol = 100 * pref.eps; 
 
 n = 10; 
 f = chebpoly(n); 

--- a/tests/chebfun2/test_complex.m
+++ b/tests/chebfun2/test_complex.m
@@ -5,7 +5,7 @@ if ( nargin == 0)
     pref = chebfunpref; 
 end
 
-tol = 1000*pref.cheb2Prefs.eps; 
+tol = 1000*pref.eps; 
 j = 1; 
 
 f = chebfun2(@(x,y) cos(x.*y)); 

--- a/tests/chebfun2/test_composition_operators.m
+++ b/tests/chebfun2/test_composition_operators.m
@@ -5,7 +5,7 @@ if ( nargin == 0 )
     pref = chebfunpref; 
 end
 
-tol = 1000*pref.cheb2Prefs.eps;
+tol = 1000*pref.eps;
 j = 1; 
 
 f = chebfun2(@(x,y) cos(x.*y) + sin(x.*y) + y -.1); 

--- a/tests/chebfun2/test_conj.m
+++ b/tests/chebfun2/test_conj.m
@@ -5,7 +5,7 @@ if ( nargin == 0 )
     pref = chebfunpref; 
 end
 
-tol = 10*pref.cheb2Prefs.eps; 
+tol = 10*pref.eps; 
 
 f = chebfun2(@(x,y) cos(x.*y)); 
 g = conj( f ); 

--- a/tests/chebfun2/test_constructor.m
+++ b/tests/chebfun2/test_constructor.m
@@ -4,7 +4,7 @@ function pass = test_constructor( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e2 * pref.cheb2Prefs.eps; 
+tol = 1e2 * pref.eps; 
 
 % Can we make a chebfun2: 
 f = @(x,y) cos( x ) + sin( x .* y );  % simple function. 

--- a/tests/chebfun2/test_contour.m
+++ b/tests/chebfun2/test_contour.m
@@ -5,7 +5,7 @@ if ( nargin == 0)
     pref = chebfunpref; 
 end
 
-tol = 1000*pref.cheb2Prefs.eps; 
+tol = 1000*pref.eps; 
 j = 1; 
 
 f = chebfun2(@(x,y) cos(x.*y)); 

--- a/tests/chebfun2/test_cumsum.m
+++ b/tests/chebfun2/test_cumsum.m
@@ -4,7 +4,7 @@ if ( nargin == 0 )
     pref = chebfunpref; 
 end
 
-tol = 100*pref.cheb2Prefs.eps; 
+tol = 100*pref.eps; 
 j = 1; 
 
 % Check cumsum on square domain

--- a/tests/chebfun2/test_diag.m
+++ b/tests/chebfun2/test_diag.m
@@ -5,7 +5,7 @@ if ( nargin == 0)
     pref = chebfunpref; 
 end
 
-tol = 1000*pref.cheb2Prefs.eps; 
+tol = 1000*pref.eps; 
 j = 1; 
 
 % checking diag

--- a/tests/chebfun2/test_diff.m
+++ b/tests/chebfun2/test_diff.m
@@ -4,7 +4,7 @@ function pass = test_diff( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e6 * pref.cheb2Prefs.eps; 
+tol = 1e6 * pref.eps; 
 j = 1; 
 
 % Battery:  functions, df/dx, and df/dy

--- a/tests/chebfun2/test_divide.m
+++ b/tests/chebfun2/test_divide.m
@@ -5,7 +5,7 @@ if ( nargin == 0)
     pref = chebfunpref; 
 end
 
-tol = 1000*pref.cheb2Prefs.eps; 
+tol = 1000*pref.eps; 
 j = 1; 
 
 f = chebfun2(@(x,y) cos(x.*y)); 

--- a/tests/chebfun2/test_feval.m
+++ b/tests/chebfun2/test_feval.m
@@ -5,7 +5,7 @@ if ( nargin == 0)
     pref = chebfunpref; 
 end
 
-tol = 100*pref.cheb2Prefs.eps;  
+tol = 100*pref.eps;  
 
 f = chebfun2(@(x,y) x); 
 pass(1) = (abs(f(pi/6,pi/12)-pi/6) < tol); 

--- a/tests/chebfun2/test_get.m
+++ b/tests/chebfun2/test_get.m
@@ -4,7 +4,7 @@ function pass = test_get( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e2 * pref.cheb2Prefs.eps; 
+tol = 1e2 * pref.eps; 
 j = 1; 
 
 f = chebfun2(@(x,y) cos(x.*y)); 

--- a/tests/chebfun2/test_guide.m
+++ b/tests/chebfun2/test_guide.m
@@ -5,7 +5,7 @@ function pass = test_guide( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end
-tol = 1e3*pref.cheb2Prefs.eps; 
+tol = 1e3*pref.eps; 
 
 % commands from guide1: 
 f = chebfun2(@(x,y) cos(x.*y));

--- a/tests/chebfun2/test_imag.m
+++ b/tests/chebfun2/test_imag.m
@@ -4,7 +4,7 @@ if ( nargin == 0 )
     pref = chebfunpref; 
 end
 
-tol = 100*pref.cheb2Prefs.eps; 
+tol = 100*pref.eps; 
 
 f = chebfun2(@(x,y) cos(x.*y)); 
 g = chebfun2(@(x,y) sin(x+y.^2));

--- a/tests/chebfun2/test_integralEqns.m
+++ b/tests/chebfun2/test_integralEqns.m
@@ -5,7 +5,7 @@ if ( nargin == 0)
     pref = chebfunpref; 
 end
 
-tol = 1000*pref.cheb2Prefs.eps; 
+tol = 1000*pref.eps; 
 j = 1; 
 
 % Fred on [-1 1 -1 1]

--- a/tests/chebfun2/test_interpaccuracy.m
+++ b/tests/chebfun2/test_interpaccuracy.m
@@ -6,7 +6,7 @@ if ( nargin < 1 )
     pref = chebfunpref; 
 end 
 
-tol = 100*pref.cheb2Prefs.eps; 
+tol = 100*pref.eps; 
 j = 1; 
 
 % Mohsin's bugs. 

--- a/tests/chebfun2/test_lu.m
+++ b/tests/chebfun2/test_lu.m
@@ -5,7 +5,7 @@ if ( nargin == 0 )
     pref = chebfunpref; 
 end 
 
-tol = 100*pref.cheb2Prefs.eps; 
+tol = 100*pref.eps; 
 
 % Decomposition on [-1,1,-1,1]: 
 x = chebpts(100);

--- a/tests/chebfun2/test_max.m
+++ b/tests/chebfun2/test_max.m
@@ -4,7 +4,7 @@ function pass = test_max( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end
-tol = 100*pref.cheb2Prefs.eps; 
+tol = 100*pref.eps; 
 
 f = chebfun2(@(x,y) cos(x.*y)); 
 g = chebfun(@(x) 1 + 0*x); 

--- a/tests/chebfun2/test_mean.m
+++ b/tests/chebfun2/test_mean.m
@@ -5,7 +5,7 @@ if ( nargin < 1 )
     pref = chebfunpref; 
 end 
 
-tol = pref.cheb2Prefs.eps; 
+tol = pref.eps; 
 j = 1; 
 
 f = chebfun2(@(x,y) sin((x-.1).*y)); 

--- a/tests/chebfun2/test_min.m
+++ b/tests/chebfun2/test_min.m
@@ -4,7 +4,7 @@ function pass = test_min( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end
-tol = 1000*pref.cheb2Prefs.eps; 
+tol = 1000*pref.eps; 
 tol = sqrt(tol); 
 
 f = chebfun2(@(x,y) cos(x.*y)); 

--- a/tests/chebfun2/test_minus.m
+++ b/tests/chebfun2/test_minus.m
@@ -4,7 +4,7 @@ function pass = test_basic_minus( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e5 * pref.cheb2Prefs.eps; 
+tol = 1e5 * pref.eps; 
 j = 1;
 
 D = [-1 1 -1 1; -2 2 -2 2; -1 pi 0 2*pi];

--- a/tests/chebfun2/test_optimization.m
+++ b/tests/chebfun2/test_optimization.m
@@ -5,7 +5,7 @@ if ( nargin < 1 )
     pref = chebfunpref; 
 end 
 
-tol = 1000*pref.cheb2Prefs.eps; 
+tol = 1000*pref.eps; 
 j = 1; 
 
 Battery = {@(x,y) cos(pi*x.*y),...

--- a/tests/chebfun2/test_plus.m
+++ b/tests/chebfun2/test_plus.m
@@ -4,7 +4,7 @@ function pass = test_plus( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e5 * pref.cheb2Prefs.eps; 
+tol = 1e5 * pref.eps; 
 j = 1;
 
 D = [-1 1 -1 1; -2 2 -2 2; -1 pi 0 2*pi];

--- a/tests/chebfun2/test_qr.m
+++ b/tests/chebfun2/test_qr.m
@@ -5,7 +5,7 @@ if ( nargin == 0 )
     pref = chebfunpref; 
 end 
 
-tol = 100*pref.cheb2Prefs.eps; 
+tol = 100*pref.eps; 
 j = 1; 
 
 % Decomposition on [-1,1,-1,1]: 

--- a/tests/chebfun2/test_rank.m
+++ b/tests/chebfun2/test_rank.m
@@ -5,7 +5,7 @@ if ( nargin < 1 )
     pref = chebfunpref; 
 end 
 
-tol = pref.cheb2Prefs.eps; 
+tol = pref.eps; 
 j = 1; 
 
 C = 100;

--- a/tests/chebfun2/test_repeatedArithmetic.m
+++ b/tests/chebfun2/test_repeatedArithmetic.m
@@ -5,7 +5,7 @@ function pass = test_repeatedArithmetic( prefs )
 if ( nargin < 1 ) 
     prefs = chebfunpref(); 
 end
-tol = 1e4*prefs.cheb2Prefs.eps; 
+tol = 1e4*prefs.eps; 
 
 % Add 100 functions together: 
 f = chebfun2(@(x,y) cos(x.*y)); 

--- a/tests/chebfun2/test_restriction.m
+++ b/tests/chebfun2/test_restriction.m
@@ -4,7 +4,7 @@ function pass = test_restriction( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e5 * pref.cheb2Prefs.eps; 
+tol = 1e5 * pref.eps; 
 j = 1; 
 
 % Restricting a chebfun2 to a point. 

--- a/tests/chebfun2/test_roots_syntax.m
+++ b/tests/chebfun2/test_roots_syntax.m
@@ -4,7 +4,7 @@ function pass = test_roots_syntax( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end
-tol = 10*pref.cheb2Prefs.eps; 
+tol = 10*pref.eps; 
 
 % Try out the many different ways of calling the same algorithms. 
 f = chebfun2(@(x,y) cos(7*x.^2.*y + y)); 

--- a/tests/chebfun2/test_scl.m
+++ b/tests/chebfun2/test_scl.m
@@ -5,7 +5,7 @@ function pass = test_scl( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 10*pref.cheb2Prefs.eps; 
+tol = 10*pref.eps; 
 j = 1;
 
 % Scale invariant

--- a/tests/chebfun2/test_squeeze.m
+++ b/tests/chebfun2/test_squeeze.m
@@ -5,7 +5,7 @@ if ( nargin == 0 )
     pref = chebfunpref; 
 end
 
-tol = 10*pref.cheb2Prefs.eps; 
+tol = 10*pref.eps; 
 
 % This does not squeeze: 
 f = chebfun2(@(x,y) cos(x.*y)); 

--- a/tests/chebfun2/test_subsref.m
+++ b/tests/chebfun2/test_subsref.m
@@ -4,7 +4,7 @@ if ( nargin < 1 )
     pref = chebfunpref; 
 end
 
-tol = 1000*pref.cheb2Prefs.eps; 
+tol = 1000*pref.eps; 
 
 % Evaluation 
 f = chebfun2(@(x,y) sin(x.*(y-.1)), [-2 2 -3 4]);

--- a/tests/chebfun2/test_sum.m
+++ b/tests/chebfun2/test_sum.m
@@ -5,7 +5,7 @@ if ( nargin < 1 )
     pref = chebfunpref; 
 end 
 
-tol = 100*pref.cheb2Prefs.eps; 
+tol = 100*pref.eps; 
 j = 1; 
 
 % Example from wiki: http://en.wikipedia.org/wiki/Multiple_integral#Double_integral

--- a/tests/chebfun2/test_times.m
+++ b/tests/chebfun2/test_times.m
@@ -5,7 +5,7 @@ if ( nargin == 0)
     pref = chebfunpref; 
 end
 
-tol = 1000*pref.cheb2Prefs.eps; 
+tol = 1000*pref.eps; 
 j = 1; 
 
 f = chebfun2(@(x,y) cos(x.*y)); 

--- a/tests/chebfun2/test_transpose.m
+++ b/tests/chebfun2/test_transpose.m
@@ -5,7 +5,7 @@ if ( nargin == 0)
     pref = chebfunpref; 
 end
 
-tol = 1000*pref.cheb2Prefs.eps; 
+tol = 1000*pref.eps; 
 j = 1; 
 
 % symmetric function:

--- a/tests/chebfun2/test_trig.m
+++ b/tests/chebfun2/test_trig.m
@@ -5,7 +5,7 @@ if ( nargin == 0 )
     pref = chebfunpref; 
 end
 
-tol = 100*pref.cheb2Prefs.eps; 
+tol = 100*pref.eps; 
 
 f = {@cos, @sin, @tan, @cosh, @sinh, @tanh, @tand}; 
 

--- a/tests/chebfun2/test_uminus.m
+++ b/tests/chebfun2/test_uminus.m
@@ -1,10 +1,10 @@
-function pass = test_basic_uminus( pref ) 
+function pass = test_uminus( pref ) 
 % This tests the basic arithmetic operations on chebfun2 objects.
 
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e5 * pref.cheb2Prefs.eps; 
+tol = 1e5 * pref.eps; 
 j = 1;
 
 D = [-1 1 -1 1; -2 2 -2 2; -1 pi 0 2*pi];

--- a/tests/chebfun2/test_uplus.m
+++ b/tests/chebfun2/test_uplus.m
@@ -1,10 +1,10 @@
-function pass = test_basic_uplus( pref ) 
+function pass = test_uplus( pref ) 
 % This tests the basic arithmetic operations on chebfun2 objects.
 
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e5 * pref.cheb2Prefs.eps; 
+tol = 1e5 * pref.eps; 
 j = 1;
 
 D = [-1 1 -1 1; -2 2 -2 2; -1 pi 0 2*pi];

--- a/tests/chebfun2/test_vectoriseFlag.m
+++ b/tests/chebfun2/test_vectoriseFlag.m
@@ -5,7 +5,7 @@ if ( nargin < 1 )
     prefs = chebfunpref(); 
 end 
 
-tol = 10*prefs.cheb2Prefs.eps; 
+tol = 10*prefs.eps; 
 
 % All these calls to the constructor should be the same: 
 f1 = chebfun2(@(x,y) x); 

--- a/tests/chebfun2/test_vertcat.m
+++ b/tests/chebfun2/test_vertcat.m
@@ -4,7 +4,7 @@ function pass = test_vertcat( prefs )
 if ( nargin < 1 ) 
     prefs = chebfunpref(); 
 end
-tol = 10*prefs.cheb2Prefs.eps;
+tol = 10*prefs.eps;
 
 f = chebfun2(@(x,y) x); 
 g = chebfun2(@(x,y) y);

--- a/tests/chebfun2/test_zerofunction.m
+++ b/tests/chebfun2/test_zerofunction.m
@@ -5,7 +5,7 @@ function pass = test_zerofunction( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 100 * pref.cheb2Prefs.eps; 
+tol = 100 * pref.eps; 
 
 % construction
 f = chebfun2(0); 

--- a/tests/chebfun2v/test_arithmetic.m
+++ b/tests/chebfun2v/test_arithmetic.m
@@ -6,7 +6,7 @@ function pass = test_arithmetic( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e3 * pref.cheb2Prefs.eps; 
+tol = 1e3 * pref.eps; 
 j = 1;
 
 % These function chosen so that scl does not change.

--- a/tests/chebfun2v/test_conj.m
+++ b/tests/chebfun2v/test_conj.m
@@ -5,7 +5,7 @@ if ( nargin == 0 )
     pref = chebfunpref; 
 end
 
-tol = 100*pref.cheb2Prefs.eps; 
+tol = 100*pref.eps; 
 
 f = chebfun2v(@(x,y) cos(x.*y),@(x,y) cos(x.*y)); 
 g = conj( f ); 

--- a/tests/chebfun2v/test_constructor.m
+++ b/tests/chebfun2v/test_constructor.m
@@ -6,7 +6,7 @@ if ( nargin < 1 )
     pref = chebfunpref; 
 end 
 
-tol = 100*pref.cheb2Prefs.eps; 
+tol = 100*pref.eps; 
 
 D = [-1 1 -1 1; -2 3 0 1];
 

--- a/tests/chebfun2v/test_cross.m
+++ b/tests/chebfun2v/test_cross.m
@@ -5,7 +5,7 @@ if ( nargin == 0 )
     pref = chebfunpref; 
 end
 
-tol = 10*pref.cheb2Prefs.eps; 
+tol = 10*pref.eps; 
 
 % Check definition: 
 F = chebfun2v(@(x,y) cos(x), @(x,y) sin(y)); 

--- a/tests/chebfun2v/test_curl.m
+++ b/tests/chebfun2v/test_curl.m
@@ -4,8 +4,7 @@ if ( nargin == 0 )
     pref = chebfunpref; 
 end
 
-tol = 50*pref.cheb2Prefs.eps; 
-
+tol = 50*pref.eps; 
 
 % Check definition: 
 F = chebfun2v(@(x,y) cos(x), @(x,y) sin(y));  

--- a/tests/chebfun2v/test_divergence.m
+++ b/tests/chebfun2v/test_divergence.m
@@ -5,7 +5,7 @@ if ( nargin == 0 )
     pref = chebfunpref; 
 end
 
-tol = 100*pref.cheb2Prefs.eps; 
+tol = 100*pref.eps; 
 
 % Check definition: 
 F = chebfun2v(@(x,y) cos(x), @(x,y) sin(y)); 

--- a/tests/chebfun2v/test_divgrad.m
+++ b/tests/chebfun2v/test_divgrad.m
@@ -4,7 +4,7 @@ if ( nargin == 0 )
     pref = chebfunpref; 
 end
 
-tol = 50*pref.cheb2Prefs.eps; 
+tol = 50*pref.eps; 
 
 % Check definition: 
 F = chebfun2v(@(x,y) cos(x), @(x,y) sin(y)); 

--- a/tests/chebfun2v/test_dot.m
+++ b/tests/chebfun2v/test_dot.m
@@ -4,7 +4,7 @@ if ( nargin == 0 )
     pref = chebfunpref; 
 end
 
-tol = 50*pref.cheb2Prefs.eps; 
+tol = 50*pref.eps; 
 
 % Check definition: 
 F = chebfun2v(@(x,y) cos(x), @(x,y) sin(y)); 

--- a/tests/chebfun2v/test_imag.m
+++ b/tests/chebfun2v/test_imag.m
@@ -5,7 +5,7 @@ if ( nargin == 0 )
     pref = chebfunpref; 
 end
 
-tol = 10*pref.cheb2Prefs.eps; 
+tol = 10*pref.eps; 
 
 f = chebfun2v(@(x,y) cos(x.*y),@(x,y) cos(x.*y)); 
 g = imag( f ); 

--- a/tests/chebfun2v/test_jacobian.m
+++ b/tests/chebfun2v/test_jacobian.m
@@ -4,7 +4,7 @@ function pass = test_jacobian( pref )
 if ( nargin == 0 ) 
     pref = chebfunpref; 
 end
-tol = 100*pref.cheb2Prefs.eps; 
+tol = 100*pref.eps; 
 
 
 % Check defintion: 

--- a/tests/chebfun2v/test_laplacian.m
+++ b/tests/chebfun2v/test_laplacian.m
@@ -5,7 +5,7 @@ if ( nargin == 0 )
     pref = chebfunpref; 
 end
 
-tol = 50*pref.cheb2Prefs.eps; 
+tol = 50*pref.eps; 
 
 % Check definition: 
 F = chebfun2v(@(x,y) cos(x), @(x,y) sin(y)); 

--- a/tests/chebfun2v/test_real.m
+++ b/tests/chebfun2v/test_real.m
@@ -5,7 +5,7 @@ if ( nargin == 0 )
     pref = chebfunpref; 
 end
 
-tol = 100*pref.cheb2Prefs.eps; 
+tol = 100*pref.eps; 
 
 f = chebfun2v(@(x,y) cos(x.*y),@(x,y) cos(x.*y)); 
 g = real( f ); 

--- a/tests/chebfun2v/test_roots01.m
+++ b/tests/chebfun2v/test_roots01.m
@@ -5,7 +5,7 @@ function pass = test_roots01( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e3 * pref.cheb2Prefs.eps; 
+tol = 1e3 * pref.eps; 
 j = 1;
 
 %% 

--- a/tests/chebfun2v/test_roots02.m
+++ b/tests/chebfun2v/test_roots02.m
@@ -5,7 +5,7 @@ function pass = test_roots02( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e3 * pref.cheb2Prefs.eps; 
+tol = 1e3 * pref.eps; 
 j = 1;
 
 %%

--- a/tests/chebfun2v/test_roots03.m
+++ b/tests/chebfun2v/test_roots03.m
@@ -5,7 +5,7 @@ function pass = test_roots03( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e3 * pref.cheb2Prefs.eps; 
+tol = 1e3 * pref.eps; 
 j = 1;
 
 %% (Marching squares fails)

--- a/tests/chebfun2v/test_roots04.m
+++ b/tests/chebfun2v/test_roots04.m
@@ -5,7 +5,7 @@ function pass = test_roots04( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e3 * pref.cheb2Prefs.eps; 
+tol = 1e3 * pref.eps; 
 j = 1;
 
 %%

--- a/tests/chebfun2v/test_roots05.m
+++ b/tests/chebfun2v/test_roots05.m
@@ -5,7 +5,7 @@ function pass = test_roots05( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e3 * pref.cheb2Prefs.eps; 
+tol = 1e3 * pref.eps; 
 j = 1;
 
 %%

--- a/tests/chebfun2v/test_roots06.m
+++ b/tests/chebfun2v/test_roots06.m
@@ -5,7 +5,7 @@ function pass = test_roots06( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e3 * pref.cheb2Prefs.eps; 
+tol = 1e3 * pref.eps; 
 j = 1;
 
 %% Marching squares double counts some solutions. 

--- a/tests/chebfun2v/test_roots07.m
+++ b/tests/chebfun2v/test_roots07.m
@@ -4,7 +4,7 @@ function pass = test_roots07( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e3 * pref.cheb2Prefs.eps; 
+tol = 1e3 * pref.eps; 
 j = 1;
 
 %%

--- a/tests/chebfun2v/test_roots08.m
+++ b/tests/chebfun2v/test_roots08.m
@@ -4,7 +4,7 @@ function pass = test_roots08( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e3 * pref.cheb2Prefs.eps; 
+tol = 1e3 * pref.eps; 
 j = 1;
 
 %%

--- a/tests/chebfun2v/test_roots09.m
+++ b/tests/chebfun2v/test_roots09.m
@@ -4,7 +4,7 @@ function pass = test_roots09( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e3 * pref.cheb2Prefs.eps; 
+tol = 1e3 * pref.eps; 
 j = 1;
 
 %%

--- a/tests/chebfun2v/test_roots10.m
+++ b/tests/chebfun2v/test_roots10.m
@@ -4,7 +4,7 @@ function pass = test_roots10( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e3 * pref.cheb2Prefs.eps; 
+tol = 1e3 * pref.eps; 
 j = 1;
 
 %% (Marching Squares misses some solution along edge)

--- a/tests/chebfun2v/test_roots_slow.m
+++ b/tests/chebfun2v/test_roots_slow.m
@@ -5,7 +5,7 @@ function pass = test_roots2c( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e3 * pref.cheb2Prefs.eps; 
+tol = 1e3 * pref.eps; 
 j = 1;
 
 %% (slow one)

--- a/tests/chebfun2v/test_syntax.m
+++ b/tests/chebfun2v/test_syntax.m
@@ -5,7 +5,7 @@ function pass = test_syntax( pref )
 if ( nargin < 1 )
     pref = chebfunpref;
 end
-tol = 1e5 * pref.cheb2Prefs.eps; 
+tol = 1e5 * pref.eps; 
 
 D = [-1 1 -1 1; -1 1 1 2];
 

--- a/tests/chebfun2v/test_threecomponents.m
+++ b/tests/chebfun2v/test_threecomponents.m
@@ -6,7 +6,7 @@ function pass = test_threecomponents( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e5 * pref.cheb2Prefs.eps; 
+tol = 1e5 * pref.eps; 
 j = 1;
 
 % Different calls to the constructor. 

--- a/tests/chebfun2v/test_times.m
+++ b/tests/chebfun2v/test_times.m
@@ -5,7 +5,7 @@ function pass = test_times( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e3 * pref.cheb2Prefs.eps; 
+tol = 1e3 * pref.eps; 
 j = 1;
 
 f = chebfun2(@(x,y) cos(x.*y)); 

--- a/tests/chebfun2v/test_twocomponents.m
+++ b/tests/chebfun2v/test_twocomponents.m
@@ -6,7 +6,7 @@ function pass = test_twocomponents( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e5 * pref.cheb2Prefs.eps; 
+tol = 1e5 * pref.eps; 
 j = 1;
 
 % Different calls to the constructor. 

--- a/tests/chebfun2v/test_vertcat.m
+++ b/tests/chebfun2v/test_vertcat.m
@@ -6,7 +6,7 @@ function pass = test_vertcat( pref )
 if ( nargin < 1 ) 
     pref = chebfunpref; 
 end 
-tol = 1e3 * pref.cheb2Prefs.eps; 
+tol = 1e3 * pref.eps; 
 j = 1;
 
 f = chebfun2(@(x,y) cos(x.*y)); 

--- a/tests/chebop/test_chap21.m
+++ b/tests/chebop/test_chap21.m
@@ -2,6 +2,8 @@ function pass = test_chap21(pref)
 
 % Here we test that everything in chapter 21 of ATAP runs OK.
 
+warnState = warning('off', 'CHEBFUN:CHEBOP:feval:deprecated');
+
 x = chebfun('x'); p = sin(x); length(p);
 pp = diff(p); x14 = chebpts(14); pp14 = pp(x14);
 D = chebop(@(u) diff(u)); D14 = D(14);
@@ -52,5 +54,7 @@ N.lbc = -pi/2; N.rbc = 5*pi/2; theta = N\0;
 % plot(-cos(theta)), grid on, ylim([-1 1])
 % title('Nonlinear pendulum (21.5), another solution',FS,9)
 % xlabel('t',FS,10), ylabel('height -cos(\theta)')
+
+warning(warnState);
 
 end

--- a/tests/misc/test_quantumstates.m
+++ b/tests/misc/test_quantumstates.m
@@ -11,8 +11,6 @@ V = x.^2;       % Potential, harmonic oscillator
 [efuns, evals] = quantumstates(V, 'noplot');
 
 % Extract eigenvalues
-% Extract eigenvalues
-D = diag(evals);
 D = diag(evals);
 
 % Expect the eigenvalues to go up in steps of .2
@@ -26,6 +24,8 @@ n = 6;
 
 % Solve
 [efuns, evals] = quantumstates(V, n, h, 'noplot');
+
+efuns = horzcat(efuns{1:n});
 
 % The Schroedinger operator
 op = @(u) -h^2*diff(u,2) + repmat(V, 1, n).*u;


### PR DESCRIPTION
(which should be extracted from the tech level anyway.)

Also removing the 'scale' pref from `chebfunpref()` , which should now be passed as data.

Most of the changes in this commit as simply changing the tolerances for `chebfun2` tests, which were using `pref.cheb2.eps`.
