### PR TITLE
Fix for trigcoeffs bug when even number coefficients requested

### DIFF
--- a/@trigtech/trigcoeffs.m
+++ b/@trigtech/trigcoeffs.m
@@ -44,19 +44,27 @@ numCoeffs = size(c, 1);
 
 % Determine which index corresponds to the constant term:
 if ( fIsEven )
-    constIndex = numCoeffs/2;
+    constIndex = numCoeffs/2+1;
 else
     constIndex = (numCoeffs+1)/2;
 end
 
 % Use symmetry:
 if ( NisEven )
-    id = (constIndex-(N/2-1)) : (constIndex+(N/2));
+    id = (constIndex-N/2) : (constIndex+(N/2-1));
+    % Extract out the entries:
+    out = c(id,:);
+    % Need to adjust the first term so that it corresponds to the 
+    % coefficient for cos(N/2*pi*x)
+    if id(end) < numCoeffs
+        % Only do this if there are enough coefficients
+        out(1,:) = (out(1,:) + c(id(end)+1,:));
+    end
 else
     id = (constIndex-((N-1)/2)) : (constIndex+((N-1)/2));
+    out = c(id,:);
 end
 
-% Extract out the entries:
-out = c(id,:);
+
 
 end

--- a/tests/trigtech/test_trigcoeffs.m
+++ b/tests/trigtech/test_trigcoeffs.m
@@ -20,6 +20,7 @@ f = testclass.make(@(x) 3*ones(size(x)), [], pref);
 p = trigcoeffs(f);
 pass(2) = (norm(p - 3, inf) < 10*f.vscale.*f.epslevel);
 
+%% Odd tests
 f = testclass.make(@(x) 1+cos(pi*x), [], pref);
 p = trigcoeffs(f);
 pass(3) = (norm(p - [0.5 1 0.5]', inf) < 10*f.vscale.*f.epslevel);
@@ -39,6 +40,17 @@ p = trigcoeffs(f,3);
 pass(8) = (norm(p - [1 1 0]', inf) ...
     < 10*f.vscale.*f.epslevel);
 
+%% Even tests
+f = testclass.make(@(x) 2+cos(pi*x), [], pref);
+p = trigcoeffs(f,2);
+pass(9) = (norm(p - [1 2]', inf) < 10*f.vscale.*f.epslevel);
+f = testclass.make(@(x) 2+sin(pi*x), [], pref);
+p = trigcoeffs(f,2);
+pass(10) = (norm(p - [0 2]', inf) < 10*f.vscale.*f.epslevel);
+f = testclass.make(@(x) 2+cos(2*pi*x), [], pref);
+p = trigcoeffs(f,4);
+pass(11) = (norm(p - [1 0 2 0]', inf) < 10*f.vscale.*f.epslevel);
+
 %%
 % Verify operation for array-valued trigtech objects.
 
@@ -50,7 +62,7 @@ p_exact = [0 0   0;...
            3 1   1;...
            0 0.5 0;...
            0 0   1];
-pass(9) = (norm(p(:) - p_exact(:), inf) < 10*max(f.vscale.*f.epslevel));
+pass(12) = (norm(p(:) - p_exact(:), inf) < 10*max(f.vscale.*f.epslevel));
 
 p = trigcoeffs(f,7);
 p_exact = [0 0   0;...
@@ -60,15 +72,15 @@ p_exact = [0 0   0;...
            0 0.5 0;...
            0 0   1;...
            0 0   0];
-pass(10) = (norm(p(:) - p_exact(:), inf) < 10*max(f.vscale.*f.epslevel));
+pass(13) = (norm(p(:) - p_exact(:), inf) < 10*max(f.vscale.*f.epslevel));
 
 p = trigcoeffs(f,3);
 p_exact = [0 0.5 1;...   
            3 1   1;...
            0 0.5 0];
-pass(11) = (norm(p(:) - p_exact(:), inf) < 10*max(f.vscale.*f.epslevel));
+pass(14) = (norm(p(:) - p_exact(:), inf) < 10*max(f.vscale.*f.epslevel));
 
 p = trigcoeffs(f,0);
-pass(12) = isempty(p);
+pass(15) = isempty(p);
 
 end


### PR DESCRIPTION
The `trigtech/trigcoeffs` method is not returning the correct coefficients when an even number is requested.  For example,

```
>> f = chebfun('1 + cos(pi*x)','trig');
>> trigcoeffs(f,2)
ans =
   1.0000 + 0.0000i
   0.5000 - 0.0000i
```

This also resulted in incorrect results when using the `trunc` flag:

```
>> f = chebfun('1 + cos(pi*x)','trig','trunc',2)
f =
   chebfun column (1 smooth piece)
       interval       length   endpoint values trig
[      -1,       1]        2      -0.5     -0.5 
Epslevel = 1.480297e-15.  Vscale = 1.500000e+00.
```

Note the end point values indicate the result is off.

This pull request fixes this bug and includes tests for even number trig coefficient requests.
