### PR TITLE
adding error in remez for complex chebfuns.

### DIFF
--- a/@chebfun/remez.m
+++ b/@chebfun/remez.m
@@ -52,17 +52,17 @@ dom = f.domain([1, end]);
 normf = norm(f);
 
 if ( ~isreal(f) )
-    error ('CHEBFUN:remez:real', ...
+    error('CHEBFUN:CHEBFUN:remez:real', ...
         'REMEZ only supports real valued functions.');
 end
 
 if ( numColumns(f) > 1 )
-    error ('CHEBFUN:remez:quasi', ...
+    error('CHEBFUN:CHEBFUN:remez:quasi', ...
         'REMEZ does not currently support quasimatrices.');
 end
 
 if ( issing(f) )
-    error('CHEBFUN:remez:singularFunction', ...
+    error('CHEBFUN:CHEBFUN:remez:singularFunction', ...
         'REMEZ does not currently support functions with singularities.');
 end
 


### PR DESCRIPTION
Chebfun's remez only works for real valued functions however, it was silently computing garbage results for complex valued functions. An error message has been added.
