### PR TITLE
Feature fraccalc new

### DIFF
--- a/@bndfun/fracInt.m
+++ b/@bndfun/fracInt.m
@@ -1,0 +1,19 @@
+function f = fracInt(f, mu)
+%FRACINT  Fractional integral of a BNDFUN. 
+%   FRACINT(F, MU) gives the order MU fractional integral of a BNDFUN object F.
+
+% Copyright 2014 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+% Scaling for domain:
+scl = (diff(f.domain)/2)^mu;
+
+if ( ~isa(f.onefun, 'singfun') )
+    % Cast ONEFUN to a SINGFUN since the result must be singular:
+    f.onefun = singfun(f.onefun);
+end
+
+% Fractional integral of the ONEFUN:
+f.onefun = scl * fracInt(f.onefun, mu);
+
+end

--- a/@chebfun/chebfun.m
+++ b/@chebfun/chebfun.m
@@ -297,6 +297,12 @@ classdef chebfun
         
         % Round a CHEBFUN towards minus infinity.
         g = floor(f);
+        
+        % Fractional derivative of a CHEBFUN object:
+        f = fracDiff(f, mu, type)
+        
+        % Fractional integral of a CHEBFUN object:
+        f = fracInt(f, mu)
 
         % Get properties of a CHEBFUN object.
         out = get(f, prop, simpLevel);

--- a/@chebfun/cumsum.m
+++ b/@chebfun/cumsum.m
@@ -7,7 +7,7 @@ function f = cumsum(f, m, dim)
 %   integral is chosen to make the representation of G as simple as possible.
 %
 %   CUMSUM(F, N) returns the Nth integral of F. If N is not an integer then
-%   CUMSUM(F, N) returns the fractional integral of order N as defined by the
+%   CUMSUM(F, MU) returns the fractional integral of order MU as defined by the
 %   Riemann-Liouville integral.
 %
 %   CUMSUM(F, N, 2) will take the Nth cumulative sum over the columns F an
@@ -37,10 +37,7 @@ end
 
 if ( round(m) ~= m )
     % Fractional integral:
-    % [TODO]: Implement this!
-    error('CHEBFUN:CHEBFUN:cumsum:notImplemented', ...
-        'Fractional antiderivatives not yet implemented.');
-    f = fracCalc(f, m);
+    f = fracInt(f, m);
     return
 end
 

--- a/@chebfun/diff.m
+++ b/@chebfun/diff.m
@@ -40,16 +40,13 @@ if ( nargin < 3 )
     dim = 1;
 end
 
-if ( ~any(dim == [1, 2]) )
+if ( isnumeric(dim) && ~any(dim == [1, 2]) )
     error('CHEBFUN:CHEBFUN:diff:dim', 'Dimension must either be 1 or 2.');
 end
     
 if ( round(n) ~= n )
-    % Fractional integral:
-    % [TODO]: Implement this!
-    error('CHEBFUN:CHEBFUN:diff:notImplemented', ...
-        'Fractional derivatives not yet implemented.');
-    F = fracCalc(F, n);
+    % Fractional derivative:
+    F = fracDiff(F, n, dim);
     return
 end
 

--- a/@chebfun/fracDiff.m
+++ b/@chebfun/fracDiff.m
@@ -1,0 +1,48 @@
+function f = fracDiff(f, mu, type)
+%FRACDIFF  Fractional derivative of a CHEBFUN. 
+%   FRACINT(F, MU) gives the order MU Riemann-Liouville fractional derivative of
+%   a CHEBFUN object F.
+%
+%   FRACINT(F, MU, 'Caputo') instead uses the Caputo definition of the
+%   fractional derivative.
+%
+%   Currently this only supports the situation where F is smooth (i.e., it has
+%   no breakpoints or endpoint singularities) and on a finite domain.
+
+% Copyright 2014 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+
+% Default to Riemann-Liouville:
+if ( nargin < 3  )
+    type = 'RL';
+end
+
+% Extract the fractional part:
+mu_int = floor(mu);
+mu_frac = mu - mu_int;
+
+if ( mu_frac == 0 )
+    f = diff(f, mu_int);
+    return
+end
+
+% No piecewise support yet:
+if ( numel(f.funs) > 1 )
+    error('CHEBFUN:CHEBFUN:fracInt:breakpoints', ...
+        'FRACINT() does not currently support piecewise functions.');
+end
+
+if ( strcmpi(type, 'Caputo') )
+    % Caputo:
+    f = fracInt(f, 1-mu_frac);
+    f = diff(f, mu_int + 1);
+    
+else
+    % Riemann-Liouville:
+    f = diff(f, mu_int + 1);
+    f = fracInt(f, 1-mu_frac);    
+    
+end
+
+end

--- a/@chebfun/fracDiff.m
+++ b/@chebfun/fracDiff.m
@@ -35,13 +35,13 @@ end
 
 if ( strcmpi(type, 'Caputo') )
     % Caputo:
-    f = fracInt(f, 1-mu_frac);
+    f = fracInt(f, 1 - mu_frac);
     f = diff(f, mu_int + 1);
     
 else
     % Riemann-Liouville:
     f = diff(f, mu_int + 1);
-    f = fracInt(f, 1-mu_frac);    
+    f = fracInt(f, 1 - mu_frac); 
     
 end
 

--- a/@chebfun/fracInt.m
+++ b/@chebfun/fracInt.m
@@ -28,4 +28,6 @@ end
 % Call BNDFUN/FRACINT():
 f.funs{1} = fracInt(f.funs{1}, mu_frac);
 
+f.pointValues = chebfun.getValuesAtBreakpoints(f.funs);
+
 end

--- a/@chebfun/fracInt.m
+++ b/@chebfun/fracInt.m
@@ -8,26 +8,48 @@ function f = fracInt(f, mu)
 % Copyright 2014 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
+% No piecewise support yet:
+if ( numel(domain(f)) > 2 )
+    error('CHEBFUN:CHEBFUN:fracInt:breakpoints', ...
+        'FRACINT() does not currently support piecewise functions.');
+end
+
 % Extract the fractional part of mu:
 mu_int = floor(mu);
 mu_frac = mu - mu_int;
 
 % Computer the integer CUMSUMs:
