### PR TITLE
Fix plateauCheck.

### DIFF
--- a/@chebDiscretization/testConvergence.m
+++ b/@chebDiscretization/testConvergence.m
@@ -44,7 +44,7 @@ tech = tech();
 
 % If an external vscale was supplied, it can supplant the inherent scale of the
 % result.
-vscale = max(u.vscale, max(vscale));
+vscale = max(u.vscale, vscale);
 prefTech = tech.techPref();
 prefTech.eps = pref.errTol;
 
@@ -52,7 +52,7 @@ for i = 1:numInt
     c = cat(2, coeffs{i,:});
     f = tech.make({[], c});
     f.vscale = vscale;
-    [isDone(i), neweps, cutoff(i,:)] = plateauCheck(f, get(f,'values'), ...
+    [isDone(i), neweps, cutoff(i,:)] = plateauCheck(f, get(f, 'values'), ...
         prefTech);
     epsLevel = max(epsLevel, neweps);
 end

--- a/@chebtech/plateauCheck.m
+++ b/@chebtech/plateauCheck.m
@@ -1,4 +1,4 @@
-function [ishappy, epsLevel, cutoff] = plateauCheck(f, values, pref)
+function [ishappy, epsLevel, cutOff] = plateauCheck(f, values, pref)
 %PLATEAUCHECK   Attempt to trim trailing Chebyshev coefficients in a CHEBTECH.
 %   [ISHAPPY, EPSLEVEL, CUTOFF] = PLATEAUCHECK(F, VALUES) returns an estimated
 %   location, the CUTOFF, at which the CHEBTECH F could be truncated. One of two
@@ -57,12 +57,12 @@ maxvals = max(abs(values), [], 1);
 if ( max(maxvals) == 0 )
     % This is the zero function, so we must be happy!
     ishappy = true;
-    cutoff = 1;
+    cutOff = 1;
     return
 elseif ( any(isinf(maxvals)) )
     % Inf located. No cutoff.
     ishappy = false;
-    cutoff = n;
+    cutOff = n;
     return
 end
 
@@ -71,25 +71,27 @@ end
 n90 = ceil( 0.90*n );
 absCoeff = abs( coeff(1:n90,:) );
 vscale = max(absCoeff,[],1);          % scaling in each column
-vscale = max( [vscale(:); f.vscale] );
-absCoeff = absCoeff / vscale;
+vscale = max( [vscale ; f.vscale] );
+absCoeff = absCoeff * diag(1./vscale);
 
 %% Deal with array-valued functions.
 
 numCol = size(coeff, 2);
 ishappy = false(1,numCol);
 epsLevels = zeros(1,numCol);
-cutoff = zeros(1,numCol);
+cutOff = zeros(1,numCol);
 for m = 1:numCol
-    [ishappy(m), epsLevels(m), cutoff(m)] = checkColumn(absCoeff(:,m),epsLevel);
+    [ishappy(m), epsLevels(m), cutOff(m)] = checkColumn(absCoeff(:,m), epsLevel);
     if ( ~ishappy(m) )
         % No need to continue if it fails on any column.
         break
     end
 end
 
-epsLevel = max(epsLevels);
+epsLevel = epsLevels;
+% epsLevel = max(epsLevel)
 ishappy = all(ishappy); 
+cutOff = max(cutOff);
 
 end
 

--- a/@linop/eigs.m
+++ b/@linop/eigs.m
@@ -242,7 +242,7 @@ for dim = dimVals
     
 
     % Test the happiness of the function pieces:
-    vscale = zeros(sum(isFun),1);   % intrinsic scaling only
+    vscale = zeros(1, sum(isFun));   % intrinsic scaling only
     [isDone, epsLevel] = testConvergence(discA, u(isFun), vscale, pref);
 
     if ( all(isDone) )

--- a/@linop/linsolve.m
+++ b/@linop/linsolve.m
@@ -37,7 +37,7 @@ function [u, disc] = linsolve(L, f, varargin)
 % Parse input
 prefs = [];    % no prefs given
 disc = [];     % no discretization given
-vscale = zeros(size(L,2),1);
+vscale = zeros(1, size(L, 2));
 for j = 1:nargin-2
     item = varargin{j};
     if ( isa(item, 'cheboppref') )
@@ -45,7 +45,7 @@ for j = 1:nargin-2
     elseif ( isa(item,'chebDiscretization') )
         disc = item;
     elseif ( isnumeric(item) )
-        vscale = item;
+        vscale = item(:)';
     else
         error('CHEBFUN:LINOP:linsolve:badInput', ...
             'Could not parse argument number %i.',j+2)
@@ -139,8 +139,8 @@ for dim = [dimVals inf]
     u = partition(disc, v);
     
     % Need a vector of vscales.
-    if ( numel(vscale)==1 ) 
-        vscale = repmat(vscale, sum(isFun), 1);
+    if ( numel(vscale) == 1 ) 
+        vscale = repmat(vscale, 1, sum(isFun));
     end
 
     % Test the happiness of the function pieces:

--- a/tests/chebtech/test_happinessCheck.m
+++ b/tests/chebtech/test_happinessCheck.m
@@ -101,9 +101,9 @@ for n = 1:2
     
     % Test plateauCheck with an array-valued input:
     p = pref;
-    p.techPrefs.happinessCheck = @classicCheck;
+    p.happinessCheck = @classicCheck;
     f1 = testclass.make(@(x) [sin(x) cos(x)], [], p);
-    p.techPrefs.happinessCheck = @plateauCheck;
+    p.happinessCheck = @plateauCheck;
     f2 = testclass.make(@(x) [sin(x) cos(x)], [], p);
     pass(n, 9) = normest(f1 - f2) < 10*max(f2.epslevel);
 


### PR DESCRIPTION
`plateauCheck` was not respecting `vscales` in array-valued construction properly.

The test which should have caught this (`chebtech/test_happinessCheck.m` test 9) wasn't doing so as the preference to use `@plateauCheck` wasn't being set correctly.

This pull request fixes this, as well as the issues resulting from the change in `chebop` and `linop` classes (which are the main clients of `plateauCheck` and were, for some reason, using column vectors for `vscales`).