### PR TITLE
Fix dimension-related bugs in chebfun.mtimes().

### DIFF
--- a/@chebfun/mtimes.m
+++ b/@chebfun/mtimes.m
@@ -11,62 +11,14 @@ function f = mtimes(f, g)
 % Copyright 2014 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-if ( ~isa(f, 'chebfun') )   % ??? * CHEBFUN
+fIsChebfun = isa(f, 'chebfun');
+gIsChebfun = isa(g, 'chebfun');
 
-    % Ensure CHEBFUN is the first input:
-    if ( ~g(1).isTransposed )
-        f = mtimes(g, f);
-    else
-        f = mtimes(g.', f.').';
-    end
-
-elseif ( isempty(g) )       % CHEBFUN * []
+if ( isempty(f) || isempty(g) )             % [] * CHEBFUN or CHEBFUN * []
 
     f = [];
-    
-elseif ( isnumeric(g) )     % CHEBFUN * double
 
-    if ( isscalar(g) )
-        f = times(f, g);
-        return
-    end
-
-    if ( numel(f) == 1 )
-        % Array-valued CHEBFUN case:
-    
-        % Loop over the FUNs:
-        for k = 1:numel(f.funs)
-            f.funs{k} = mtimes(f.funs{k}, g);
-        end
-
-        % Multiply the pointValues:
-        f.pointValues = f.pointValues * g;
-
-    else
-        % QUASIMATRIX case:
-        numCols = numel(f);
-        if ( length(g) ~= numCols && min(size(g)) ~= 1 )
-            error('CHEBFUN:CHEBFUN:mtimes:dims', ...
-                'Matrix dimensions must agree.');
-        end
-        % Transpose g if f is a row CHEBFUN:
-        if ( f(1).isTransposed )
-            g = g.';
-        end
-        s = f(1)*g(1,:);
-        % Loop over the columns:
-        for k = 2:numCols
-            s = s + f(k).*g(k,:);
-        end
-        f = s;
-    end
-
-elseif ( ~isa(g, 'chebfun') )
-
-    error('CHEBFUN:CHEBFUN:mtimes:unknown', ...
-          ['Undefined function ''mtimes'' for input arguments of type ' ...
-           '%s and %s.'], class(f), class(g));
-else                        % CHEBFUN' * CHEBFUN
+elseif ( fIsChebfun && gIsChebfun )         % CHEBFUN * CHEBFUN
 
     % We can't do MTIMES() on two CHEBFUNs that have the same transpose state.
     if ( f(1).isTransposed == g(1).isTransposed )
@@ -81,24 +33,61 @@ else                        % CHEBFUN' * CHEBFUN
     end
 
     if ( f(1).isTransposed && ~g(1).isTransposed ) % Row times column.
-        
+        % Compute the inner product (we call CONJ() here because INNERPRODUCT()
+        % is semilinear in the first factor, and we want to undo that):
         f = innerProduct(conj(f), g);
-%         % Overlap:
-%         [f, g] = overlap(f, g);
-% 
-%         % Compute the inner product (we call CONJ() here because INNERPRODUCT()
-%         % is semilinear in the first factor, and we want to undo that):
-%         S = 0;
-%         for k = 1:numel(f.funs)
-%             S = S + innerProduct(conj(f.funs{k}), g.funs{k});
-%         end
-% 
-%         % Output in f:
-%         f = S;
-    else                                     % Column times row.
-        % Outer-product of two chebfuns is a chebfun2. 
+    else                                           % Column times row.
+        % Outer-product of two CHEBFUNs is a CHEBFUN2.
         f = chebfun2.outerProduct(f, g);
     end
