### PR TITLE
Throw error in trigcoeffs when the input is not a trigfun and the number coeffs not specified

### DIFF
--- a/@chebfun/trigcoeffs.m
+++ b/@chebfun/trigcoeffs.m
@@ -50,13 +50,12 @@ end
 %% Initialize and error checking
 numFuns = numel(f.funs);
 
-% If N is not passed...
-if ( (nargin == 1) )
-    % If numFuns > 1 then throw an error
-    if ( (numFuns > 1 ) )
+% If N is not given:
+if ( nargin == 1 )
+    if ( numFuns > 1 )
         error('CHEBFUN:trigcoeffs:inputN',...
             'Input N is required for piecewise CHEBFUN objects.');
-    elseif ~isPeriodicTech(f)
+    elseif ( ~isPeriodicTech(f) )
         error('CHEBFUN:trigcoeffs:chebfun',...   
             'trigcoeffs(<chebfun>,N) is allowed but not trigcoeffs(<chebfun>).');
     else
@@ -87,7 +86,6 @@ if ( numFuns ~= 1 )
     f = merge(f);
     numFuns = numel(f.funs);
 end
-
 
 %% Compute the coefficients.
 

--- a/@chebfun/trigcoeffs.m
+++ b/@chebfun/trigcoeffs.m
@@ -53,10 +53,10 @@ numFuns = numel(f.funs);
 % If N is not given:
 if ( nargin == 1 )
     if ( numFuns > 1 )
