### PR TITLE
Fixing a bug for plotting an unbndfun

### DIFF
--- a/@bndfun/plotData.m
+++ b/@bndfun/plotData.m
@@ -26,7 +26,7 @@ if ( (nargin == 1) || isempty(g) )
     data.xJumps = [f.domain(1) ; NaN ; f.domain(2)];
     data.yJumps = getJumps(f, data.yLine);
     
-    % Sort out the xLim:
+    % Overwrite the current xLim if it is provided by plotData@singfun:
     data.xLim = f.domain;
     
 elseif ( nargin == 2 )

--- a/@chebfun/plot.m
+++ b/@chebfun/plot.m
@@ -363,12 +363,16 @@ end
 % We always want to set the x-limits. Otherwise, plots like
 %   plot(chebfun(@(x) sin(x), [0 pi])
 % will have extra white space around the ends of the domain, and look ugly.
-set(gca, 'xlim', xLim)
+
+if ( diff(xLim) )
+    set(gca, 'xLim', xLim)
+end
 
 % Set the Y-limits if appropriate values have been suggested, or if we were
 % holding on when we entered this method:
-if ( ~defaultYLim || (holdState && strcmp(yLimModeCurrent, 'manual')) )
-    set(gca, 'ylim', yLim)
+if ( ~defaultYLim || (holdState && strcmp(yLimModeCurrent, 'manual')) ) && ...
+        ( diff(yLim) )
+    set(gca, 'yLim', yLim)
 end
 
 %% Misc:

--- a/@chebtech/plotData.m
+++ b/@chebtech/plotData.m
@@ -55,6 +55,9 @@ if ( isempty(g) )
     
     % yLim:
     data.yLim = [min(data.yLine(:)) max(data.yLine(:))];
+    
+    % xLim:
+    data.xLim = [-1 1];
 
 elseif ( isa(g, 'chebtech') )   
     % PLOT(F, G)

--- a/@chebtech/plotData.m
+++ b/@chebtech/plotData.m
@@ -40,7 +40,7 @@ npts = min(max(501, round(4*pi*len)), chebtech.techPref().maxLength);
 
 % Initialise the output structure:
 data = struct('xLine', [], 'yLine', [], 'xPoints', [], 'yPoints', [], ...
-    'yLim', [], 'defaultXLim', 1, 'defaultYLim', 1);
+    'xLim', [], 'yLim', [], 'defaultXLim', 1, 'defaultYLim', 1);
 
 if ( isempty(g) )       
     % PLOT(F):

--- a/@singfun/plotData.m
+++ b/@singfun/plotData.m
@@ -24,6 +24,7 @@ if ( nargin == 1 )
     g = [];
     h = [];
     data = plotData(f.smoothPart);
+    singMask = ( f.exponents < 0 );
     
 elseif (nargin == 2)
     
@@ -31,6 +32,7 @@ elseif (nargin == 2)
     f = singfun(f);
     g = singfun(g);
     data = plotData(f.smoothPart, g.smoothPart);
+    singMask = ( g.exponents < 0 );
     
 elseif (nargin == 3)
     
@@ -38,6 +40,7 @@ elseif (nargin == 3)
     g = singfun(g);
     h = singfun(h);
     data = plotData(f.smoothPart, g.smoothPart, h.smoothPart);
+    singMask = ( h.exponents < 0 );
     
 end
 
@@ -76,18 +79,32 @@ end
 data.yLim = getYLimits(data.yLine, f.exponents);
 
 % If F is blowing up, do not use the yLim chosen by Matlab built-in plot:
-if ( any(f.exponents < 0) )
+if ( any(singMask) )
     data.defaultYLim = 0;
 end
 