-f = cumsum(f, mu_int);
-
-if ( mu_frac == 0 )
+if ( mu_int > 0 )
+    % Ensure mu is in [0, 1):
+    f = cumsum(f, mu_int);
+    f = fracInt(f, mu_frac);
+    return
+elseif ( mu_frac == 0 )
+    % Nothing more to do (non-fractional integral).
     return
 end
 
-% No piecewise support yet:
-if ( numel(f.funs) > 1 )
-    error('CHEBFUN:CHEBFUN:fracInt:breakpoints', ...
-        'FRACINT() does not currently support piecewise functions.');
+% Quasimatrix / Array-valued support:
+% TODO: This should be overhauled once SINGFUN supports array-valuedness.
+m = numColumns(f);
+if ( m > 1 )
+    % Convert to cell-array of scalar CHEBFUNs.
+    f = mat2cell(f);    
+    % Loop over columns:
+    for k = 1:m
+        f{k} = fracInt(f{k}, mu_frac);
+    end
+    % Convert from cell array to quasimatrix.
+    f = cat(2-f{1}.isTransposed, f{:});
+    return
 end
+
+% From here on f is scalar-valued:
 
 % Call BNDFUN/FRACINT():
 f.funs{1} = fracInt(f.funs{1}, mu_frac);
 
+% Update the pointValues:
 f.pointValues = chebfun.getValuesAtBreakpoints(f.funs);
 
 end

--- a/@chebfun/fracInt.m
+++ b/@chebfun/fracInt.m
@@ -1,0 +1,31 @@
+function f = fracInt(f, mu)
+%FRACINT  Fractional integral of a CHEBFUN. 
+%   FRACINT(F, MU) gives the order MU fractional integral of a CHEBFUN object F.
+%
+%   Currently this only supports the situation where F is smooth (i.e., it has
+%   no breakpoints or endpoint singularities) and on a finite domain.
+
+% Copyright 2014 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+% Extract the fractional part of mu:
+mu_int = floor(mu);
+mu_frac = mu - mu_int;
+
+% Computer the integer CUMSUMs:
+f = cumsum(f, mu_int);
+
+if ( mu_frac == 0 )
+    return
+end
+
+% No piecewise support yet:
+if ( numel(f.funs) > 1 )
+    error('CHEBFUN:CHEBFUN:fracInt:breakpoints', ...
+        'FRACINT() does not currently support piecewise functions.');
+end
+
+% Call BNDFUN/FRACINT():
+f.funs{1} = fracInt(f.funs{1}, mu_frac);
+
+end

--- a/@chebtech/chebtech.m
+++ b/@chebtech/chebtech.m
@@ -235,7 +235,7 @@ classdef chebtech < smoothfun % (Abstract)
         f = flipud(f)
         
         % Fractional integral of a CHEBTECH object.
-        f = fracInt(f, mu)
+        f = fracInt(f, mu, b)
 
         % Happiness test for a CHEBTECH
         [ishappy, epslevel, cutoff] = happinessCheck(f, op, values, pref)

--- a/@chebtech/chebtech.m
+++ b/@chebtech/chebtech.m
@@ -233,6 +233,9 @@ classdef chebtech < smoothfun % (Abstract)
         
         % Flip/reverse a CHEBTECH object.
         f = flipud(f)
+        
+        % Fractional integral of a CHEBTECH object.
+        f = fracInt(f, mu)
 
         % Happiness test for a CHEBTECH
         [ishappy, epslevel, cutoff] = happinessCheck(f, op, values, pref)

--- a/@chebtech/fracInt.m
+++ b/@chebtech/fracInt.m
@@ -1,8 +1,12 @@
-function g = fracInt(f, mu)
+function g = fracInt(f, mu, b)
 %FRACINT  Fractional integral of a CHEBTECH. 
 %   G = FRACINT(F, MU) returns the smooth part, G, of the order MU fractional
-%   integral of the CHEBTECH object F. That is, (J^{MU}F)(x) = (1+x)^MU * G.
+%   integral of the CHEBTECH object F. That is, J^{MU}(F(x)) = (1+x)^MU * G.
 %   MU is assumed to be in the range (0,1).
+%
+%   G = FRACINT(F, MU, B) is similar, but returns the smoothpart of the
+%   fractional integral of the (1+x)^B*F. That is, J^{MU}((1+x)^B*F(x)) =
+%   (1+x)^(MU+B) * G(x). 
 %
 %   The algorithm used to is to expand F in the Legendre basis and apply the
 %   formula [1, (18.17.9)]. The resulting Jacobi polynomial series is converted
@@ -26,29 +30,44 @@ if ( ~isa(f, 'chebtech') )
     error('CHEFBFUN:CHEBTECH:halfInt:chebtech', ....
         'FRACINT() only supports CHEBTECH objects.');
 end
+if ( nargin < 3 )
+    % Default to b = 0:
+    b = 0;
+end
 
-% Legendre coefficients of f:
-c_leg = cheb2leg(f.coeffs);
+if ( b == 0 )
+    % Legendre coefficients of f:
+    c_leg = cheb2leg(f.coeffs);
 
