### PR TITLE
Fix bug in simplification of identically-zero chebtechs.

### DIFF
--- a/@chebtech/simplify.m
+++ b/@chebtech/simplify.m
@@ -47,7 +47,7 @@ largeCoeffs = (bsxfun(@minus, abs(f.coeffs), tol.*f.vscale) > 0);
 
 % If the whole thing is now zero, leave just one coefficient:
 if ( isempty(lastNonZeroRow) )
-    lastNonZeroRow = size(f, 1);
+    lastNonZeroRow = 1;
     f.coeffs = 0*f.coeffs;
 end
 

--- a/tests/chebtech/test_simplify.m
+++ b/tests/chebtech/test_simplify.m
@@ -74,6 +74,11 @@ for n = 1:2
     g = simplify(f, 1e20);
     pass(n, 14) = iszero(g);
 
+    % Check that a long identically-zero CHEBTECH simplifies correctly:
+    f = testclass.make(@(x) 0*x, [], struct('fixedLength', 8));
+    g = simplify(f);
+    pass(n, 15) = iszero(g) && (length(g) == 1);
+
 end
 
 end


### PR DESCRIPTION
This addresses one of the points raised in #1283.  With the coefficients now ordered from lowest degree to highest, if we want to leave just one coefficient when our simplification yields an identically-zero result, we need to make that we set the last nonzero coefficient row to the _first_ row, not the last.  This modification should have been done a while ago but must have been missed when the coefficient ordering was flipped.

A test has been added to check for this problem in the future.
