### PR TITLE
Fixing chebfun2v/roots when method is not supplied by chebfun2/roots.

### DIFF
--- a/@chebfun2v/roots.m
+++ b/@chebfun2v/roots.m
@@ -48,14 +48,28 @@ if ( (nargin > 1) && ~any(strcmpi(varargin{1}, validArgs)) )
         'Unrecognised optional argument.');
 end
 
-if ( (isempty(varargin) && dd <= max_degree) || ...
-        strcmpi(varargin{1}, 'resultant') )
+
+if ( isempty(varargin) )
+    % If rootfinding method has not been defined, then use resultant if
+    % degrees are small: 
+    if ( dd <= max_degree ) 
+        [xroots, yroots] = roots_resultant(F);
+    else
+        [xroots, yroots] = roots_marchingSquares(F);
+        xroots = xroots.'; 
+        yroots = yroots.';
+    end
+elseif ( strcmpi(varargin{1}, 'resultant') )
+    % If the user wants the resultant method, then use it: 
     [xroots, yroots] = roots_resultant(F);
-elseif ( isempty(varargin) || ...
-        any(strcmpi(varargin{1}, {'ms', 'marchingsquares'})) )
+elseif ( any( strcmpi(varargin{1}, {'ms', 'marchingsquares'} ) ) )
+    % If the user wants the marching squares method, then use it: 
     [xroots, yroots] = roots_marchingSquares(F);
     xroots = xroots.'; 
     yroots = yroots.';
+else
+    % Print error. Unknown method. 
+    error('CHEBFUN2V:ROOTS:METHOD', 'Unknown rootfinding method.') 
 end
 
 if ( nargout <= 1 )

--- a/@chebfun2v/subsref.m
+++ b/@chebfun2v/subsref.m
@@ -73,4 +73,3 @@ switch ( ref(1).type )
 end
 
 end
-

--- a/tests/chebfun2v/test_roots_syntax.m
+++ b/tests/chebfun2v/test_roots_syntax.m
@@ -1,0 +1,44 @@
+function pass = test_roots_syntax( pref )
+% Check chebfun2v rootfinding syntax. 
+
+if ( nargin < 1 ) 
+    pref = chebfunpref; 
+end 
+tol = 1e3 * pref.eps; 
+j = 1;
+
+% This is James Whidborne's problem that caused a silly error with the
+% rootfinding syntax in Chebfun: 
+% set up to solve a common roots problem
+pdomain = [0.01 25]; % p domain eq31
+phidomain = [0 2*pi]; % phi domain
+
+V1= [phidomain  pdomain];
+
+phi=chebfun2(@(phi,p) phi, V1);
+p=chebfun2(@(phi,p) p, V1);
+
+q=1.4; %
+
+A=(q*cos(q*pi).*cos(phi)+(2*q^2-1)*sin(q*pi).*sin(phi))/(q^2-1)...
+        + pi*sin(q*pi)./p + cos(q*pi)./(q*p); %eq32
+B=(-q*sin(q*pi).*cos(phi)+(2*q^2-1)*cos(q*pi).*sin(phi))/(q^2-1)...
+        + pi*cos(q*pi)./p -sin(q*pi)./(q*p); %eq33
+eq43=1-q.*A.*p*cos(2*pi*q) +q.*B.*p*sin(2*pi*q) - q^2.*p.*cos(phi)/(q^2-1);
+eq44=q^2.*A*sin(2*pi*q) + q^2.*B*cos(2*pi*q) + q^2.*sin(phi)/(q^2-1);
+
+% now get common roots
+r1 = roots(eq43, eq44, 'ms'); % marching squares
+r2 = roots(eq43, eq44); % figure out the method
+r3 = roots(eq43,eq44, 'resultant'); % resulant
+r4 = roots([eq43 ; eq44], 'ms'); % marching squares
+r5 = roots([eq43 ; eq44]); % figure out the method
+r6 = roots([eq43 ;eq44], 'resultant'); % resulant
+
+pass(1) = norm( r1 - r2 ) < tol; 
+pass(2) = norm( r1 - r3 ) < tol; 
+pass(3) = norm( r1 - r4 ) < tol; 
+pass(4) = norm( r1 - r5 ) < tol; 
+pass(5) = norm( r1 - r6 ) < tol; 
+
+end


### PR DESCRIPTION
Closes #1086.
