### PR TITLE
Use splitting in ODESOL. Fix DOCs.

### DIFF
--- a/@chebfun/ode15s.m
+++ b/@chebfun/ode15s.m
@@ -2,7 +2,7 @@ function varargout = ode15s(varargin)
 %ODE15S   Solve stiff differential equations and DAEs. Output a CHEBFUN.
 %   Y = CHEBFUN.ODE15S(ODEFUN, D, ...) applies the standard ODE15S method to
 %   solve an initial-value problem on the domain D. The result is then converted
-%   to a piecewise-defined CHEBFUN with one column per solution component.
+%   to a piecewise-defined CHEBFUN.
 %
 %   CHEBFUN.ODE15S has the same calling sequence as Matlab's standard ODE15S. 
 %
@@ -10,12 +10,10 @@ function varargout = ode15s(varargin)
 %   on the domain D.
 %
 % Example:
-%   y = chebfun.ode15s(@vdp1000, [0, 3000], [2 ; 0]); % Solve Van der Pol problem
-%   roots(y(:,1) - 1);                                % Find when y = 1
+%   y = chebfun.ode15s(@vdp1000, [0, 3000], [2; 0]); % Solve Van der Pol problem
+%   roots(y(:,1) - 1);                               % Find when y = 1
 %
 % See also ODESET, ODE113, ODE45,
-
-% [TODO]: This example performs poorly.
 
 % Copyright 2014 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.

--- a/@chebfun/odesol.m
+++ b/@chebfun/odesol.m
@@ -5,7 +5,7 @@ function varargout = odesol(sol, opt)
 %   representation Y. SOL is the one-output form of any solver such as ODE45,
 %   ODE15S, BVP5C, etc. OPT is the option structure used by the ODE solver. If
 %   OPT is not passed, it is extracted from SOL.EXTDATA.OPTIONS if available.
-%   The result is a piecewise CHEBFUN of low polynomial degree on each piece.
+%   The result is a piecewise CHEBFUN representing the solution.
 %
 %   [Y, T] = ODESOL(SOL, OPT) returns also the linear CHEBFUN T on the domain of
 %   Y. Note that the order of outputs is the reverse of that from calls to
@@ -14,11 +14,8 @@ function varargout = odesol(sol, opt)
 % Copyright 2014 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.
 
-% [TODO]: Think about tolerances.
-
 %% Extract data from sol:
 d = sol.x([1, end]);
-hscale = diff(d);
 vscale = max(abs(sol.y), [], 2); % Vertical scale (needed for RelTol)
 numCols = size(sol.y, 1);
 
@@ -55,6 +52,7 @@ relTol = max(relTol(:), absTol(:)./vscale(:));
 %% Create a CHEBFUN object.
 p = chebfunpref();
 p.techPrefs.eps = max(relTol); % Use the same tolerance for each column.
+p.splitting = true;            % use splitting, always, or there is no hope.
 y = chebfun(@(x) deval(sol, x).', d, p);
 
 % Parse outputs:


### PR DESCRIPTION
The documentation is `odesol` and related methods was incorrect, even in V4. It claimed that a piecewise `chebfun` was returned with one component per piece.

In reality, both V4 and V5 try to construct a smooth global solution. 

However, there's no way we can how to resolve the VdP problem in the help documentation with a global interpolant. Therefore, we turn splitting on. The VdP example now works wonderfully. 