-% Determine the new coefricients via [1, (18.17.9)] or [1, (18.17.45)]:
-if ( mu ~= .5 )
-    % Coefficients of the fractional integral:
-    c_jac = (c_leg.*beta((0:n-1)'+1, mu))/gamma(mu);
-    c_new = jac2cheb(c_jac, -mu, mu);
+    % Determine the new Coefficients via [1, (18.17.9)] or [1, (18.17.45)]:
+    if ( mu ~= .5 )
+        % Coefficients of the fractional integral:
+        c_jac = (c_leg.*beta((0:n-1)'+1, mu))/gamma(mu);
+        c_new = jac2cheb(c_jac, -mu, mu);
+    else
+        % Coefficients of the half-integral:
+        z = zeros(1, m);
+        scl = (0:n-1)'+.5;
+        c_scl = c_leg./(scl*gamma(.5));
+        c_new = ( [c_scl ; z] + [z ; c_scl] );
+
+        % For consistence with mu ~= .5, we must divide out by (1+x). (See
+        % chebtech/extractBoundaryRoots() for details of this imlpementation.)
+        e = ones(n, 1); 
+        D = spdiags([.5*e, e, .5*e], 0:2, n, n); 
+        D(1) = 1;
+        % Compute the new coefficients:
+        c_new = [D\c_new(2:end,:) ; z];
+    end
+    
 else
-    % Coefficients of the half-integral:
-    z = zeros(1, m);
-    scl = (0:n-1)'+.5;
-    c_scl = c_leg./scl/gamma(.5);
-    c_new = ( [c_scl ; z] + [z ; c_scl] );
+    % P^(0, b) coefficients of f:
+    c_jac1 = cheb2jac(f.coeffs, 0, b);
 
-    % For consistence with mu ~= .5, we must divide out by (1+x). (See
-    % chebtech/extractBoundaryRoots() for details of this imlpementation.)
-    e = ones(n, 1); 
-    D = spdiags([.5*e, e, .5*e], 0:2, n, n); 
-    D(1) = 1;
-    % Compute the new coefficients:
-    c_new = [D\c_new(2:end,:) ; z];
+    % Determine the new Coefficients via [1, (18.17.9)]:
+    c_jac2 = (c_jac1.*beta((0:n-1)'+b+1, mu))/gamma(mu);
+    c_new = jac2cheb(c_jac2, -mu, b+mu);
+    
 end
 
 % Update f:

--- a/@chebtech/fracInt.m
+++ b/@chebtech/fracInt.m
@@ -1,0 +1,60 @@
+function g = fracInt(f, mu)
+%FRACINT  Fractional integral of a CHEBTECH. 
+%   G = FRACINT(F, MU) returns the smooth part, G, of the order MU fractional
+%   integral of the CHEBTECH object F. That is, (J^{MU}F)(x) = (1+x)^MU * G.
+%   MU is assumed to be in the range (0,1).
+%
+%   The algorithm used to is to expand F in the Legendre basis and apply the
+%   formula [1, (18.17.9)]. The resulting Jacobi polynomial series is converted
+%   back to Chebyshev via JAC2CHEB(). In the special case when MU = .5, [1,
+%   (18.17.45)] is used instead, as this removes the need for JAC2CHEB().
+%
+%   References:
+%    [1] F.W.J. Olver et al., editors. NIST Handbook of Mathematical Functions.
+%    Cambridge University Press, New York, NY, 2010.
+
+% Copyright 2014 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+% Parse inputs:
+[n, m] = size(f);
+if ( m > 1 )
+    error('CHEFBFUN:CHEBTECH:fracInt:arrayvalued', ....
+        'Array-valued CHEBTECH objects are not supported.');
+end
+if ( ~isa(f, 'chebtech') )
+    error('CHEFBFUN:CHEBTECH:halfInt:chebtech', ....
+        'FRACINT() only supports CHEBTECH objects.');
+end
+
+% Legendre coefficients of f:
+c_leg = cheb2leg(f.coeffs);
+
+% Determine the new coefricients via [1, (18.17.9)] or [1, (18.17.45)]:
+if ( mu ~= .5 )
+    % Coefficients of the fractional integral:
+    c_jac = (c_leg.*beta((0:n-1)'+1, mu))/gamma(mu);
+    c_new = jac2cheb(c_jac, -mu, mu);
+else
+    % Coefficients of the half-integral:
+    z = zeros(1, m);
+    scl = (0:n-1)'+.5;
+    c_scl = c_leg./scl/gamma(.5);
+    c_new = ( [c_scl ; z] + [z ; c_scl] );
+
+    % For consistence with mu ~= .5, we must divide out by (1+x). (See
+    % chebtech/extractBoundaryRoots() for details of this imlpementation.)
+    e = ones(n, 1); 
+    D = spdiags([.5*e, e, .5*e], 0:2, n, n); 
+    D(1) = 1;
+    % Compute the new coefficients:
+    c_new = [D\c_new(2:end,:) ; z];
+end
+
+% Update f:
+g = f;
+g.coeffs = c_new;
+g.vscale = getvscl(f);
+g.epslevel = updateEpslevel(f);
+
+end

--- a/@chebtech/fracInt.m
+++ b/@chebtech/fracInt.m
@@ -26,10 +26,6 @@ if ( m > 1 )
     error('CHEFBFUN:CHEBTECH:fracInt:arrayvalued', ....
         'Array-valued CHEBTECH objects are not supported.');
 end
-if ( ~isa(f, 'chebtech') )
-    error('CHEFBFUN:CHEBTECH:halfInt:chebtech', ....
-        'FRACINT() only supports CHEBTECH objects.');
-end
 if ( nargin < 3 )
     % Default to b = 0:
     b = 0;

--- a/@fun/fun.m
+++ b/@fun/fun.m
@@ -61,8 +61,7 @@ classdef fun % (Abstract)
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     methods ( Abstract = true, Static = false )
 
-        % Test if the FUN is constructed with a basis of periodic
-        % functions.
+        % Test if the FUN is constructed with a basis of periodic functions.
         out = isPeriodicTech(f);
 
         % Return a version of the fun with all deltas removed.

--- a/@onefun/onefun.m
+++ b/@onefun/onefun.m
@@ -107,6 +107,9 @@ classdef onefun % (Abstract)
         
         % Flip/reverse a ONEFUN object.
         f = flipud(f)
+        
+        % Fractional integral of a ONEFUN object.
+        f = fracInt(f, mu)
 
         % Imaginary part of a ONEFUN.
         f = imag(f)

--- a/@singfun/fracInt.m
+++ b/@singfun/fracInt.m
@@ -2,20 +2,31 @@ function g = fracInt(f, mu)
 %FRACINT  Fractional integral of a SINGFUN. 
 %   FRACINT(F, MU) gives the order MU fractional integral of a SINGFUN object F.
 %
-%   Currently this only supports the situation where F is smooth (i.e., it has
-%   trivial exponents).
+%   Currently this only supports the situation where F is  is smooth at the
+%   right boundary (i.e., F.exponents(2) = 0).
 
 % Copyright 2014 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-if ( any( f.exponents ) )
+% Attempt to simplify the exponents as we must have zero at the right.
+f = simplifyExponents(f);
+exps = f.exponents;
+
+if ( exps(2) ~= 0 )
     error('CHEBFUN:SINGFUN:fracInt:exponents', ...
-        ['FRACINT currently this only supports the situation where g is smooth',
-         ' (i.e., it has trivial exponents)']);
+        ['FRACINT currently only supports the situation where g is smooth ',
+         'at the right boundary.']);
 end
 
 g = f;
-g.smoothPart = fracInt(f.smoothPart, mu);
-g.exponents = [mu, 0];
+% Compute the smooth part:
+g.smoothPart = fracInt(f.smoothPart, mu, exps(1));
+% Update the exponents:
+g.exponents = f.exponents + [mu, 0];
+
+if ( exps(1) ~= 0 )
+    % Simplify the exponents again.
+    g = simplifyExponents(g);
+end
 
 end

--- a/@singfun/fracInt.m
+++ b/@singfun/fracInt.m
@@ -14,8 +14,8 @@ exps = f.exponents;
 
 if ( exps(2) ~= 0 )
     error('CHEBFUN:SINGFUN:fracInt:exponents', ...
-        ['FRACINT currently only supports the situation where g is smooth ',
-         'at the right boundary.']);
+        ['FRACINT(F, MU) currently only supports the situation when F is ', ...
+         'smooth at the right boundary.']);
 end
 
 g = f;

--- a/@singfun/fracInt.m
+++ b/@singfun/fracInt.m
@@ -1,0 +1,21 @@
+function g = fracInt(f, mu)
+%FRACINT  Fractional integral of a SINGFUN. 
+%   FRACINT(F, MU) gives the order MU fractional integral of a SINGFUN object F.
+%
+%   Currently this only supports the situation where F is smooth (i.e., it has
+%   trivial exponents).
+
+% Copyright 2014 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+if ( any( f.exponents ) )
+    error('CHEBFUN:SINGFUN:fracInt:exponents', ...
+        ['FRACINT currently this only supports the situation where g is smooth',
+         ' (i.e., it has trivial exponents)']);
+end
+
+g = f;
+g.smoothPart = fracInt(f.smoothPart, mu);
+g.exponents = [mu, 0];
+
+end

--- a/@singfun/singfun.m
+++ b/@singfun/singfun.m
@@ -238,6 +238,9 @@ classdef (InferiorClasses = {?chebtech2, ?chebtech1}) singfun < onefun %(See Not
         % SINGFUN does not support FLOOR.
         g = floor(f)
         
+        % Fractional integral of a SINGFUN object.
+        f = fracInt(f, mu)
+        
         % Get method:
         val = get(f, prop)
         

--- a/@trigtech/fracInt.m
+++ b/@trigtech/fracInt.m
@@ -1,4 +1,4 @@
-function f = fracInt(f, mu)
+function varargout = fracInt(varargin)
 %FRACINT  Fractional integral of an TRIGTECH. 
 %   Fractional integrals of TRIGTECH objects are not yet supported.
 

--- a/@trigtech/fracInt.m
+++ b/@trigtech/fracInt.m
@@ -1,0 +1,13 @@
+function f = fracInt(f, mu)
+%FRACINT  Fractional integral of an TRIGTECH. 
+%   Fractional integrals of TRIGTECH objects are not yet supported.
+
+% Copyright 2014 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+error('CHEBFUN:TRIGTECH:fracInt:noSupport', ...
+    'Fractional integrals of TRIGTECH objects are not yet supported.')
+
+% TODO: Implement this.
+
+end

--- a/@trigtech/trigtech.m
+++ b/@trigtech/trigtech.m
@@ -259,6 +259,9 @@ classdef trigtech < smoothfun % (Abstract)
         
         % Flip/reverse a TRIGTECH object.
         f = flipud(f)
+        
+        % Fractional integral of a TRIGTECH object.
+        f = fracInt(f, mu)
 
         % Plot (semilogy) the trigonometric coefficients of a TRIGTECH object.
         varargout = plotcoeffs(f, varargin)

--- a/@trigtech/trigtech.m
+++ b/@trigtech/trigtech.m
@@ -261,7 +261,7 @@ classdef trigtech < smoothfun % (Abstract)
         f = flipud(f)
         
         % Fractional integral of a TRIGTECH object.
-        f = fracInt(f, mu)
+        varargout = fracInt(varargin)
 
         % Plot (semilogy) the trigonometric coefficients of a TRIGTECH object.
         varargout = plotcoeffs(f, varargin)

--- a/@unbndfun/fracInt.m
+++ b/@unbndfun/fracInt.m
@@ -1,0 +1,11 @@
+function f = fracInt(f, mu)
+%FRACINT  Fractional integral of an UNBNDFUN. 
+%   Fractional integrals on unbounded domain are not supported.
+
+% Copyright 2014 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+error('CHEBFUN:UNBNDFUN:fracInt:noSupport', ...
+    'Fractional integrals on unbounded domains are not yet supported.')
+
+end

--- a/cheb2jac.m
+++ b/cheb2jac.m
@@ -25,7 +25,7 @@ if ( alph == 0 && bet == 0 )
     return
 end
 
-c_jac = cheb2jac_direct(c_cheb, alph, bet); 
+c_jac = cheb2jac_direct(c_cheb, alph, bet);
 
 end
 
@@ -37,6 +37,11 @@ function c_jac = cheb2jac_direct(c_cheb, a, b)
 %CHEB2LEG_DIRECT   Convert Cheb to Leg coeffs using the 3-term recurrence.
 [N, m] = size(c_cheb);              % Number of columns.
 N = N - 1;                          % Degree of polynomial.
+% Don't let N be too big:
+if ( N > 2^11 )
+    error('CHEBFUN:cheb2jac:arraySize', ...
+        'Maximum transform size (2048) is exceeded.');
+end
 if ( N <= 0 ), c_jac = c_cheb; return, end % Trivial case.
 f = dct1([c_cheb ; zeros(N, m)]);   % Values on 2*N+1 Chebyshev grid.
 % 2*N+1 Chebyshev grid (reversed order) and Clenshaw-Curtis-Jacobi weights:
@@ -60,7 +65,7 @@ end
 % NN = (0:N)';
 % scale = 2^(a+b+1)*gamma(NN+a+1).*gamma(NN+b+1) ./ ...
 %     ((2*NN+a+b+1).*gamma(NN+a+b+1).*factorial(NN))
-scale = zeros(N, 1);
+scale = zeros(N+1, 1);
 scale(1) = beta(a+1, b+1);
 for n = 0:N-1
     scale(n+2) = (2*n+a+b+1)*(n+a+1)*(n+b+1) / ...

--- a/cheb2jac.m
+++ b/cheb2jac.m
@@ -1,0 +1,133 @@
+function c_jac = cheb2jac(c_cheb, alph, bet)
+%CHEB2JAC   Convert Chebyshev coefficients to Jacobi coefficients. 
+%   C_JAC = CHEB2LEG(C_CHEB, A, B) converts the vector C_CHEB of Chebyshev
+%   coefficients to a vector C_JAC of Jacobi coefficients such that 
+%    C_CHEB(1)*T_0(x) + ... + C_CHEB(N)*T{N-1}(x) = ...
+%           C_LEG(1)*P_0^{(A,B)}(x) + ... + C_LEG(N)*P{N-1}^{(A,B)}(x),
+%   where P_k^{(A,B)} is the degree k Jacobi polynomial corresponding to the
+%   weight function w(x) = (1-X)^A * (1+X)^B.
+%
+%   If C_CHEB is a matrix then the CHEB2JAC operation is applied to each column.
+%
+% See also JAC2CHEB.
+
+% Copyright 2014 by The University of Oxford and The Chebfun Developers. 
+% See http://www.chebfun.org/ for Chebfun information.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% DEVELOPER NOTE:
+%  This simply uses the recurrence relation to for the Jacobi-Vandermode matrix.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+if ( alph == 0 && bet == 0 )
+    % Special case:
+    c_jac = cheb2leg(c_cheb);
+    return
+end
+
+c_jac = cheb2jac_direct(c_cheb, alph, bet); 
+
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% %%%%%%%%%%%%%%%%%%%%%%%%%%%% DIRECT METHOD %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+function c_jac = cheb2jac_direct(c_cheb, a, b)
+%CHEB2LEG_DIRECT   Convert Cheb to Leg coeffs using the 3-term recurrence.
+[N, m] = size(c_cheb);              % Number of columns.
+N = N - 1;                          % Degree of polynomial.
+if ( N <= 0 ), c_jac = c_cheb; return, end % Trivial case.
+f = dct1([c_cheb ; zeros(N, m)]);   % Values on 2*N+1 Chebyshev grid.
+% 2*N+1 Chebyshev grid (reversed order) and Clenshaw-Curtis-Jacobi weights:
+[w, x] = ccjQuadwts(2*N+1, a, b); w = fliplr(w); x = flipud(x);
+
+% Make the Jacobi-Chebyshev Vandemonde matrix:
+apb = a + b; aa  = a * a; bb  = b * b;
+P = zeros(2*N+1, N+1); P(:,1) = 1;    
+P(:,2) = 0.5*(2*(a + 1) + (apb + 2)*(x - 1));   
+for k = 2:N
+    k2 = 2*k;
+    k2apb = k2 + apb;
+    q1 =  k2*(k + apb)*(k2apb - 2);
+    q2 = (k2apb - 1)*(aa - bb);
+    q3 = (k2apb - 2)*(k2apb - 1)*k2apb;
+    q4 =  2*(k + a - 1)*(k + b - 1)*k2apb;
+    P(:,k+1) = ((q2 + q3*x).*P(:,k) - q4*P(:,k-1)) / q1;
+end
+
+% Scaling:
+% NN = (0:N)';
+% scale = 2^(a+b+1)*gamma(NN+a+1).*gamma(NN+b+1) ./ ...
+%     ((2*NN+a+b+1).*gamma(NN+a+b+1).*factorial(NN))
+scale = zeros(N, 1);
+scale(1) = beta(a+1, b+1);
+for n = 0:N-1
+    scale(n+2) = (2*n+a+b+1)*(n+a+1)*(n+b+1) / ...
+        ((n+1)*(2*n+a+b+3)*(n+a+b+1))*scale(n+1);
+end
+scale = 2^(a+b+1)*scale;
+
+% Jacobi coefficients:
+c_jac = bsxfun(@times, P.'*(bsxfun(@times, f , w.')), 1./scale); 
+
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% %%%%%%%%%%%%%%%%%%%%%%%%%%%% DCT METHODS %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+function v = dct1(c)
+%DCT1   Compute a (scaled) DCT of type 1 using the FFT. 
+% DCT1(C) returns T_N(X_N)*C, where X_N = cos(pi*(0:N))/N and T_N(X) = [T_0,
+% T_1, ..., T_N](X) where T_k is the kth 1st-kind Chebyshev polynomial.
+N = size(c, 1);                     % Number of terms.
+ii = N-1:-1:2;                      % Indicies of interior coefficients.
+c(ii,:) = 0.5*c(ii,:);              % Scale interior coefficients.
+v = ifft([c ; c(ii,:)]);            % Mirror coefficients and call FFT.
+v = (N-1)*[ 2*v(N,:) ; v(ii,:) + v(2*N-ii,:) ; 2*v(1,:) ]; % Re-order.
+v = flipud(v);                      % Flip the order.
+end
+
+function [w, x] = ccjQuadwts(n, a, b)
+%CCJQUADWTS   Clenshaw-Curtis-Jacobi quadrature weights.
+%   [W, X] = CCJQUADWTS(N, A, B) returns the N-point Clenshaw-Curtis-Jacobi
+%   quadrature nodes, X = CHEBPTS(N), and weights, W, corresponding to the
+%   weight function w(t) = (1-t)^A * (1+t)^B on the interval [-1,1].
+
+% TODO: Move this to somewhere more sensible / accessible.
+
+if ( a == b && a == 0 ) % Clenshaw-Curtis
+
+    c = 2./[1, 1-(2:2:(n-1)).^2];          % Standard Chebyshev moments
+    c = [c, c(floor(n/2):-1:2)];           % Mirror for DCT via FFT 
+    w = ifft(c);                           % Interior weights
+    w([1, n]) = w(1)/2;                    % Boundary weights
+
+elseif ( a == b )       % Gegenbauer
+    
+    l = a + .5;                            % Gegenbauer parameter
+    g0 = gamma(l+.5)*sqrt(pi)/gamma(l+1);
+    k = 1:floor((n-1)/2); 
+    c = g0*[1, cumprod((k-l-1)./(k+l))];   % Chebyshev moments for (1-x)^a(1+x)^b
+    c = [c, c(floor(n/2):-1:2)];           % Mirror for DCT via FFT 
+    w = ifft(c);                           % Interior weights
+    w([1, n]) = w(1)/2;                    % Boundary weights
+    
+else                    % Jacobi
+    
+    c = [1, (a-b)/(a+b+2), zeros(1, n-2)]; % Initialise moments
+    for r = 1:n % Recurrence relation for 3F2([r, -r, b +1 ; .5, a+b+2] ; 1 ):
+        c(r+2) = - (2*(b-a)*c(r+1) + (a+b+2-r)*c(r)) / (a+b+2+r);
+    end
+    c = 2^(a+b+1)*gamma(a+1)*gamma(b+1)/gamma(a+b+2) * c; % Moments (with const)
+    v = ifft([c(1:n), c(n-1:-1:2)]);       % Mirror for DCT via FFT 
+    w = [v(1), 2*v(2:n-1), v(n)];          % Rescale interior weights
+
+end
+
+if ( nargout > 1 )
+    x = chebtech2.chebpts(n);              % 2nd-kind Chebyshev points.
+end
+
+end

--- a/cheb2leg.m
+++ b/cheb2leg.m
@@ -1,8 +1,9 @@
 function c_leg = cheb2leg(c_cheb, normalize, M)
-%LEG2CHEB   Convert Chebyshev coefficients to Legendre coefficients. 
+%CHEB2LEG   Convert Chebyshev coefficients to Legendre coefficients. 
 %   C_LEG = CHEB2LEG(C_CHEB) converts the vector C_CHEB of Chebyshev
 %   coefficients to a vector C_LEG of Legendre coefficients such that
-%   C_CHEB(1)*T0 + ... + C_CHEB(N)*T{N-1} = C_LEG(1)*P0 + ... + C_LEG(N)*P{N-1},
+%       C_CHEB(1)*T0 + ... + C_CHEB(N)*T{N-1} = ...
+%           C_LEG(1)*P0 + ... + C_LEG(N)*P{N-1},
 %   where P{k} is the degree k Legendre polynomial normalized so that
 %   max(|P{k}|) = 1.
 % 
@@ -117,11 +118,11 @@ end
 
 function c_leg = cheb2leg_direct(c_cheb)
 %CHEB2LEG_DIRECT   Convert Cheb to Leg coeffs using the 3-term recurrence.
-[N, n] = size(c_cheb);              % Number of columns.
+[N, m] = size(c_cheb);              % Number of columns.
 N = N - 1;                          % Degree of polynomial.
 if ( N <= 0 ), c_leg = c_cheb; return, end % Trivial case.
-x = cos(.5*pi*(0:2*N)'/N);          % 2*N+1 Chebyshev grid (reversed order).
-f = dct1([c_cheb ; zeros(N,n)]);    % Values on 2*N+1 Chebyshev grid.
+x = cos(.5*pi*(0:2*N).'/N);         % 2*N+1 Chebyshev grid (reversed order).
+f = dct1([c_cheb ; zeros(N, m)]);   % Values on 2*N+1 Chebyshev grid.
 w = chebtech2.quadwts(2*N+1).';     % Clenshaw-Curtis quadrature weights.
 Pm2 = 1; Pm1 = x;                   % Initialise.
 L = zeros(2*N+1, N+1);              % Vandermonde matrix.
@@ -131,8 +132,8 @@ for k = 1:N-1 % Recurrence relation:
     Pm2 = Pm1; Pm1 = P; 
     L(:,2+k) = P;
 end
-scale = (2*(0:N).'+1)/2;            % Scaling in coefficients.
-c_leg = bsxfun(@times, L'*(bsxfun(@times, f ,w)), scale); % Legendre coeffs.
+scale = (2*(0:N).'+1)/2;            % Scaling in coefficients [NIST, (18.3.1)].
+c_leg = bsxfun(@times, L.'*(bsxfun(@times, f ,w)), scale); % Legendre coeffs.
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/jac2cheb.m
+++ b/jac2cheb.m
@@ -1,0 +1,68 @@
+function c_cheb = jac2cheb(c_jac, alph, bet)
+%LEG2CHEB convert Legendre coefficients to Chebyshev coefficients. 
+%   C_CHEB = LEG2CHEB(C_LEG) converts the vector C_LEG of Legendre coefficients
+%   to a vector C_CHEB of Chebyshev coefficients such that C_CHEB(N)*T0 + ... +
+%   C_CHEB(1)*T{N-1} = C_LEG(N)*P0 + ... + C_LEG(1)*P{N-1}, where P{k} is the
+%   degree k Legendre polynomial normalized so that max(|P{k}| = 1.
+% 
+%   C_CHEB = LEG2CHEB(C_LEG, 'norm') is as above, but with the Legendre
+%   polynomials normalized to be orthonormal.
+%
+%   If C_LEG is a matrix then the LEG2CHEB operation is applied to each column.
+%
+% See also CHEB2LEG. 
+
+% Copyright 2014 by The University of Oxford and The Chebfun Developers. 
+% See http://www.chebfun.org/ for Chebfun information.
+
+% TODO: Update documentation.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% DEVELOPER NOTE:
+%  This simply uses the recurrence relation to for the Jacobi-Vandermode matrix.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+c_cheb = jac2cheb_direct(c_jac, alph, bet); 
+
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% %%%%%%%%%%%%%%%%%%%%%%%%%%%% DIRECT METHOD %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+function c_cheb = jac2cheb_direct(c_jac, a, b)
+%JAC2CHEB_DIRECT   Convert Leg to Cheb coeffs using the 3-term recurrence.
+N = size(c_jac,1) - 1;                      % Degree of polynomial.
+if ( N <= 0 ), c_cheb = c_jac; return, end  % Trivial case.
+x = cos(pi*(0:N)'/N);                       % Chebyshev grid (reversed order).
+% Make the Jacobi-Chebyshev Vandemonde matrix:
+apb = a + b; aa  = a * a; bb  = b * b;
+P = zeros(N+1); P(:,1) = 1;    
+P(:,2) = 0.5*(2*(a + 1) + (apb + 2)*(x - 1));   
+for k = 2:N
+    k2 = 2*k;
+    k2apb = k2 + apb;
+    q1 =  k2*(k + apb)*(k2apb - 2);
+    q2 = (k2apb - 1)*(aa - bb);
+    q3 = (k2apb - 2)*(k2apb - 1)*k2apb;
+    q4 =  2*(k + a - 1)*(k + b - 1)*k2apb;
+    P(:,k+1) = ((q2 + q3*x).*P(:,k) - q4*P(:,k-1)) / q1;
+end
+v_cheb = P*c_jac;                           % Values on Chebyshev grid.
+c_cheb = idct1(v_cheb);                     % Chebyshev coefficients.
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% %%%%%%%%%%%%%%%%%%%%%%%%%%%% DCT METHODS %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+function c = idct1(v)
+%IDCT1   Convert values on a Cheb grid to Cheb coefficients (inverse DCT1).
+% IDCT1(V) returns T_N(X_N)\V, where X_N = cos(pi*(0:N))/N and T_N(X) = [T_0,
+% T_1, ..., T_N](X) where T_k is the kth 1st-kind Chebyshev polynomial.
+N = size(v, 1);                             % Number of terms.
+c = fft([v ; v(N-1:-1:2,:)])/(2*N-2);       % Laurent fold and call FFT.
+c = c(1:N,:);                               % Extract the first N terms.
+if (N > 2), c(2:N-1,:) = 2*c(2:N-1,:); end  % Scale interior coefficients.
+if ( isreal(v) ), c = real(c); end          % Ensure a real output.
+end

--- a/jac2cheb.m
+++ b/jac2cheb.m
@@ -1,26 +1,29 @@
 function c_cheb = jac2cheb(c_jac, alph, bet)
-%LEG2CHEB convert Legendre coefficients to Chebyshev coefficients. 
-%   C_CHEB = LEG2CHEB(C_LEG) converts the vector C_LEG of Legendre coefficients
-%   to a vector C_CHEB of Chebyshev coefficients such that C_CHEB(N)*T0 + ... +
-%   C_CHEB(1)*T{N-1} = C_LEG(N)*P0 + ... + C_LEG(1)*P{N-1}, where P{k} is the
-%   degree k Legendre polynomial normalized so that max(|P{k}| = 1.
-% 
-%   C_CHEB = LEG2CHEB(C_LEG, 'norm') is as above, but with the Legendre
-%   polynomials normalized to be orthonormal.
+%JAC2CHEB convert Legendre coefficients to Chebyshev coefficients. 
+%   C_CHEB = JAC2CHEB(C_JAC, A, B) converts the vector C_JAC of Jacobi
+%   coefficients to a vector C_CHEB of Chebyshev coefficients such that
+%       C_CHEB(1)*T_0(x) + ... + C_CHEB(N)*T{N-1}(x) = ...
+%           C_JAC(1)*P_0^{(A,B)}(x) + ... + C_JAC(N)*P_{N-1}^{(A,B)},
+%   where P_k^{(A,B)} is the degree k Jacobi polynomial corresponding to the
+%   weight function w(x) = (1-X)^A * (1+X)^B.
 %
 %   If C_LEG is a matrix then the LEG2CHEB operation is applied to each column.
 %
-% See also CHEB2LEG. 
+% See also CHEB2JAC. 
 
 % Copyright 2014 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.
-
-% TODO: Update documentation.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % DEVELOPER NOTE:
 %  This simply uses the recurrence relation to for the Jacobi-Vandermode matrix.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+if ( alph == 0 && bet == 0 )
+    % Special case:
+    c_cheb = leg2cheb(c_jac); 
+    return
+end
 
 c_cheb = jac2cheb_direct(c_jac, alph, bet); 
 

--- a/jac2cheb.m
+++ b/jac2cheb.m
@@ -36,6 +36,11 @@ end
 function c_cheb = jac2cheb_direct(c_jac, a, b)
 %JAC2CHEB_DIRECT   Convert Leg to Cheb coeffs using the 3-term recurrence.
 N = size(c_jac,1) - 1;                      % Degree of polynomial.
+% Don't let N be too big:
+if ( N > 2^11 )
+    error('CHEBFUN:jac2cheb:arraySize', ...
+        'Maximum transform size (2048) is exceeded.');
+end
 if ( N <= 0 ), c_cheb = c_jac; return, end  % Trivial case.
 x = cos(pi*(0:N)'/N);                       % Chebyshev grid (reversed order).
 % Make the Jacobi-Chebyshev Vandemonde matrix:

--- a/leg2cheb.m
+++ b/leg2cheb.m
@@ -1,9 +1,11 @@
 function c_cheb = leg2cheb(c_leg, normalize, M)
 %LEG2CHEB convert Legendre coefficients to Chebyshev coefficients. 
 %   C_CHEB = LEG2CHEB(C_LEG) converts the vector C_LEG of Legendre coefficients
-%   to a vector C_CHEB of Chebyshev coefficients such that C_CHEB(N)*T0 + ... +
-%   C_CHEB(1)*T{N-1} = C_LEG(N)*P0 + ... + C_LEG(1)*P{N-1}, where P{k} is the
-%   degree k Legendre polynomial normalized so that max(|P{k}| = 1.
+%   to a vector C_CHEB of Chebyshev coefficients such that 
+%       C_CHEB(1)*T0 + ... + C_CHEB(N)*T{N-1} = ...
+%           C_LEG(N)*P0 + ... + C_LEG(1)*P{N-1}, 
+%   where P{k} is the degree k Legendre polynomial normalized so that max(|P{k}|
+%   = 1.
 % 
 %   C_CHEB = LEG2CHEB(C_LEG, 'norm') is as above, but with the Legendre
 %   polynomials normalized to be orthonormal.

--- a/tests/chebfun/test_fracInt.m
+++ b/tests/chebfun/test_fracInt.m
@@ -10,7 +10,7 @@ tol = 100*pref.eps;
 dom = [0, 1];
 
 % Test values:
-xx = linspace(dom(1)+.1, dom(2)-.1, 100);
+xx = linspace(dom(1)+.1, dom(2)-.1, 10)';
 
 %% Polynomials
 x = chebfun('x', dom);
@@ -18,10 +18,11 @@ q = sqrt(2)/2;
 k = 1;
 for n = [1, 4]
     
-    xnpq = diff(x.^n, q, 'Caputo');
+    U = diff(x.^n, q, 'Caputo');
     tru = gamma(n+1)./gamma(n+1-q)*chebfun(@(x) x.^(n-q), dom, 'exps', [n-q, 0]); 
     
-    err(k) = norm(tru(xx) - xnpq(xx), inf);
+    err(k) = norm(tru(xx) - U(xx), inf);
+    tol(k) = 10*epslevel(U)*vscale(U)*hscale(U);
     k = k + 1;
     
 end
@@ -32,15 +33,32 @@ trueC = chebfun('erf(sqrt(x)).*exp(x) + 1./sqrt(pi*x)', dom, 'exps', [-.5 0]);
 trueRL = chebfun('erf(sqrt(x)).*exp(x)', dom, 'exps', [.5, 0]);
 
 % RL
-up05a = diff(u, .5, 'RL');
-err(3) = norm(trueRL(xx) - up05a(xx), inf);
+U = diff(u, .5, 'RL');
+err(3) = norm(trueRL(xx) - U(xx), inf);
+tol(3) = 10*epslevel(U)*vscale(U)*hscale(U);
 
 % Caputo
-up05b = diff(u, .5, 'Caputo');
-err(4) = norm(trueC(xx) - up05b(xx), inf);
+U = diff(u, .5, 'Caputo');
+err(4) = norm(trueC(xx) - U(xx), inf);
+tol(4) = 10*epslevel(U)*vscale(U)*hscale(U);
+
+%% Integrate twice:
+xx = linspace(-sqrt(2)*pi+.1, pi-.1, 10).';
+f = chebfun(@sin, [-sqrt(2)*pi, pi]);
+F = cumsum(f);
+G = fracInt(fracInt(f, .3), .7);
+err(5) = norm(feval(F, xx) - feval(G, xx), inf);
+tol(5) = 10*epslevel(G)*vscale(G)*hscale(G);
+
+%% Differentiate twice:
+xx = linspace(-sqrt(2)*pi+.1, pi-.1, 10)';
+f = chebfun(@sin, [-sqrt(2)*pi, pi]);
+F = diff(f);
+G = fracDiff(fracDiff(f, .3), .7);
+err(6) = norm(feval(F, xx) - feval(G, xx), inf);
+tol(6) = 10*epslevel(G)*vscale(G)*hscale(G);
 
 %%
-
 pass = err < tol;
 
 end

--- a/tests/chebfun/test_fracInt.m
+++ b/tests/chebfun/test_fracInt.m
@@ -1,0 +1,46 @@
+% Test file for fractional calculus.
+
+function pass = test_fracInt(pref)
+
+if ( nargin == 0 ) 
+    pref = chebfunpref();
+end
+
+tol = 100*pref.eps;
+dom = [0, 1];
+
+% Test values:
+xx = linspace(dom(1)+.1, dom(2)-.1, 100);
+
+%% Polynomials
+x = chebfun('x', dom);
+q = sqrt(2)/2;
+k = 1;
+for n = [1, 4]
+    
+    xnpq = diff(x.^n, q, 'Caputo');
+    tru = gamma(n+1)./gamma(n+1-q)*chebfun(@(x) x.^(n-q), dom, 'exps', [n-q, 0]); 
+    
+    err(k) = norm(tru(xx) - xnpq(xx), inf);
+    k = k + 1;
+    
+end
+
+%% Exponential
+u = chebfun('exp(x)', dom);
+trueC = chebfun('erf(sqrt(x)).*exp(x) + 1./sqrt(pi*x)', dom, 'exps', [-.5 0]);
+trueRL = chebfun('erf(sqrt(x)).*exp(x)', dom, 'exps', [.5, 0]);
+
+% RL
+up05a = diff(u, .5, 'RL');
+err(3) = norm(trueRL(xx) - up05a(xx), inf);
+
+% Caputo
+up05b = diff(u, .5, 'Caputo');
+err(4) = norm(trueC(xx) - up05b(xx), inf);
+
+%%
+
+pass = err < tol;
+
+end


### PR DESCRIPTION
Add support for fractional integrals and derivatives of **smooth** `chebfun` objects.

The key idea is to express the function as a Legendre series and then use explicit expressions for the fractional integrals of these guys from §18.17 on NIST.

For half-integrals and derivatives, this is very fast as we need only `cheb2leg()`. For arbitrary values of `mu` it's a little slower as we must convert Jacobi coefficients back to Chebyshev coefficients. This is currently done in `jac2cheb()` using an O(n^2) direct approach (i.e., using the standard recurrence relation). However, since here `mu` is in (0,1), it should be no problem to use the H-T asymptotic approach that is used in `leg2cheb`.

When it comes to adding support for piecewise smooth functions, this approach can be used to compute the 'local' contributions. 

There is some scope for computing fractional derives of functions with endpoint singularities at the left end point using NIST (18.17.9) (and flipping using symmetry), but I haven't investigated this further. I'm not sure that there are formulas for the case when the singularity is on the right.

It's not clear what to do on unbounded domains (although NIST (18.17.10) may be useful) and I'm not sure what should happen in the `trigtech` case (currently I throw an error).

Edit: typos.