### PR TITLE
Rewrite of trigtech/simplify and fixes a bug in simplification of identically-zero trigtechs 

### DIFF
--- a/@trigtech/simplify.m
+++ b/@trigtech/simplify.m
@@ -34,9 +34,7 @@ if ( nargin < 2 )
     tol = f.epslevel/2;
 end
 
-% [TODO] The reversal of coeffs below should be removed but then 
-% the whole algoirthm needs to be redone.
-c = f.coeffs(end:-1:1,:);  % Obtain Fourier coefficients {c_k}
+c = f.coeffs;  % Obtain Fourier coefficients {c_k}
 numCoeffs = size(c, 1);
 fIsEven = ( mod(numCoeffs, 2) == 0 );
 
@@ -45,20 +43,23 @@ if ( fIsEven )
     % In this case the negative coefficients have an additional term
     % corresponding to the cos(N/2*x) coefficient. We account for this by
     % making the positive coefficients symmetric.
-    cn = c(numCoeffs:-1:numCoeffs/2,:);
-    cn(1,:) = 0.5*c(numCoeffs,:);
-    cp = [cn(1,:); c(1:numCoeffs/2,:)];
+    numPorNCoeffs = numCoeffs/2+1;
+    cn = c(numPorNCoeffs:-1:1,:);
+    cn(numPorNCoeffs,:) = 0.5*cn(numPorNCoeffs,:);
+    cp = [c(numPorNCoeffs:numCoeffs,:); cn(numPorNCoeffs,:)];
 else
-    cn = c(numCoeffs:-1:(numCoeffs+1)/2,:);
-    cp = c(1:(numCoeffs+1)/2,:);
+    numPorNCoeffs = (numCoeffs+1)/2;
+    cp = c(numPorNCoeffs:numCoeffs,:);
+    cn = c(numPorNCoeffs:-1:1,:);
 end
 
 % Need to check both the positive and negative coefficients in the Fourier
 % expansion.
 
-% Zero all coefficients smaller than the tolerance relative to F.VSCALE:
-idp = bsxfun(@minus, abs(cp), tol.*f.vscale) < 0;
-idn = bsxfun(@minus, abs(cn), tol.*f.vscale) < 0;
+% Check for trailing coefficients smaller than the tolerance relative
+% to F.VSCALE:
+idp = bsxfun(@minus, abs(cp), tol.*f.vscale) > 0;
+idn = bsxfun(@minus, abs(cn), tol.*f.vscale) > 0;
 
 % Before July 2014 we used to zero all small coefficients:
 % cp(idp) = 0;
@@ -68,31 +69,27 @@ idn = bsxfun(@minus, abs(cn), tol.*f.vscale) < 0;
 % [ignored, firstNonZeroRowN] = find(cn.' ~= 0, 1);
 
 % Check for trailing small coefficients:
-[ignored, firstNonZeroRowP] = find(idp.' == 0, 1);
-[ignored, firstNonZeroRowN] = find(idn.' == 0, 1);
+[ignored, lastNonZeroRowP] = find(idp.' == 1, 1, 'last');
+[ignored, lastNonZeroRowN] = find(idn.' == 1, 1, 'last');
 
 % If the whole thing's now zero, leave just one coefficient:
-if ( isempty(firstNonZeroRowP) && isempty(firstNonZeroRowN) )
-    firstNonZeroRow = size(cp, 1);
+if ( isempty(lastNonZeroRowP) && isempty(lastNonZeroRowN) )
+    lastNonZeroRowP = 1;
+    lastNonZeroRowN = 1;
     cp = 0*cp; 
     cn = 0*cn;
-% The negative and positive cofficient vectors need to be the same length
-% So, we remove the smaller of the tails from both.
-else
-    firstNonZeroRow = min(firstNonZeroRowP, firstNonZeroRowN);
 end
 
+lastNonZeroRow = max(lastNonZeroRowP, lastNonZeroRowN);
+
 % Remove trailing zeros:
-if ( firstNonZeroRow > 0 )
-    cp = cp(firstNonZeroRow:end,:);
-    cn = cn(firstNonZeroRow:end,:);
+if ( lastNonZeroRow > 0 )
+    cp = cp(1:lastNonZeroRow,:);
+    cn = cn(1:lastNonZeroRow,:);
 end
 
 % Now put the coefficients vector back together.
-f.coeffs = [cp(1:end,:); cn(end-1:-1:1,:)];
-
-% [TODO]: This should be reomved, see the TODO above.
-f.coeffs = f.coeffs(end:-1:1,:);
+f.coeffs = [cn(end:-1:2,:); cp(1:end,:)];
 
 % Update values and epslevel:
 f.values = f.coeffs2vals(f.coeffs);

--- a/tests/trigtech/test_simplify.m
+++ b/tests/trigtech/test_simplify.m
@@ -66,4 +66,10 @@ f = testclass.make(@(x) sin(100*pi*(x + 0.1)));
 g = simplify(f, 1e20);
 pass(11) = iszero(g);
 
+%%
+% Check that a long identically-zero TRIGTECH simplifies correctly:
+f = testclass.make(@(x) 0*x, [], struct('fixedLength', 8));
+g = simplify(f);
+pass(12) = iszero(g) && (length(g) == 1);
+
 end


### PR DESCRIPTION
Rewrite of `trigtech/simplify` to conform to the new arrangement of coefficients from negative powers to positive powers.  Also fixes a bug where a zero `trigtech` was not being simplified to have length zero.  This was fixed for `chebtech` in #1284, but not for `trigtech`.
