### PR TITLE
Loosen tolerance in orr-som test to get better accuracy. 

### DIFF
--- a/tests/chebop/test_eigs_orrsom.m
+++ b/tests/chebop/test_eigs_orrsom.m
@@ -11,6 +11,7 @@ pass = true;
 if ( nargin == 0 )
     pref = cheboppref();
 end
+pref.errTol = 1e-9;
 
 Re = 5772.22;               % Reynolds number
 alph = 1;                   % longitudinal Fourier parameter
@@ -23,10 +24,7 @@ A.rbc = @(u) [u ; diff(u)];
 
 discType = {@colloc2, @ultraS, @colloc1};
 
-%TODO: Why does colloc1 have so much larger error?
-%TODO: It's not for me on my Mac. NH 21/06/2014.
-%TODO: It is for me on my Linux Mint. AB, 07/07/2014.
-tol = [1e-3 ; 1e-6 ; 1e-3];
+tol = 1e-6;
 
 for disc = 1:3
     pref.discretization = discType{disc};
@@ -38,7 +36,7 @@ for disc = 1:3
 
     e_crit_v4 = -0.000078029804093 - 0.261565915010080i;
     err = abs(e_crit - e_crit_v4);
-    pass(disc) = err < tol(disc);
+    pass(disc) = err < tol;
     
     % If we had to remove some entries, then there were spurious eigenvalues..
     pass(disc+3) = (numel(e) == 20);


### PR DESCRIPTION
Probably what happens is that when we shoot for the moon the ill-conditioning starts to hurt us. In particular, aiming for 9 digits we get around 8 digits in the critical eigenvalue and the coefficients look nice happy to around 12 digits at length 90. Aiming for the default 10 digits we get 4 digits and there's a nasty bump in the coefficients at around this level.

_shrug_
