### PR TITLE
Use eps instead of epslevel(f) when setting htol in chebfun.roots.

### DIFF
--- a/@chebfun/roots.m
+++ b/@chebfun/roots.m
@@ -81,7 +81,7 @@ function r = columnRoots(f, rootsPref)
 el = epslevel(f);
 hs = hscale(f);
 vs = vscale(f);
-htol = 10*el*hs;
+htol = 10*eps*hs;
 vtol = el*vs;
 dom = f.domain;
 

--- a/tests/chebfun/test_roots.m
+++ b/tests/chebfun/test_roots.m
@@ -161,4 +161,14 @@ f = chebfun('1i+cos(5*x).*exp(cos(x))',[-pi,pi],'periodic');
 r = roots(f);
 pass(16) = isempty(r);
 
+% Check that we don't miss roots for unresolved functions.  (See GitHub issue
+% #1146.)
+warnState = warning('off', 'CHEBFUN:CHEBFUN:constructor:funNotResolved');
+p = pref;
+p.splitting = true;
+p.splitPrefs.splitMaxLength = 300;
+f = chebfun(@(x) sin(exp(2*(tanh(sin(10*x))))), [0 10], p);
+pass(17) = length(roots(f)) == 32;
+warning(warnState);
+
 end


### PR DESCRIPTION
Using epslevel to construct this tolerance doesn't really make sense.  As Alex Townsend points out, the subdivision process perturbs roots by eps_hscale(f), not epslevel(f)_hscale(f).  Moreover, a function's epslevel tells us (sort of) how accurate it is relative to its _vertical_ scale and has essentially nothing
to do with its _horizontal_ scale.

This closes #1146, which showed that setting htol using epslevel(f) instead of eps can cause us to miss roots near breakpoints if the function is unresolved.
