### PR TITLE
Adding simplify step after dividing by a singfun

### DIFF
--- a/@singfun/rdivide.m
+++ b/@singfun/rdivide.m
@@ -84,6 +84,9 @@ if ( isa(f, 'singfun') && isa(g, 'singfun') )
     end
 end
 
+%% Simplify and replace the boundary roots:
+s = simplify(s);
+
 %% 
 % Check if after division s has become smooth:
 if ( issmooth(s) )

--- a/@singfun/simplifyExponents.m
+++ b/@singfun/simplifyExponents.m
@@ -2,7 +2,7 @@ function f = simplifyExponents(f)
 %SIMPLIFYEXPONENTS  Simplify the exponents of a SINGFUN.
 %   F = SIMPLIFYEXPONENTS(F) returns a SINGFUN which has both exponents less
 %   than 1 by absorbing the integer part of any boundary exponents larger than
-%   1 into its smoothPart.
+%   or equal to 1 into its smoothPart.
 %
 % See also EXTRACTBOUNDARYROOTS.
 

--- a/tests/singfun/test_rdivide.m
+++ b/tests/singfun/test_rdivide.m
@@ -83,6 +83,29 @@ tol = 1e2*max(get(h1, 'vscale')*get(h1, 'epslevel'), ...
     get(h2, 'vscale')*get(h2, 'epslevel'));
 pass(9) = norm(feval(h1, x) - feval(h2, x), inf) < tol;
 
+%%
+% Check exponents of reciprocals of singfuns.
+a = randi(20); b = randi(20);
+
+% flip the exponents from positive to negative
+gh = @(x) ((1+x).^a).*((1-x).^b);
+data.exponents = [ a b ];
+data.singType = {'pole', 'pole'};
+g = singfun(gh, data, pref);
+h = 1./g;
+pass(10) = all( h.exponents == [ -a -b ] );
+
+% simplify / smooth out exponents when greater than or equal to 1
+gh = @(x) ((1+x).^-a).*((1-x).^-b);
+data.exponents = [];
+data.singType = {'pole', 'pole'};
+g = singfun(gh, data, pref);
+h = 1./g;
+if isa(h,'singfun')
+    pass(11) = all( get(1./g,'exponents') < 1);
+else
+    pass(11) = true;
+end
 
 end
 


### PR DESCRIPTION
- singfun/rdivide now matches singfun/times, per discussion in #1006
- updated comment in simplifyExponent
- added test to ensure that rdivide deals with exponents as intended

As I started writing the test, I couldn't help but think about "auto"-simplification.  That is, if we want singfun objects (or objects of other classes) to, generally, stay tidy, do we want them to be able to exist outside of that state?  

Also, I noticed that when we simplify a singfun whose exponents are both greater than or equal to 1, we may (or always?) end up with an object that's not a singfun.  I don't how exactly this fits into the bigger picture but you can see the probably inelegant way that I handled this in line 104 to 108 of the test below.