-% Set the x-limits accordingly:
-idxl1 = find(data.yLine >= data.yLim(1), 1, 'first');
-idxl2 = find(data.yLine <= data.yLim(2), 1, 'first');
+% Set the x-limits accordingly: Note that these x-limits provide the information
+% for upper level to see where the major part of the plot is and they will be
+% tweaked by adding extra spaces in plotData@bndfun or plotData@unbndfun.
+if ( singMask(1) )
+    if ( data.yLine(2) > 0 )
+        idxl = find(data.yLine <= data.yLim(2), 1, 'first');
+    else
+        idxl = find(data.yLine >= data.yLim(1), 1, 'first');
+    end
+    idxl = floor((3/5)*idxl);
+    data.xLim(1) = data.xLine(idxl);
+end
 
-idxr1 = find(data.yLine >= data.yLim(1), 1, 'last');
-idxr2 = find(data.yLine <= data.yLim(2), 1, 'last');
-
-data.xLim = [data.xLine(max([idxl1 idxl2])) data.xLine(min([idxr1 idxr2]))];
+if ( singMask(2) )
+    if ( data.yLine(end-1) > 0 )
+        idxr = find(data.yLine <= data.yLim(2), 1, 'last');
+    else
+        idxr = find(data.yLine >= data.yLim(1), 1, 'last');
+    end
+    idxr = idxr + floor((3/5)*(length(data.yLine)-idxr));
+    data.xLim(2) = data.xLine(idxr);
+end
 
 end
 
@@ -110,7 +127,7 @@ end
 if ( exps(2) < 0 )
     scl = min(-.2*exps(2), .5);
     numChuck = max(ceil(scl*len), 5);
-    mask(end-numChuck:end) = false;
+    mask(end-numChuck+1:end) = false;
 end
 
 % Adjust the y-limits:

--- a/@singfun/plotData.m
+++ b/@singfun/plotData.m
@@ -80,6 +80,15 @@ if ( any(f.exponents < 0) )
     data.defaultYLim = 0;
 end
 
+% Set the x-limits accordingly:
+idxl1 = find(data.yLine >= data.yLim(1), 1, 'first');
+idxl2 = find(data.yLine <= data.yLim(2), 1, 'first');
+
+idxr1 = find(data.yLine >= data.yLim(1), 1, 'last');
+idxr2 = find(data.yLine <= data.yLim(2), 1, 'last');
+
+data.xLim = [data.xLine(max([idxl1 idxl2])) data.xLine(min([idxr1 idxr2]))];
+
 end
 
 function yLim = getYLimits(vals, exps)

--- a/@singfun/plotData.m
+++ b/@singfun/plotData.m
@@ -102,7 +102,7 @@ if ( singMask(2) )
     else
         idxr = find(data.yLine >= data.yLim(1), 1, 'last');
     end
-    idxr = idxr + floor((3/5)*(length(data.yLine)-idxr));
+    idxr = idxr + floor((2/5)*(length(data.yLine)-idxr)) + 1;
     data.xLim(2) = data.xLine(idxr);
 end
 

--- a/@unbndfun/plotData.m
+++ b/@unbndfun/plotData.m
@@ -18,36 +18,54 @@ if ( nargin == 1 || isempty(g) )
     % Map the 'x' data using f.mapping.For:
     data.xLine = f.mapping.For(data.xLine);
     data.xPoints = f.mapping.For(data.xPoints);
+    data.xLim = f.mapping.For(data.xLim);
     
     %% Figure out the xlim:
-    data.xLim = get(f, 'domain');
+    xLim = get(f, 'domain');
     
     % Size of the window:
-    window = 10;
+    window = 20;
     
     % [TODO]: We need to find a better way to determine the center and the
     % width of the window.
     
     % Center the window at the origin.
-    if ( all(isinf(data.xLim)) )
+    if ( all(isinf(xLim)) )
         center = 0;
         
         % If the left endpoint is -Inf:
-        if ( isinf(data.xLim(1)) )
-            data.xLim(1) = center - window;
+        if ( isinf(xLim(1)) )
+            xLim(1) = center - window;
         end
         
         % If the right endpoint is Inf:
-        if ( isinf(data.xLim(2)) )
-            data.xLim(2) = center + window;
+        if ( isinf(xLim(2)) )
+            xLim(2) = center + window;
         end
         
-    elseif ( isinf(data.xLim(1)) )
-        data.xLim(1) = data.xLim(2) - window;
+    elseif ( isinf(xLim(1)) )
+        xLim(1) = xLim(2) - window;
     else
-        data.xLim(2) = data.xLim(1) + window;
+        xLim(2) = xLim(1) + window;
     end
     
+    % Update the xLim:
+    if ( isfinite(data.xLim(1)) );
+        % If the left endpoint is finite:
+        data.xLim(1) = (data.xLim(1) + xLim(1))/2;
+    else
+        % If the left endpoint is -Inf:
+        data.xLim(1) = max([data.xLim(1) xLim(1)]);
+    end
+    
+    if ( isfinite(data.xLim(2)) );
+        % If the right endpoint is finite:
+        data.xLim(2) = (data.xLim(2) + xLim(2))/2;
+    else
+        % If the right endpoint is Inf:
+        data.xLim(2) = min([data.xLim(2) xLim(2)]);
+    end
+
     % Get a better yLim:
     mask = data.xLine > data.xLim(1) & data.xLine < data.xLim(2);
     data.yLim = [min(data.yLine(mask)) max(data.yLine(mask))];

--- a/@unbndfun/plotData.m
+++ b/@unbndfun/plotData.m
@@ -48,8 +48,14 @@ if ( nargin == 1 || isempty(g) )
     else
         xLim(2) = xLim(1) + window;
     end
-    
-    % Update the xLim:
+
+    % Get a better yLim:
+    mask = data.xLine > data.xLim(1) & data.xLine < data.xLim(2);
+    data.yLim = [min(data.yLine(mask)) max(data.yLine(mask))];
+   
+    % Update the xLim: If the onefun is bounded, xLim is not changed. If the 
+    % onefun is unbounded (i.e. singfun with poles), then xLim is tweaked to pad
+    % extra space at the end where function blows up:
     if ( isfinite(data.xLim(1)) );
         % If the left endpoint is finite:
         data.xLim(1) = (data.xLim(1) + xLim(1))/2;
@@ -65,10 +71,6 @@ if ( nargin == 1 || isempty(g) )
         % If the right endpoint is Inf:
         data.xLim(2) = min([data.xLim(2) xLim(2)]);
     end
-
-    % Get a better yLim:
-    mask = data.xLine > data.xLim(1) & data.xLine < data.xLim(2);
-    data.yLim = [min(data.yLine(mask)) max(data.yLine(mask))];
     
     % Sort out the jumps:
     data.xJumps = [f.domain(1) ; NaN ; f.domain(2)];

--- a/@unbndfun/plotData.m
+++ b/@unbndfun/plotData.m
@@ -20,33 +20,31 @@ if ( nargin == 1 || isempty(g) )
     data.xPoints = f.mapping.For(data.xPoints);
     data.xLim = f.mapping.For(data.xLim);
     
-    %% Figure out the xlim:
-    xLim = get(f, 'domain');
-    
-    % Size of the window:
-    window = 20;
+    %% Figure out the location of the window:
+    xLimWindow = get(f, 'domain');
+    windowSize = 10;
     
     % [TODO]: We need to find a better way to determine the center and the
     % width of the window.
     
     % Center the window at the origin.
-    if ( all(isinf(xLim)) )
+    if ( all(isinf(xLimWindow)) )
         center = 0;
         
         % If the left endpoint is -Inf:
-        if ( isinf(xLim(1)) )
-            xLim(1) = center - window;
+        if ( isinf(xLimWindow(1)) )
+            xLimWindow(1) = center - windowSize;
         end
         
         % If the right endpoint is Inf:
-        if ( isinf(xLim(2)) )
-            xLim(2) = center + window;
+        if ( isinf(xLimWindow(2)) )
+            xLimWindow(2) = center + windowSize;
         end
         
-    elseif ( isinf(xLim(1)) )
-        xLim(1) = xLim(2) - window;
+    elseif ( isinf(xLimWindow(1)) )
+        xLimWindow(1) = xLimWindow(2) - windowSize;
     else
-        xLim(2) = xLim(1) + window;
+        xLimWindow(2) = xLimWindow(1) + windowSize;
     end
 
     % Get a better yLim:
@@ -58,18 +56,18 @@ if ( nargin == 1 || isempty(g) )
     % extra space at the end where function blows up:
     if ( isfinite(data.xLim(1)) );
         % If the left endpoint is finite:
-        data.xLim(1) = (data.xLim(1) + xLim(1))/2;
+        data.xLim(1) = (data.xLim(1) + xLimWindow(1))/2;
     else
         % If the left endpoint is -Inf:
-        data.xLim(1) = max([data.xLim(1) xLim(1)]);
+        data.xLim(1) = max([data.xLim(1) xLimWindow(1)]);
     end
     
     if ( isfinite(data.xLim(2)) );
         % If the right endpoint is finite:
-        data.xLim(2) = (data.xLim(2) + xLim(2))/2;
+        data.xLim(2) = (data.xLim(2) + xLimWindow(2))/2;
     else
         % If the right endpoint is Inf:
-        data.xLim(2) = min([data.xLim(2) xLim(2)]);
+        data.xLim(2) = min([data.xLim(2) xLimWindow(2)]);
     end
     
     % Sort out the jumps:

--- a/tests/chebfun/test_plot.m
+++ b/tests/chebfun/test_plot.m
@@ -122,6 +122,9 @@ pass(46) = doesNotCrash(@() plot(fsr1, 'linew', 15));
 pass(47) = doesNotCrash(@() plot(fsr1, 'lines', '--'));
 pass(48) = doesNotCrash(@() plot(fsr1, 'markers', 10));
 
+% Test plot of a complex constant:
+pass(49) = doesNotCrash(@() plot(chebfun(1i)));
+
 close(hfig);
 
 end

--- a/tests/chebfun/test_plot_xylim.m
+++ b/tests/chebfun/test_plot_xylim.m
@@ -114,9 +114,17 @@ hold on
 plot(f2)
 % Check that we obtain reasonable ylimits
 ylNew = get(gca, 'ylim');
-pass3(length(pass3) + 1)  = ( (norm(ylOld(1) - ylNew(1)) < tol) && ...
+pass3(length(pass3) + 1) = ( (norm(ylOld(1) - ylNew(1)) < tol) && ...
     (ylNew(2) > 10) );
 hold off
+
+% Check x-lim and y-lim symmetry of x:
+f = chebfun(@(x) x, [-inf inf]);
+plot(f)
+xl = get(gca, 'xlim');
+yl = get(gca, 'ylim');
+pass3(length(pass3) + 1) = (abs(sum(xl)) < 1e-10) && (abs(sum(yl)) < 1e-10);
+
 %%
 pass = [pass1, pass2, pass3];
 


### PR DESCRIPTION
Fixing a bug for plotting an unbndfun defined on [a Inf] or [-Inf b] which has unbounded function value at the finite endpoint. This bug was reported by Hadrien.
```
g = chebfun(@(x) 1./x.^2, [0 Inf], 'exps', [-2 0]); plot(g)
```
Before:
![fig1](https://cloud.githubusercontent.com/assets/3542751/4877143/6c2ef0ca-62de-11e4-8988-a902e908f046.png)
After:
![fig2](https://cloud.githubusercontent.com/assets/3542751/4877144/738b1114-62de-11e4-963b-9de6b7bc0b42.png)
