### PR TITLE
Fix trigtech diff

### DIFF
--- a/@trigtech/diff.m
+++ b/@trigtech/diff.m
@@ -80,8 +80,8 @@ function f = diffContinuousDim(f, k)
     
     % If N is even make it odd
     if ( mod(N,2) == 0 )
-        % half the first coefficient and add its complex conjugate to the end
-        c = [c(1,:)/2;c(2:end,:);conj(c(1,:)/2)];
+        % half the first coefficient and add it to the end
+        c = [c(1,:)/2;c(2:end,:);c(1,:)/2];
         
         % increment N
         N = N+1;

--- a/tests/trigtech/test_diff.m
+++ b/tests/trigtech/test_diff.m
@@ -126,4 +126,10 @@ f = testclass.make(@(x) sin(pi*x));
 dim2df = diff(f, 1, 2);
 pass(16) = (isempty(dim2df.coeffs));
 
+% even example with complex coefficients
+f = testclass.make({[],[1+1i;1-1i]});
+df = diff(f);
+df_coeffs_exact = [-.5*pi*1i*(1+1i);0;.5*pi*1i*(1+1i)];
+pass(17) = (norm(df.coeffs-df_coeffs_exact, inf) < eps*norm(df_coeffs_exact,inf));
+
 end


### PR DESCRIPTION
Changed trigtech/diff.m so that whenever it computes the derivative of an even length trigtech it first converts it to an odd length trigtech. 
