### PR TITLE
fix-dct-real

### DIFF
--- a/@chebfun/dct.m
+++ b/@chebfun/dct.m
@@ -32,10 +32,11 @@ switch type
         
         % Equivalent to evaluating a ChebT expansion at 2nd kind points 
         % (up to a diagonal scaling). Implemented using the connection to 
-        % a real-even DFT, see CHEBTECH2.COEFFS2VALS().
-        
-        y = fft( [ u ; u(end-1:-1:2 ,: ) ]/2 ); 
-        y = y( 1:n, : );
+        % CHEBTECH2.COEFFS2VALS().
+
+        u([1, end],:) = .5*u([1, end],:);
+        y = chebtech2.coeffs2vals(u);
+        y = y(end:-1:1,:);
         
     case 2
         
@@ -43,15 +44,14 @@ switch type
         % (up to a diagonal scaling). Also the inverse of DCT-III 
         % (up to a diagonal scaling) and this is how it is implemented.  
         
-        u = flipud( u );
-        y = ( n / 2 ) * chebtech1.vals2coeffs( u );        
+        y = ( n / 2 ) * chebtech1.vals2coeffs( u(end:-1:1,:) );        
         y(1,:) = 2 * y(1, :); 
         
     case 3
         
         % Equivalent to evaluating a ChebT expansion at 1st kind points 
         % (up to a diagonal scaling). Implemented using the connection to a 
-        % real-even DFT of half-shifted output, see CHEBTECH2.COEFFS2VALS().  
+        % real-even DFT of half-shifted output, see CHEBTECH1.COEFFS2VALS().  
         
         u(1,:) = .5*u(1, :); 
         y = chebtech1.coeffs2vals( u );    

--- a/@chebfun/dst.m
+++ b/@chebfun/dst.m
@@ -67,7 +67,7 @@ switch type
         % (up to a diagonal scaling).
 
         y = chebfun.dct( u(end:-1:1,:) , 4);
-        y = bsxfun(@times, y, (-1).^(0:n-1)' );
+        y(2:2:end,:) = -y(2:2:end,:);
         
     case 5
         % Relate DSTV of length N to a DSTI of length 2N: 

--- a/@chebfun/dst.m
+++ b/@chebfun/dst.m
@@ -32,6 +32,13 @@ switch type
         Z = zeros(1, m); 
         y = fft( [ Z ; u ; Z ; -u(end:-1:1,:)] ); 
         y = -1i*( y( 2*n+2:-1:n+3, : )/2 );
+        
+        % Ensure real/imaginary output for real/imaginary input:
+        if ( isreal(u) )
+            y = real(y);
+        elseif ( isreal(1i*u) )
+            y = imag(y);
+        end
 
     case 2
         

--- a/@chebtech1/coeffs2vals.m
+++ b/@chebtech1/coeffs2vals.m
@@ -30,21 +30,27 @@ if ( n <= 1 )
     return
 end
 
-% Pre-compute the weight vector:
-w = repmat((exp(-1i*(0:2*n-1)*pi/(2*n))/2).', 1, m);
-w(1,:) = 2*w(1, :);
-w(n+1,:) = 0;
-w(n+2:end,:) = -w(n+2:end, :);
+% Computing the weight vector often accounts for at least half the cost of this
+% transformation. Given that (a) the weight vector depends only on the length of
+% the coefficients and not the coefficients themselves and (b) that we often
+% perform repeated transforms of the same length, we store w persistently.
+persistent w
+if ( size(w,1) ~= 2*n )
+    % Pre-compute the weight vector:
+    w = (exp(-1i*(0:2*n-1)*pi/(2*n))/2).';
+    w([1, n+1]) = [2*w(1); 0];
+    w(n+2:end) = -w(n+2:end);
+end
 
 % Mirror the values for FFT:
-tmp = [coeffs(1:end,:) ; ones(1, m) ; coeffs(end:-1:2,:)];
+c_mirror = [coeffs ; ones(1, m) ; coeffs(end:-1:2,:)];
 
 % Apply the weight vector:
-tmp = tmp.*w;
-values = fft(tmp);
+c_weight = bsxfun(@times, c_mirror, w);
+values = fft(c_weight);
 
-% Truncate, flip the order, and multiply the weight vector:
-values = values(n:-1:1, :);
+% Truncate and flip the order:
+values = values(n:-1:1,:);
 
 % Post-process:
 if ( isreal(coeffs) )           

--- a/@chebtech1/vals2coeffs.m
+++ b/@chebtech1/vals2coeffs.m
@@ -23,7 +23,7 @@ function coeffs = vals2coeffs(values)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % Get the length of the input:
-[n, m] = size(values);
+n = size(values, 1);
 
 % Trivial case (constant):
 if ( n <= 1 )
@@ -31,15 +31,22 @@ if ( n <= 1 )
     return
 end
 
-% Pre-compute the weight vector:
-w = repmat(2*exp(1i*(0:n-1)*pi/(2*n)).',1,m);
+% Computing the weight vector often accounts for at least half the cost of this
+% transformation. Given that (a) the weight vector depends only on the length of
+% the coefficients and not the coefficients themselves and (b) that we often
+% perform repeated transforms of the same length, we store w persistently.
+persistent w
+if ( size(w, 1) ~= n )
+    % Pre-compute the weight vector:
+    w = 2*exp(1i*(0:n-1)*pi/(2*n)).';
+end
 
 % Mirror the values for FFT:
 tmp = [values(n:-1:1, :) ; values];
 coeffs = ifft(tmp);
 
 % Truncate, flip the order, and multiply the weight vector:
-coeffs = w.*coeffs(1:n, :);
+coeffs = bsxfun(@times, w, coeffs(1:n, :));
 
 % Scale the coefficient for the constant term:
 coeffs(1,:) = coeffs(1,:)/2;


### PR DESCRIPTION
Ensure real (imaginary) output for real (imaginary) input in DCT and DST

Closes #1380.

(This actually required very little effort, as kinds II-VIII are essentially implemented via kind I in both cases.)