### PR TITLE
Adding the Rössler attractor as a Chebgui demo

### DIFF
--- a/chebguiDemos/ivpdemos/rosslerAttractor.guifile
+++ b/chebguiDemos/ivpdemos/rosslerAttractor.guifile
@@ -1,0 +1,7 @@
+'Rossler attractor'
+'system'
+domain = '[0 100]';
+DE = {'u'' = -v - w','v'' = u + 0.2*v','w'' = 0.2 + w*(u - 5.7)'};
+BC = {'u(0) = -4','v(0) = 0','w(0) = 0'};
+init = ''; tol = '1e-10';
+type = 'ivp';


### PR DESCRIPTION
The Rössler attractor is an example of chaos even more simple than the Lorenz attractor. (Lorenz has two nonlinear terms; Rössler only one.) The IVP solver allows it to be solved on a large domain. Here is a 3D plot of the result on [0, 100]:

![rossler](https://cloud.githubusercontent.com/assets/913747/4687373/a77b1e48-5653-11e4-8eb2-ab2b55b527c3.png)

The total length of the solution is 2078.
