### PR TITLE
Fix chebfun vscale

### DIFF
--- a/@chebfun/chebfun.m
+++ b/@chebfun/chebfun.m
@@ -399,7 +399,7 @@ classdef chebfun
         f = uplus(f)
         
         % Vertical scale of a CHEBFUN object.
-        out = vscale(f);
+        out = vscale(f, s);
     end
     
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/@chebfun/disp.m
+++ b/@chebfun/disp.m
@@ -121,16 +121,16 @@ end
 
 % Display epslevel:
 s = [s, sprintf('Epslevel = %i.', epslevel(f))];
-s = [s, sprintf('  Vscale = %i.', vscale(f))];
+s = [s, sprintf('  Vscale = %i.', vscale(f, 'sup'))];
 
 % Display total length for piecewise chebfuns:
 if ( numFuns > 1 )
     s = [s, sprintf('  Total length = %i.', sum(len))];
 end
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Dispaly for delta functions:
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 out = get(f, 'deltas');
 if ( ~isempty(out) )
     deltaLoc = out(1, :);
@@ -147,6 +147,6 @@ if ( ~isempty(out) )
     s = [s, sprintf( 'Locations:\n')];
     s = [s, sprintf('%8.2g', deltaLoc)];
 end
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 end

--- a/@chebfun/vscale.m
+++ b/@chebfun/vscale.m
@@ -1,9 +1,15 @@
-function out = vscale(F)
+function out = vscale(F, supString)
 %VSCALE   Vertical scale of a CHEBFUN object.
 %   VSCALE(F) returns an estimate of the maximum absolute value of F. VSCALE
 %   always returns a scalar, even when F is an array-valued CHEBFUN or a
 %   quasimatrix. Vertical scales of each of the piecewise components and columns
-%   of F are given by get(F, 'vscale-local');
+%   of F are given by get(F, 'vscale-local'); Values of F at its break points
+%   are ignored by VSCALE(F).
+% 
+%   VSCALE(F, 'ess-sup') is the same as VSCALE(F)
+% 
+%   VSCALE(F, 'sup') also takes into account the point values of the object 
+%   F at its break points while computing its VSCALE.
 %
 % See also MAX, MINANADMAX.
 
@@ -15,6 +21,21 @@ if ( isempty(F) )
     return
 end
 
+if ( nargin < 2 )
+    % By default, we ignore values at the break points while computing the
+    % vsclase:
+    ignoreBreaks = 1;    
+else
+    switch supString
+        case 'ess-sup'          % This is the same as default.
+            ignoreBreaks = 1;
+        case 'sup'
+            ignoreBreaks = 0;   % Don't ignore break point values.
+        otherwise
+            error( 'CHEBFUN:CHEBUN:vscale:unknownFlag', 'unknown flag passed.' )
+    end
+end
+            
 out = 0;
 for k = 1:numel(F)
     % Get the local vscales:
@@ -22,6 +43,9 @@ for k = 1:numel(F)
 
     % Compute the maximum:
     out = max(out, max(v(:)));
+    if ( ~ignoreBreaks )
+        out = max(out, max(F(k).pointValues(:)));
+    end
 end
 
 end


### PR DESCRIPTION
This "fixes" #895.

The displayed vscale of a chebfun takes into account the point values of f, and this is equivalent to 

```
vscale(f, 'sup')
```

Internally, we use vscale for tolerances and there we ignore values of f at break points while computing its vscale. This is and was the default behaviour when we typed

```
vscale(f)
```

which is the same as

```
vscale(f, 'ess-sup')
```

In particular, the example given in #895  now works:

```
>> f = chebfun(0);
f.pointValues(1) = 1
f =
   chebfun column (1 smooth piece)
       interval       length   endpoint values  
[      -1,       1]        1         0        0 
Epslevel = 2.220446e-16.  Vscale = 1.
>> max(f)
ans =
     1
```
