### PR TITLE
Fix trigtech compose vscale

### DIFF
--- a/@trigtech/compose.m
+++ b/@trigtech/compose.m
@@ -36,7 +36,6 @@ else
 end
 
 % Set some preferences:
-vscale = f.vscale;
 pref.minSamples = max(pref.minSamples, length(f));
 pref.eps = max(pref.eps, f.epslevel);
 pref.sampleTest = false;
@@ -47,8 +46,7 @@ if ( nfuns == 2 )
               'Matrix dimensions must agree.')
     end
 
-    % Grab some data from G2:
-    vscale = max(vscale, g.vscale);
+    % Grab some data from G:
     pref.minSamples = max(pref.minSamples, length(g));
     pref.eps = max(pref.eps, g.epslevel);
     
@@ -64,7 +62,6 @@ elseif ( isa(op, 'trigtech') )
               'The range of f is not contained in the domain of g.')
     end
 
-    vscale = max(vscale, op.vscale);
     pref.minSamples = max(pref.minSamples, length(op));
     pref.eps = max(pref.eps, op.epslevel);
     
@@ -79,17 +76,10 @@ if ( ischar(pref.refinementFunction) )
     end
 end
 
-% Make TRIGTECH object:
-if ( ~isfield(data, 'vscale') || isempty(data.vscale) )
-    data.vscale = vscale;
-end
-
 if ( ~isfield(data, 'hscale') || isempty(data.hscale) )
     data.hscale = f.hscale;
 end
-
 f = f.make(op, data, pref);
-f = simplify(f);
 
 % Throw a warning:
 if ( ~f.epslevel )

--- a/tests/chebfun/test_rdivide.m
+++ b/tests/chebfun/test_rdivide.m
@@ -164,7 +164,18 @@ hExact = oph(x);
 err = hVals - hExact;
 pass(17) = norm(err, inf) < 1e1*get(f,'epslevel')*get(f,'vscale');
 
-%% Test division between a CHEBFUN and a FOURFUN.
+
+%%
+% Test that rdivide works correctly when the two triguns involved have 
+% widely different vscales.
+k = 10;
+z = chebfun('4*exp(1i*s)',[0 2*pi],'trig');
+f = z./((exp(z)-1));
+B10 = factorial(k)*sum((f./z.^(k+1)).*diff(z))/(2i*pi);  % 10 Bernoulli num
+exact = 5/66;
+pass(18) = abs(exact-B10) < get(f,'epslevel')*get(f,'vscale');
+
+%% Test division between a CHEBFUN and a TRIGFUN.
 
 dom = [0 pi 2*pi];
 
@@ -173,21 +184,21 @@ f = chebfun(@(x) x + x.^2, dom, pref);
 g = chebfun(@(x) 2+cos(x), [dom(1) dom(end)], 'periodic');
 h1 = f./g;
 % We want the result to use the same tech as the one used by f.
-pass(18) = strcmpi(func2str(get(h1.funs{1}.onefun, 'tech')), ...
+pass(19) = strcmpi(func2str(get(h1.funs{1}.onefun, 'tech')), ...
                    func2str(get(f.funs{1}.onefun, 'tech')));
 h2 = chebfun(@(x) (x + x.^2)./(2+cos(x)), dom, pref);
-pass(19) = norm(h1-h2, inf) < get(h2,'epslevel').*get(h2,'vscale');
+pass(20) = norm(h1-h2, inf) < get(h2,'epslevel').*get(h2,'vscale');
 
 % 2. Quasimatrix case.
 f = chebfun(@(x) [cos(x), sin(x)], [dom(1) dom(end)], 'periodic');
 g = chebfun(@(x) [2+x, 2+x.^3], dom, pref);
 h1 = f./g;
 % We want the result to use the same tech as the one used by g.
-pass(20) = strcmpi(func2str(get(h1(:,1).funs{1}.onefun, 'tech')), ...
+pass(21) = strcmpi(func2str(get(h1(:,1).funs{1}.onefun, 'tech')), ...
                    func2str(get(g(:,1).funs{1}.onefun, 'tech')));
-pass(21) = strcmpi(func2str(get(h1(:,2).funs{1}.onefun, 'tech')), ...
+pass(22) = strcmpi(func2str(get(h1(:,2).funs{1}.onefun, 'tech')), ...
                    func2str(get(g(:,2).funs{1}.onefun, 'tech')));
 h2 = chebfun(@(x) [cos(x)./(2+x), sin(x)./(2+x.^3)], dom, pref);
-pass(22) = norm(h1-h2, inf) < get(h2,'epslevel').*get(h2,'vscale');
+pass(23) = norm(h1-h2, inf) < get(h2,'epslevel').*get(h2,'vscale');
 
 end


### PR DESCRIPTION
Don't pass a `vscale` to the `trigtech` constructor in `trigtech/compose`.

Closes #1291.
