### PR TITLE
Fix chebtech qr

### DIFF
--- a/@chebtech/qr.m
+++ b/@chebtech/qr.m
@@ -112,7 +112,7 @@ end
 
 % Project the values onto a Legendre grid: (where integrals of polynomials
 % p_n*q_n will be computed exactly and on an n-point grid)
-if ( length(WP) ~= n || type ~= class(f))
+if ( length(WP) ~= n || (~isempty(type) && isa(f, type)) )
     xc = f.chebpts(n);
     vc = f.barywts(n);
     [xl, wl, vl] = legpts(n);


### PR DESCRIPTION
For speed we persistently store two matrices in CHEBTECH/QR; WP and its inverse. The documentation claims these matrices depend only on the length of the dat, not the dat itself. This is sort of true, but they also depend on the type of CHEBTECH being used. Hence, using a CHEBTECH1 and then a CHEBTECH2 will produce incorrect results.

This commit should fix this. It's not elegant, but the alternatives involve splitting the built-in QR back out the both CHEBTECH1 and CHEBTECH2 (which is a lot of duplication) or take a hit in performance. The docs claim CHEBFUN2 relies heavily on QR for speed, so I'm hesitant to do that either. Instead I propose we live with this tiny bit of ugliness.