+
+elseif ( fIsChebfun && isnumeric(g) )       % CHEBFUN * double
+
+    if ( isscalar(g) )
+        f = times(f, g);
+    else
+
+        % Check the dimensions.
+        if ( (size(g, 1) ~= size(f, 2)) || (ndims(g) > 2) )
+            error('CHEBFUN:CHEBFUN:mtimes:dims', ...
+                'Matrix dimensions must agree.');
+        end
+
+        if ( numel(f) == 1 )
+            % Array-valued CHEBFUN case:
+
+            % Loop over the FUNs:
+            for k = 1:numel(f.funs)
+                f.funs{k} = mtimes(f.funs{k}, g);
+            end
+
+            % Multiply the pointValues:
+            f.pointValues = f.pointValues * g;
+        else
+            % QUASIMATRIX case:
+            numCols = numel(f);
+            % Transpose g if f is a row CHEBFUN:
+            if ( f(1).isTransposed )
+                g = g.';
+            end
+            s = f(1)*g(1,:);
+            % Loop over the columns:
+            for k = 2:numCols
+                s = s + f(k).*g(k,:);
+            end
+            f = s;
+        end
+    end
+
+elseif ( isnumeric(f) && gIsChebfun )       % double * CHEBFUN
+
+        f = mtimes(g.', f.').';
+
+else                                        % ??? * CHEBFUN or CHEBFUN * ???
+
+    error('CHEBFUN:CHEBFUN:mtimes:unknown', ...
+          ['Undefined function ''mtimes'' for input arguments of type ' ...
+           '%s and %s.'], class(f), class(g));
 
 end
 

--- a/@chebfun2/lu.m
+++ b/@chebfun2/lu.m
@@ -48,7 +48,7 @@ k = length( f );
 % Make C unit lower triangular 
 Scl = diag( C( PivLoc(:, 2), : ) );
 C = C * spdiags( 1./Scl, 0, k, k );
-R = ( spdiags( Scl, 0, k, k ) * D ) * R; 
+R = R * ( spdiags( Scl, 0, k, k ) * D );
 
 L = C; 
 U = R; 

--- a/@chebfun2/outerProduct.m
+++ b/@chebfun2/outerProduct.m
@@ -31,8 +31,8 @@ if ( ~isa(f, 'chebfun') || ~isa(g, 'chebfun') )
 end
 
 % Extract out domains:
-fdom = f.domain; 
-gdom = g.domain; 
+fdom = domain(f);
+gdom = domain(g);
 dom = [gdom, fdom]; 
 
 h = chebfun2(0, dom); 

--- a/@chebfun2/volt.m
+++ b/@chebfun2/volt.m
@@ -36,7 +36,7 @@ if ( ~domainCheck(cols, v) )
         'Domain of CHEBFUN and CHEBFUN2 kernel do not match.');
 end
 
-RR = D * rows;
+RR = rows * D;
 
 % Cumsum with cols and v:  (This can be sped up.)
 f = chebfun( 0, dom(1:2) );

--- a/tests/chebfun/test_mtimes.m
+++ b/tests/chebfun/test_mtimes.m
@@ -163,6 +163,53 @@ gExact = op(x);
 err = gVals - gExact;
 pass(23) = norm(err, inf) < 1e1*max(get(g,'epslevel').*get(g,'vscale'));
 
