### PR TITLE
Warn if no write permissions when executing Chebgui export tests.

### DIFF
--- a/tests/chebgui/test_toFileBVP.m
+++ b/tests/chebgui/test_toFileBVP.m
@@ -4,6 +4,15 @@ function pass = test_toFileBVP(pref)
 % This test only checks whether nothing breaks, it does not try to solve the
 % problems.
 
+% This test won't work if we can't write to the current directory.
+[ignored, attr] = fileattrib(pwd);
+if ( ~attr.UserWrite )
+    warning('CHEBFUN:tests:chebgui:test_toFileBVP:perms', ...
+        'Cannot write to chebfunroot/tests/chebgui/.  Bypassing test.');
+    pass = true;
+    return;
+end
+
 % Find the folders which demos are stored in. The chebguiDemos folder lives in
 % the trunk folder, find the path of the Chebfun trunk.
 trunkPath = chebfunroot();

--- a/tests/chebgui/test_toFileEIG.m
+++ b/tests/chebgui/test_toFileEIG.m
@@ -4,6 +4,15 @@ function pass = test_toFileEIG(pref)
 % This test only checks whether nothing breaks, it does not try to solve the
 % problems.
 
+% This test won't work if we can't write to the current directory.
+[ignored, attr] = fileattrib(pwd);
+if ( ~attr.UserWrite )
+    warning('CHEBFUN:tests:chebgui:test_toFileEIG:perms', ...
+        'Cannot write to chebfunroot/tests/chebgui/.  Bypassing test.');
+    pass = true;
+    return;
+end
+
 % Find the folders which demos are stored in. The chebguiDemos folder lives in
 % the trunk folder, find the path of the Chebfun trunk.
 trunkPath = chebfunroot();

--- a/tests/chebgui/test_toFilePDE.m
+++ b/tests/chebgui/test_toFilePDE.m
@@ -4,6 +4,15 @@ function pass = test_toFilePDE(pref)
 % This test only checks whether nothing breaks, it does not try to solve the
 % problems.
 
+% This test won't work if we can't write to the current directory.
+[ignored, attr] = fileattrib(pwd);
+if ( ~attr.UserWrite )
+    warning('CHEBFUN:tests:chebgui:test_toFilePDE:perms', ...
+        'Cannot write to chebfunroot/tests/chebgui/.  Bypassing test.');
+    pass = true;
+    return;
+end
+
 % Find the folders which demos are stored in. The chebguiDemos folder lives in
 % the trunk folder, find the path of the Chebfun trunk.
 trunkPath = chebfunroot();


### PR DESCRIPTION
David Watkins sent us an e-mail indicating that these tests were failing on his machine, and while we don't have full confirmation, it looks like this is due to the fact that he has Chebfun installed in a directory to which his user account cannot write.  These tests now check if writing is allowed and pass automatically with a warning if it isn't.

Thanks to @nickhale for suggesting an idea similar to this.
