### PR TITLE
Fix chebpts rescale

### DIFF
--- a/chebpts.m
+++ b/chebpts.m
@@ -77,7 +77,7 @@ if ( length(n) == 1 ) % Single grid.
         % Rescale the barycentric weights for 1st-kind points so that 
         % norm(v, inf) = 1:
         if ( type == 1 )
-            v = v/max(v);
+            v = v/norm(v, inf);
         end
     end
     if ( nargout > 3 )


### PR DESCRIPTION
This is to address #1202. Now the barycentric weights are rescaled.

```
>> [x, w, v] = chebpts(4, 1)
x =
   -0.9239
   -0.3827
    0.3827
    0.9239
w =
    0.2643    0.7357    0.7357    0.2643
v =
   -0.4142
    1.0000
   -1.0000
    0.4142
```

@nickhale What is the benefit of such a rescaling? If there isn't much we gain, shall we just leave the code as it is but change the help text?