-        error('CHEBFUN:trigcoeffs:inputN',...
+        error('CHEBFUN:CHEBFUN:trigcoeffs:inputN',...
             'Input N is required for piecewise CHEBFUN objects.');
     elseif ( ~isPeriodicTech(f) )
-        error('CHEBFUN:trigcoeffs:chebfun',...   
+        error('CHEBFUN:CHEBFUN:trigcoeffs:chebfun',...   
             'trigcoeffs(<chebfun>,N) is allowed but not trigcoeffs(<chebfun>).');
     else
         N = length(f);
@@ -68,12 +68,12 @@ if ( N <= 0 )
     return
 end
 if ( ~isscalar(N) || isnan(N) )
-    error('CHEBFUN:trigcoeffs:inputN', 'Input N must be a scalar.');
+    error('CHEBFUN:CHEBFUN:trigcoeffs:inputN', 'Input N must be a scalar.');
 end
 
 if ( any(isinf(f.domain)) )
     % Fourier coefficients are not allowed for unbounded domains.
-    error('CHEBFUN:trigcoeffs:infint', ...
+    error('CHEBFUN:CHEBFUN:trigcoeffs:infint', ...
         'Infinite intervals are not supported here.');
 end
 

--- a/@chebfun/trigcoeffs.m
+++ b/@chebfun/trigcoeffs.m
@@ -43,25 +43,29 @@ function varargout = trigcoeffs(f, N)
 
 % Trivial empty case:
 if ( isempty(f) )
-    varargout = [];
+    varargout = {};
     return
 end
 
 %% Initialize and error checking
 numFuns = numel(f.funs);
 
-% If N is not passed in and the numFuns > 1 then throw an error
-if ( (nargin == 1) && (numFuns > 1 ) )
-    error('CHEBFUN:trigcoeffs:inputN',...
-        'Input N is required for piecewise CHEBFUN objects.');
-end
-
-if ( nargin == 1 )
-    N = length(f);
+% If N is not passed...
+if ( (nargin == 1) )
+    % If numFuns > 1 then throw an error
+    if ( (numFuns > 1 ) )
+        error('CHEBFUN:trigcoeffs:inputN',...
+            'Input N is required for piecewise CHEBFUN objects.');
+    elseif ~isPeriodicTech(f)
+        error('CHEBFUN:trigcoeffs:chebfun',...   
+            'trigcoeffs(<chebfun>,N) is allowed but not trigcoeffs(<chebfun>).');
+    else
+        N = length(f);
+    end
 end
 
 if ( N <= 0 )
-    varargout = [];
+    varargout = {};
     return
 end
 if ( ~isscalar(N) || isnan(N) )

--- a/tests/chebfun/test_trigcoeffs.m
+++ b/tests/chebfun/test_trigcoeffs.m
@@ -6,7 +6,7 @@ end
 
 % Test ordering of coefficients is correct
 f_test = @(x) 1 + (2+2i)*exp(1i*2*pi*x) + (5+5i)*exp(-1i*5*pi*x);
-f = chebfun(f_test,'trig');
+f = chebfun(f_test, 'trig');
 c = trigcoeffs(f);
 c_exact = [(5+5i) 0 0 0 0 1 0 (2+2i) 0 0 0].';
 err = c-c_exact;
@@ -14,7 +14,7 @@ pass(1) = norm(err,inf) < vscale(f).*epslevel(f);
 
 % Test sin/cos coefficient form is returned correctly.
 f_test = @(x) 1 + 5*cos(5*pi*x) + 10*cos(10*pi*x) - 7*sin(7*pi*x) + 8*sin(8*pi*x); 
-f = chebfun(f_test,'trig');
+f = chebfun(f_test, 'trig');
 [a,b] = trigcoeffs(f);
 a_exact = [1 0 0 0 0 5 0 0 0 0 10].';
 b_exact = [0 0 0 0 0 0 -7 8 0 0].';
@@ -25,7 +25,7 @@ pass(2) = norm(err,inf) < vscale(f).*epslevel(f);
 % origin.
 f_test = @(x) 2 + 2*cos(2*x) + sin(x);
 dom = [-pi pi];
-f = chebfun(f_test,dom,'trig');
+f = chebfun(f_test,dom, 'trig');
 c = trigcoeffs(f);
 c_exact = [1 0.5i 2 -0.5i 1].';
 err = c-c_exact;
@@ -34,7 +34,7 @@ pass(3) = norm(err,inf) < vscale(f).*epslevel(f);
 % Now change domains and check that the same result is given for the 
 % coefficients.
 dom = [0.1 0.1+2*pi];
-f = chebfun(f_test,dom,'trig');
+f = chebfun(f_test,dom, 'trig');
 c = trigcoeffs(f);
 err = c-c_exact;
 pass(4) = norm(err,inf) < vscale(f).*epslevel(f);
@@ -45,7 +45,7 @@ try
     c = trigcoeffs(f);
     pass(5) = false;
 catch ME
-    pass(5) = strcmp(ME.identifier, 'CHEBFUN:trigcoeffs:chebfun');
+    pass(5) = strcmp(ME.identifier, 'CHEBFUN:CHEBFUN:trigcoeffs:chebfun');
 end
 
 

--- a/tests/chebfun/test_trigcoeffs.m
+++ b/tests/chebfun/test_trigcoeffs.m
@@ -6,7 +6,7 @@ end
 
 % Test ordering of coefficients is correct
 f_test = @(x) 1 + (2+2i)*exp(1i*2*pi*x) + (5+5i)*exp(-1i*5*pi*x);
-f = chebfun(f_test,'periodic');
+f = chebfun(f_test,'trig');
 c = trigcoeffs(f);
 c_exact = [(5+5i) 0 0 0 0 1 0 (2+2i) 0 0 0].';
 err = c-c_exact;
@@ -14,7 +14,7 @@ pass(1) = norm(err,inf) < vscale(f).*epslevel(f);
 
 % Test sin/cos coefficient form is returned correctly.
 f_test = @(x) 1 + 5*cos(5*pi*x) + 10*cos(10*pi*x) - 7*sin(7*pi*x) + 8*sin(8*pi*x); 
-f = chebfun(f_test,'periodic');
+f = chebfun(f_test,'trig');
 [a,b] = trigcoeffs(f);
 a_exact = [1 0 0 0 0 5 0 0 0 0 10].';
 b_exact = [0 0 0 0 0 0 -7 8 0 0].';
@@ -25,7 +25,7 @@ pass(2) = norm(err,inf) < vscale(f).*epslevel(f);
 % origin.
 f_test = @(x) 2 + 2*cos(2*x) + sin(x);
 dom = [-pi pi];
-f = chebfun(f_test,dom,'periodic');
+f = chebfun(f_test,dom,'trig');
 c = trigcoeffs(f);
 c_exact = [1 0.5i 2 -0.5i 1].';
 err = c-c_exact;
@@ -34,9 +34,19 @@ pass(3) = norm(err,inf) < vscale(f).*epslevel(f);
 % Now change domains and check that the same result is given for the 
 % coefficients.
 dom = [0.1 0.1+2*pi];
-f = chebfun(f_test,dom,'periodic');
+f = chebfun(f_test,dom,'trig');
 c = trigcoeffs(f);
 err = c-c_exact;
 pass(4) = norm(err,inf) < vscale(f).*epslevel(f);
+
+% Check for error when input is a chebfun and not a trigfun.
+try
+    f = chebfun(@(x) exp(cos(x)),dom);
+    c = trigcoeffs(f);
+    pass(5) = false;
+catch ME
+    pass(5) = strcmp(ME.identifier, 'CHEBFUN:trigcoeffs:chebfun');
+end
+
 
 end


### PR DESCRIPTION
Added code in `trigcoeffs` to throw an error when the input is a `chebfun` (instead of a `trigfun`) and a value for the number of coefficients has not been specified.

Included a test for this case.

This addresses #1334.