### PR TITLE
Ensure we deal with the case where N.domain gets assigned as a column vector

### DIFF
--- a/@chebop/chebop.m
+++ b/@chebop/chebop.m
@@ -184,7 +184,15 @@ classdef (InferiorClasses = {?double}) chebop
             
             % Assign operator and domain:
             N.op = op;
-            N.domain = dom(:)';
+            
+            % Ensure that the domain is a row vector, not a column vector:
+            assert( (size(dom, 1) == 1) && ( size(dom, 2) > 1 ), ...
+                'CHEBOP:CHEBOP:domain', ...
+                ['The vector specifying the domain of a CHEBOP\n' ...
+                'should be a row vector of length greater than 1.'])
+            
+            % Assign the domain:
+            N.domain = dom;
             
             % Assign BCs and INIT if they were passed:
             if ( nargin == 3 )
@@ -308,6 +316,13 @@ classdef (InferiorClasses = {?double}) chebop
             %   CHEBOP.SET.DOMAIN ensures that N.DOMAIN is a row vector as
             %   required by the CHEBOP and CHEBFUN classes.
             
+            % Ensure that the domain is a row vector, not a column vector:
+            assert( (size(val, 1) == 1) && ( size(val, 2) > 1 ), ...
+                'CHEBOP:SET:domain', ...
+                ['The vector specifying the domain of a CHEBOP\n' ...
+                'should be a row vector of length greater than 1.'])
+            
+            % Assign the domain:
             N.domain = val(:)';            
         end
         

--- a/tests/chebop/test_domain.m
+++ b/tests/chebop/test_domain.m
@@ -1,36 +1,36 @@
-function pass = test_domain(pref)
+function pass = test_domain(~)
 %TEST_DOMAIN    Ensure that we can both pass row and column vectors to CHEBOP
 
 %% Setup
-if ( nargin == 0)
-    pref = cheboppref();
-end
-
 dom = [0,2];
 
-%% Row vector passed to constructor
+%% Column vector passed to constructor -- should give an error
+try
+    chebop(@(u) diff(u, 2) + u, dom');
+catch ME
+   pass(1) = strcmp(ME.identifier, 'CHEBOP:CHEBOP:domain');
+end
+
+%% Column vector set after construction -- should give an error
+N = chebop(@(u) diff(u, 2) + u);
+try
+    N.domain = dom';
+catch ME
+   pass(2) = strcmp(ME.identifier, 'CHEBOP:SET:domain');
+end
+
+%% Row vector passed to constructor -- should be OK
 N = chebop(@(u) diff(u, 2) + u, dom);
 N.bc = 0;
 u1 = N\1;
 
-%% Column vector passed to constructor
-N = chebop(@(u) diff(u, 2) + u, dom');
-N.bc = 0;
-u2 = N\1;
-
-%% Row vector set after construction
+%% Row vector set after construction -- should be OK
 N = chebop(@(u) diff(u, 2) + u);
 N.domain = dom;
 N.bc = 0;
-u3 = N\1;
+u2 = N\1;
 
-%% Column vector set after construction
-N = chebop(@(u) diff(u, 2) + u);
-N.domain = dom';
-N.bc = 0;
-u4 = N\1;
-
-%% Check that all solutions are the same
-pass = ( norm(u1 - u2) + norm(u3 - u4) + norm(u1 - u4) ) == 0;
+%% Check that both allowed approaches give the same solution
+pass(3) = norm(u1 - u2) == 0;
 
 end


### PR DESCRIPTION
Previously, we returned not a particularly useful error message:

```
>> N = chebop(@(u) diff(u, 2) + u, [0; 2]);
>> N.bc = 0;
>> u = N\1
Error using bndfun (line 84)
Domain argument should be a row vector with two entries in increasing
order.
Error in classicfun.constructor (line 100)
                obj = bndfun(op, data, pref);
Error in fun.constructor (line 51)
                obj = classicfun.constructor(op, data, pref);
Error in chebfun/constructor>getFun (line 286)
g = fun.constructor(op, data, pref);
Error in chebfun/constructor>constructorNoSplit (line 110)
    [funs{k}, ishappy, data.vscale] = getFun(opk, endsk, data, pref);
Error in chebfun/constructor (line 63)
    [funs, ends] = constructorNoSplit(op, dom, data, pref);
Error in chebfun (line 221)
                [f.funs, f.domain] = chebfun.constructor(op, dom, data,
                pref);
Error in chebop/solvebvp (line 80)
    zeroFun = chebfun(0, dom);
Error in \ (line 13)
[varargout{1:nargout}] = solvebvp(varargin{:}); 
```
