### PR TITLE
fixing warning for trig based chebfuns.

### DIFF
--- a/@chebfun/constructor.m
+++ b/@chebfun/constructor.m
@@ -111,9 +111,15 @@ for k = 1:numIntervals
 
     % Warn if unhappy (as we're unable to split the domain to improve):
     if ( ~ishappy && ~warningThrown )
+        if ( strcmpi(func2str(pref.tech), 'trigtech') )
+            str = 'a non-trig representation';
+        else
+            str = '''splitting on''';
+        end
+            
         warning('CHEBFUN:CHEBFUN:constructor:notResolved', ...
             ['Function not resolved using %d pts.', ...
-            ' Have you tried ''splitting on''?'], pref.techPrefs.maxLength);
+            ' Have you tried ' str, '?'], pref.techPrefs.maxLength);
         warningThrown = true;
     end
 end


### PR DESCRIPTION
This is a fix for #987. So we now have:

```
>> f = chebfun(@(x) abs(x))
Warning: Function not resolved using 65537 pts. Have you tried 'splitting on'? 
> In chebfun.constructor>constructorNoSplit at 120
  In chebfun.constructor at 63
  In chebfun.chebfun>chebfun.chebfun at 221 
f =
   chebfun column (1 smooth piece)
       interval       length   endpoint values  
[      -1,       1]    65537         1        1 
Epslevel = 3.704567e-10.  Vscale = 1.
>> g = chebfun(@(x) abs(x), 'trig' )
Warning: Function not resolved using 65537 pts. Have you tried a non-trig representation? 
> In chebfun.constructor>constructorNoSplit at 120
  In chebfun.constructor at 63
  In chebfun.chebfun>chebfun.chebfun at 221 
g =
   chebfun column (1 smooth piece)
       interval       length   endpoint values trig
[      -1,       1]    65536         1        1 
Epslevel = 9.094947e-13.  Vscale = 1.
```

Closes #1318.
