### PR TITLE
Dividing a chebfun by scalar 0 was handled inconsistently

### DIFF
--- a/@chebfun/mrdivide.m
+++ b/@chebfun/mrdivide.m
@@ -11,6 +11,11 @@ function X = mrdivide(B, A)
 % TODO: Give an example for each of the cases below.
 
 if ( isscalar(A) )
+    if ( A == 0 )
+        % TODO:  Return identically Inf/NaN CHEBFUN instead?
+        error('CHEBFUN:CHEBFUN:mrdivide:divisionByZero', ...
+            'Division by zero.')
+    end
     X = B*(1/A);
     
 elseif ( size(A, 2) ~= size(B, 2) )

--- a/@chebfun/rdivide.m
+++ b/@chebfun/rdivide.m
@@ -122,7 +122,8 @@ function h = columnRdivide(f, g, pref)
 
 % If g is numeric then call TIMES():
 if ( isnumeric(g) )
-    if ( g == 0 )
+    if ( any(g == 0) )
+        % note g could be a vector, with some zero components
         % TODO:  Return identically Inf/NaN CHEBFUN instead?
         error('CHEBFUN:CHEBFUN:rdivide:columnRdivide:divisionByZero', ...
             'Division by zero.')

--- a/tests/chebfun/test_mrdivide.m
+++ b/tests/chebfun/test_mrdivide.m
@@ -92,6 +92,19 @@ XExact = opExact(x);
 err = XVals - XExact;
 pass(9) = norm(err, inf) < 2*max(get(X,'epslevel').*get(X,'vscale'));
 
+%% #1111
+
+try
+    f = chebfun(@(x) exp(x));
+    g = 0;
+    f/g;
+    pass(10) = false;
+catch ME
+    pass(10) = strcmp(ME.identifier, ...
+        'CHEBFUN:CHEBFUN:mrdivide:divisionByZero');
+end
+
+
 %% [TODO]: Revive the following test:
 
 % Case 2: X*B = A, where B is a numerical matrix and A is an array-valued 

--- a/tests/chebfun/test_rdivide.m
+++ b/tests/chebfun/test_rdivide.m
@@ -164,4 +164,36 @@ hExact = oph(x);
 err = hVals - hExact;
 pass(17) = norm(err, inf) < 1e1*get(f,'epslevel')*get(f,'vscale');
 
+%% #1111:
+
+try
+    f = chebfun(@(x) exp(x));
+    g = 0;
+    f./g;
+    pass(18) = false;
+catch ME
+    pass(18) = strcmp(ME.identifier, ...
+        'CHEBFUN:CHEBFUN:rdivide:columnRdivide:divisionByZero');
+end
+
+try
+    f = chebfun(@(x) [exp(x) exp(-x)]);
+    g = [0 0];
+    f./g;
+    pass(19) = false;
+catch ME
+    pass(19) = strcmp(ME.identifier, ...
+        'CHEBFUN:CHEBFUN:rdivide:columnRdivide:divisionByZero');
+end
+
+try
+    f = chebfun(@(x) [exp(x) exp(-x) sin(x)]);
+    g = [1 0 1];
+    f./g;
+    pass(20) = false;
+catch ME
+    pass(20) = strcmp(ME.identifier, ...
+        'CHEBFUN:CHEBFUN:rdivide:columnRdivide:divisionByZero');
+end
+
 end


### PR DESCRIPTION
* These should now all throw an error: `f / 0`, `f ./ 0`, `f ./ [0 0]` and
`f ./ [0 1 0]`.
* Part of this is fixing a bug of the form "if (vector == scalar)".