+% Some tests which make sure MTIMES behaves correctly regarding the dimensions
+% of its inputs.
+f = chebfun(@sin);
+A = chebfun(@(x) [sin(x) cos(x) exp(x)]);
+Q = cheb2quasi(A);
+
+pass(24) = isequal(size(f'*f), [1 1]);
+pass(25) = isequal(size(f*f'), [Inf Inf]);
+pass(26) = isequal(size(f*[1 2]), [Inf 2]);
+pass(27) = isequal(size([1 ; 2]*f'), [2 Inf]);
+pass(28) = isequal(size(A'*A), [3 3]);
+pass(29) = isequal(size(A*A'), [Inf Inf]);
+pass(30) = isequal(size(f'*A), [1 3]);
+pass(31) = isequal(size(A'*f), [3 1]);
+pass(32) = isequal(size(A*ones(3, 2)), [Inf 2]);
+pass(33) = isequal(size(A*ones(3, 3)), [Inf 3]);
+pass(34) = isequal(size(A*ones(3, 4)), [Inf 4]);
+pass(35) = isequal(size(ones(2, 3)*A'), [2 Inf]);
+pass(36) = isequal(size(ones(3, 3)*A'), [3 Inf]);
+pass(37) = isequal(size(ones(4, 3)*A'), [4 Inf]);
+pass(38) = isequal(size(Q'*Q), [3 3]);
+pass(39) = isequal(size(Q*Q'), [Inf Inf]);
+pass(40) = isequal(size(f'*Q), [1 3]);
+pass(41) = isequal(size(Q'*f), [3 1]);
+pass(42) = isequal(size(Q*ones(3, 2)), [Inf 2]);
+pass(43) = isequal(size(Q*ones(3, 3)), [Inf 3]);
+pass(44) = isequal(size(Q*ones(3, 4)), [Inf 4]);
+pass(45) = isequal(size(ones(2, 3)*Q'), [2 Inf]);
+pass(46) = isequal(size(ones(3, 3)*Q'), [3 Inf]);
+pass(47) = isequal(size(ones(4, 3)*Q'), [4 Inf]);
+pass(48) = causesDimensionError(@() ones(3, 2)*A);
+pass(49) = causesDimensionError(@() ones(3, 3)*A);
+pass(50) = causesDimensionError(@() ones(3, 4)*A);
+pass(51) = causesDimensionError(@() A'*ones(2, 3));
+pass(52) = causesDimensionError(@() A'*ones(3, 3));
+pass(53) = causesDimensionError(@() A'*ones(4, 3));
+pass(54) = causesDimensionError(@() ones(3, 2)*Q);
+pass(55) = causesDimensionError(@() ones(3, 3)*Q);
+pass(56) = causesDimensionError(@() ones(3, 4)*Q);
+pass(57) = causesDimensionError(@() Q'*ones(2, 3));
+pass(58) = causesDimensionError(@() Q'*ones(3, 3));
+pass(59) = causesDimensionError(@() Q'*ones(4, 3));
+pass(60) = causesDimensionError(@() A*A);
+pass(61) = causesDimensionError(@() A'*A');
+pass(62) = causesDimensionError(@() Q*Q);
+pass(63) = causesDimensionError(@() Q'*Q');
+
 end
 
 % Test the multiplication of a chebfun F, specified by F_OP, by a scalar ALPHA
@@ -174,4 +221,13 @@ function result = test_mult_function_by_scalar(f, f_op, alpha, x)
     g_exact = @(x) f_op(x) * alpha;
     err = feval(g1, x) - g_exact(x);
     result(2) = norm(err(:), inf) < 10*max(vscale(g1).*epslevel(g1));
+end
+
+function result = causesDimensionError(op)
+    try
+        op();
+        result = false;
+    catch ME
+        result = strcmp(ME.identifier, 'CHEBFUN:CHEBFUN:mtimes:dims');
+    end
 end

--- a/tests/misc/test_quantumstates.m
+++ b/tests/misc/test_quantumstates.m
@@ -31,6 +31,6 @@ efuns = horzcat(efuns{1:n});
 op = @(u) -h^2*diff(u,2) + repmat(V, 1, n).*u;
 
 % Did quantumstates() return eigenfunctions and eigenvalues?
-err = norm( op(efuns) - evals*efuns );
+err = norm( op(efuns) - efuns*evals );
 pass(2) = err < 5e-8;
 end


### PR DESCRIPTION
It seems that we made a couple of errors in how dimensions are checked throughout `chebfun.mtimes()`.  Ticket #1215 (which this commit resolves) points out one of them, but while fixing it, we found more.  This commit addresses these issues by rewriting `mtimes()` to ensure that (1) we don't inappropriately swap the order of the inputs (the problem in #1215) and (2) that the dimension checks are handled correctly.  Several tests have been added to guard against similar mistakes in the future.

While we were at it, we noticed that `chebfun2.outerProduct()` was failing for quasimatrix (array-of-chebfuns) inputs.  We fix this by replacing two accesses to the `.domain` property of a chebfun with calls to the `domain()` function.  In reality, this is not very useful, since if you build a chebfun2 this way, any operations with it (including `display()`) will result in crashes, but it at least removes a potential source of asymmetry between array-valued chebfuns and quasimatrices in `chebfun.mtimes()`.  Perhaps it would be better to try to coerce quasimatrices into array-valued chebfuns whenever an outer product needs
to be computed and fail if the conversion is not successful. Nevertheless, this is a side issue and should be handled separately.

Finally, these changes flushed out a handful of places where matrices were being multiplied in a dimension-mismatched manner but the result was still OK due to the error made in #1215.  These occurred in the following files:
- `@chebfun2/lu.m`
- `@chebfun2/volt.m`
- `tests/misc/quantumstates.m`

This commit fixes these issues as well.
