### PR TITLE
Remove "cosmetic" (?) thresholding line from chebfun.roots().

### DIFF
--- a/@chebfun/roots.m
+++ b/@chebfun/roots.m
@@ -130,9 +130,6 @@ for k = 1:numFuns
 
 end
 
-% Set any ridiculously small roots to zero:
-r(abs(r) < eps*vs*hs/10) = 0;
-
 % Remove unnecessary NaNs:
 r = sort(r, 1);             % Sort will place NaNs in the final rows.
 r(all(isnan(r), 2),:) = []; % This removes any rows which contain only NaNs.


### PR DESCRIPTION
This closes #1200.  With this line in place, we can get bizarre things like the following:

```
  >> f = 1e18*chebfun(@(x) x - 1.5e4, [1e4 2e4])
  f =
     chebfun column (1 smooth piece)
         interval       length   endpoint values
  [   1e+04,   2e+04]        2    -5e+21    5e+21
  Epslevel = 1.238223e-15.  Vscale = 5.000000e+21.
  >> roots(f)
  ans =
       0
```

Note that the point 0 isn't even in the domain of this chebfun!

An alternative to removing this line like we do here would be to eliminate the dependence of the threshold on vscale.
