### PR TITLE
Loosening the tolerance used for judging a spurious/duplicate root.

### DIFF
--- a/@chebfun/roots.m
+++ b/@chebfun/roots.m
@@ -81,7 +81,7 @@ function r = columnRoots(f, rootsPref)
 el = epslevel(f);
 hs = hscale(f);
 vs = vscale(f);
-htol = 10*eps*hs;
+htol = 100*eps*hs;
 vtol = el*vs;
 dom = f.domain;
 


### PR DESCRIPTION
This fix loosens the tolerance (htol) used in roots@chebfun for determining if a root is spurious/duplicate when it is close to another root. The current tolerance introduced by commit b704d284 is a bit of too tight, causing a few failures in tests for min, minandmax, etc when 1st-kind points are used. By loosening the current tolerance by a factor of 10, the failures or crashes related to this issue are all gone.

All tests passed with 2nd-kind points at the same time. 
