### PR TITLE
Fixing a bug in cumsum@singfun.

### DIFF
--- a/@singfun/cumsum.m
+++ b/@singfun/cumsum.m
@@ -152,11 +152,11 @@ function g = singIntegral(f)
     end
     
     % Drop the leading zeros in the coefficients:
-    ind = find(cc ~= 0, 1, 'first');
+    ind = find(cc ~= 0, 1, 'last');
     if ( isempty(ind) )
         cc = 0;
     else
-        cc = cc(ind:end);
+        cc = cc(1:ind);
     end
     
     % Construct u as a smoothfun object:


### PR DESCRIPTION
Fixing a bug introduced when the coefficients are flipped at all level. This bug was introduced at 9eb7f9005d27. The bug causes failure in @bndfun/test_cumsum when computing with 1st-kind points.

All tests pass now.
