### PR TITLE
Feature speed up DSTs

### DIFF
--- a/@chebfun/dct.m
+++ b/@chebfun/dct.m
@@ -32,10 +32,11 @@ switch type
         
         % Equivalent to evaluating a ChebT expansion at 2nd kind points 
         % (up to a diagonal scaling). Implemented using the connection to 
-        % a real-even DFT, see CHEBTECH2.COEFFS2VALS().
-        
-        y = fft( [ u ; u(end-1:-1:2 ,: ) ]/2 ); 
-        y = y( 1:n, : );
+        % CHEBTECH2.COEFFS2VALS().
+
+        u([1, end],:) = .5*u([1, end],:);
+        y = chebtech2.coeffs2vals(u);
+        y = y(end:-1:1,:);
         
     case 2
         
@@ -43,15 +44,14 @@ switch type
         % (up to a diagonal scaling). Also the inverse of DCT-III 
         % (up to a diagonal scaling) and this is how it is implemented.  
         
-        u = flipud( u );
-        y = ( n / 2 ) * chebtech1.vals2coeffs( u );        
+        y = ( n / 2 ) * chebtech1.vals2coeffs( u(end:-1:1,:) );        
         y(1,:) = 2 * y(1, :); 
         
     case 3
         
         % Equivalent to evaluating a ChebT expansion at 1st kind points 
         % (up to a diagonal scaling). Implemented using the connection to a 
-        % real-even DFT of half-shifted output, see CHEBTECH2.COEFFS2VALS().  
+        % real-even DFT of half-shifted output, see CHEBTECH1.COEFFS2VALS().  
         
         u(1,:) = .5*u(1, :); 
         y = chebtech1.coeffs2vals( u );    

--- a/@chebfun/dct.m
+++ b/@chebfun/dct.m
@@ -45,7 +45,7 @@ switch type
         % (up to a diagonal scaling) and this is how it is implemented.  
         
         y = ( n / 2 ) * chebtech1.vals2coeffs( u(end:-1:1,:) );        
-        y(1,:) = 2 * y(1, :); 
+        y(1,:) = 2 * y(1,:); 
         
     case 3
         
@@ -53,41 +53,40 @@ switch type
         % (up to a diagonal scaling). Implemented using the connection to a 
         % real-even DFT of half-shifted output, see CHEBTECH1.COEFFS2VALS().  
         
-        u(1,:) = .5*u(1, :); 
+        u(1,:) = .5*u(1,:); 
         y = chebtech1.coeffs2vals( u );    
-        y = flipud( y ); 
+        y = y(end:-1:1,:); 
         
     case 4 
         
         % Equivalent to evaluating a ChebV expansion at 1st kind points 
         % (up to a diagonal scaling).
-        
-        y = bsxfun( @times, u, cos(pi/2/n*((0:(n-1))'+1/2)) );
-        y = chebfun.dct( y, 2 );
-        y(2:n, :) = 2 * y(2:n, :);
-        for k = 2 : n
-            y(k, :) = y(k, :) - y(k-1, :); 
-        end
-        
+
+        v = zeros(2*n, m); 
+        v(2:2:end, :) = u; 
+        y = chebfun.dct( v, 3 );
+        y = y(1:n, :);
+
     case 5 
         
         % Relate DCTV of length N to a DCTI of length 2N: 
         y = chebfun.dct( [2*u(1, :) ; u(2:end, :) ; zeros(n, m)], 1 ); 
-        y = y(1:2:end, :);
+        y = y(1:2:end,:);
         
     case 6 
         
         % Relate DCTVI of length N to a DCTII of length 2N-1: 
         y = chebfun.dct( [u ; zeros(n-1, m)], 2 ); 
-        y = y(1:2:end, :);
+        y = y(1:2:end,:);
         
     case 7 
         
         % Relate DCTVII of length N to a DCTIII of length 2N-1: 
         v = zeros(2*n-1, m); 
-        v(1:2:end, :) = [2*u(1,:) ; u(2:end,:)]; 
+        v(1:2:end,:) = u; 
+        v(1,:) = 2*v(1,:);
         y = chebfun.dct( v, 3 );
-        y = y(1:n, :);
+        y = y(1:n,:);
         
     case 8 
             

--- a/@chebfun/dst.m
+++ b/@chebfun/dst.m
@@ -67,7 +67,7 @@ switch type
         % (up to a diagonal scaling).
 
         y = chebfun.dct( u(end:-1:1,:) , 4);
-        y = bsxfun(@times, y, (-1).^(0:n-1)' );
+        y(2:2:end,:) = -y(2:2:end,:);
         
     case 5
         % Relate DSTV of length N to a DSTI of length 2N: 

--- a/@chebfun/dst.m
+++ b/@chebfun/dst.m
@@ -43,24 +43,51 @@ switch type
     case 2
         
         % Equivalent to evaluating a ChebW expansion at 2nd kind points 
-        % (up to a diagonal scaling). Also the inverse of DST-III.  
-        y = u;
-        for k = n - 1 : -1 : 1
-            y(k, :) = y(k, :) - y(k+1, :); 
-        end
-        y = chebfun.dst(y, 4);
-        y = bsxfun( @times, y, 2*cos(pi/2/n*((0:n-1)'+1/2)) );
+        % (up to a diagonal scaling). Also the inverse of DST-III.
+
+        
+%         e = ones(n,1);
+%         S = spdiags([e, e], 0:1, n, n);
+%         y = S\u;
+%         y = chebfun.dst(y, 4);
+%         w = 2*cos(pi/2/n*((0:n-1)'+1/2));
+%         y = bsxfun( @times, y, w );
+
+        % Weights:  
+%         persistent w1 w2 %#ok<TLEV>
+%         if ( size(w1,1) ~= n )
+            w1 = sin( .5*pi*(0:n).'/n );
+            w2 = cos( .5*pi*(1:n-1).'/n );
+%         end
+        W1 = repmat(w1, 1, m);
+        W2 = repmat(w2, 1, m);
+        z = zeros(1, m);
+        
+        v1 = chebfun.dct( W1.*[z ; u(1:end-1,:) ; 2*u(end,:)], 1); 
+        v2 = chebfun.dst( W2.*u(1:end-1,:), 1);
+        y =  [v2 ; z] - v1(2:end,:);
         
     case 3
         
         % Equivalent to evaluating a ChebU expansion at 1st kind points 
-        % (up to a diagonal scaling).  
-        u(n, :) = .5 * u(n, :);
-        y = bsxfun(@times, u, 2*cos(pi/2/n*((0:n-1)'+1/2)) );
-        y = chebfun.dst( y, 4 );
-        for k = 2 : n
-            y(k, :) = y(k, :) - y(k-1, :); 
-        end
+        % (up to a diagonal scaling). 
+        
+%         u(n, :) = .5 * u(n, :);
+%         y = bsxfun(@times, u, 2*cos(pi/2/n*((0:n-1)'+1/2)) );
+%         y = chebfun.dst( y, 4 );
+%         for k = 2 : n
+%             y(k, :) = y(k, :) - y(k-1, :); 
+%         end
+        
+        w1 = sin( .5*pi*(0:n)'/n );
+        w2 = cos( .5*pi*(1:n)'/n );
+        W1 = repmat(w1, 1, m);
+        W2 = repmat(w2, 1, m);
+        z = zeros(1, m);
+
+        v1 = W1.*chebfun.dct( [ z ; u ], 1); 
+        v2 = W2.*[ chebfun.dst( u(1:end-1,:), 1) ; z ];
+        y = v2 - v1(2:end,:);
         
     case 4 
         % Equivalent to evaluating a ChebW expansion at 1st kind points 
@@ -68,7 +95,7 @@ switch type
 
         y = chebfun.dct( u(end:-1:1,:) , 4);
         y(2:2:end,:) = -y(2:2:end,:);
-        
+                
     case 5
         % Relate DSTV of length N to a DSTI of length 2N: 
         y = chebfun.dst( [ u ; zeros(n, m)], 1);
@@ -76,9 +103,9 @@ switch type
         
     case 6
         % Relate DSTVI of length N to a DSTII of length 2N-1: 
-        v = zeros(2*n, m); 
-        v(1:2:end, :) = u; 
-        y = chebfun.dst( v, 1);
+        y = zeros(2*n, m); 
+        y(1:2:end, :) = u; 
+        y = chebfun.dst( y, 1);
         y = y(1:n,:); 
         
     case 7

--- a/@chebfun/dst.m
+++ b/@chebfun/dst.m
@@ -16,6 +16,8 @@ function y = dst(u, type)
 % Copyright 2014 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
+persistent w1 w2 %#ok<TLEV>
+
 % Default to kind 1:
 if ( nargin < 2 )
     type = 1;
@@ -45,22 +47,13 @@ switch type
         % Equivalent to evaluating a ChebW expansion at 2nd kind points 
         % (up to a diagonal scaling). Also the inverse of DST-III.
 
-        
-%         e = ones(n,1);
-%         S = spdiags([e, e], 0:1, n, n);
-%         y = S\u;
-%         y = chebfun.dst(y, 4);
-%         w = 2*cos(pi/2/n*((0:n-1)'+1/2));
-%         y = bsxfun( @times, y, w );
-
         % Weights:  
-%         persistent w1 w2 %#ok<TLEV>
-%         if ( size(w1,1) ~= n )
+        if ( size(w1, 1) ~= n+1 )
             w1 = sin( .5*pi*(0:n).'/n );
-            w2 = cos( .5*pi*(1:n-1).'/n );
-%         end
+            w2 = cos( .5*pi*(1:n).'/n );
+        end
         W1 = repmat(w1, 1, m);
-        W2 = repmat(w2, 1, m);
+        W2 = repmat(w2(1:end-1), 1, m);
         z = zeros(1, m);
         
         v1 = chebfun.dct( W1.*[z ; u(1:end-1,:) ; 2*u(end,:)], 1); 
@@ -71,16 +64,11 @@ switch type
         
         % Equivalent to evaluating a ChebU expansion at 1st kind points 
         % (up to a diagonal scaling). 
-        
-%         u(n, :) = .5 * u(n, :);
-%         y = bsxfun(@times, u, 2*cos(pi/2/n*((0:n-1)'+1/2)) );
-%         y = chebfun.dst( y, 4 );
-%         for k = 2 : n
-%             y(k, :) = y(k, :) - y(k-1, :); 
-%         end
-        
-        w1 = sin( .5*pi*(0:n)'/n );
-        w2 = cos( .5*pi*(1:n)'/n );
+
+        if ( size(w1, 1) ~= n+1 )
+            w1 = sin( .5*pi*(0:n)'/n );
+            w2 = cos( .5*pi*(1:n)'/n );
+        end
         W1 = repmat(w1, 1, m);
         W2 = repmat(w2, 1, m);
         z = zeros(1, m);

--- a/@chebfun/dst.m
+++ b/@chebfun/dst.m
@@ -32,6 +32,13 @@ switch type
         Z = zeros(1, m); 
         y = fft( [ Z ; u ; Z ; -u(end:-1:1,:)] ); 
         y = -1i*( y( 2*n+2:-1:n+3, : )/2 );
+        
+        % Ensure real/imaginary output for real/imaginary input:
+        if ( isreal(u) )
+            y = real(y);
+        elseif ( isreal(1i*u) )
+            y = imag(y);
+        end
 
     case 2
         

--- a/@chebfun/idst.m
+++ b/@chebfun/idst.m
@@ -67,7 +67,8 @@ switch type
         
     case 8
         
-        error('CHEBFUN:CHEBFUN:IDST:EIGHT','Not implemented')
+%         error('CHEBFUN:CHEBFUN:IDST:EIGHT', 'Not implemented')
+        y = NaN;
         
     otherwise
     

--- a/@chebtech1/coeffs2vals.m
+++ b/@chebtech1/coeffs2vals.m
@@ -30,21 +30,27 @@ if ( n <= 1 )
     return
 end
 
-% Pre-compute the weight vector:
-w = repmat((exp(-1i*(0:2*n-1)*pi/(2*n))/2).', 1, m);
-w(1,:) = 2*w(1, :);
-w(n+1,:) = 0;
-w(n+2:end,:) = -w(n+2:end, :);
+% Computing the weight vector often accounts for at least half the cost of this
+% transformation. Given that (a) the weight vector depends only on the length of
+% the coefficients and not the coefficients themselves and (b) that we often
+% perform repeated transforms of the same length, we store w persistently.
+persistent w
+if ( size(w,1) ~= 2*n )
+    % Pre-compute the weight vector:
+    w = (exp(-1i*(0:2*n-1)*pi/(2*n))/2).';
+    w([1, n+1]) = [2*w(1); 0];
+    w(n+2:end) = -w(n+2:end);
+end
 
 % Mirror the values for FFT:
-tmp = [coeffs(1:end,:) ; ones(1, m) ; coeffs(end:-1:2,:)];
+c_mirror = [coeffs ; ones(1, m) ; coeffs(end:-1:2,:)];
 
 % Apply the weight vector:
-tmp = tmp.*w;
-values = fft(tmp);
+c_weight = bsxfun(@times, c_mirror, w);
+values = fft(c_weight);
 
-% Truncate, flip the order, and multiply the weight vector:
-values = values(n:-1:1, :);
+% Truncate and flip the order:
+values = values(n:-1:1,:);
 
 % Post-process:
 if ( isreal(coeffs) )           

--- a/@chebtech1/coeffs2vals.m
+++ b/@chebtech1/coeffs2vals.m
@@ -35,7 +35,7 @@ end
 % the coefficients and not the coefficients themselves and (b) that we often
 % perform repeated transforms of the same length, we store w persistently.
 persistent w
-if ( size(w,1) ~= 2*n )
+if ( size(w, 1) ~= 2*n )
     % Pre-compute the weight vector:
     w = (exp(-1i*(0:2*n-1)*pi/(2*n))/2).';
     w([1, n+1]) = [2*w(1); 0];

--- a/@chebtech1/vals2coeffs.m
+++ b/@chebtech1/vals2coeffs.m
@@ -23,7 +23,7 @@ function coeffs = vals2coeffs(values)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % Get the length of the input:
-[n, m] = size(values);
+n = size(values, 1);
 
 % Trivial case (constant):
 if ( n <= 1 )
@@ -31,15 +31,22 @@ if ( n <= 1 )
     return
 end
 
-% Pre-compute the weight vector:
-w = repmat(2*exp(1i*(0:n-1)*pi/(2*n)).',1,m);
+% Computing the weight vector often accounts for at least half the cost of this
+% transformation. Given that (a) the weight vector depends only on the length of
+% the coefficients and not the coefficients themselves and (b) that we often
+% perform repeated transforms of the same length, we store w persistently.
+persistent w
+if ( size(w, 1) ~= n )
+    % Pre-compute the weight vector:
+    w = 2*exp(1i*(0:n-1)*pi/(2*n)).';
+end
 
 % Mirror the values for FFT:
 tmp = [values(n:-1:1, :) ; values];
 coeffs = ifft(tmp);
 
 % Truncate, flip the order, and multiply the weight vector:
-coeffs = w.*coeffs(1:n, :);
+coeffs = bsxfun(@times, w, coeffs(1:n, :));
 
 % Scale the coefficient for the constant term:
 coeffs(1,:) = coeffs(1,:)/2;

--- a/@chebtech2/coeffs2vals.m
+++ b/@chebtech2/coeffs2vals.m
@@ -34,7 +34,7 @@ end
 coeffs(2:n-1,:) = coeffs(2:n-1,:)/2;
 
 % Mirror the coefficients (to fake a DCT using an FFT):
-tmp = [ coeffs(1:n,:) ; coeffs(n-1:-1:2,:) ];
+tmp = [ coeffs ; coeffs(n-1:-1:2,:) ];
 
 if ( isreal(coeffs) )
     % Real-valued case:

--- a/ultrapoly.m
+++ b/ultrapoly.m
@@ -2,7 +2,7 @@ function p = ultrapoly(n, lam, dom)
 %ULTRAPOLY   Ultraspherical polynomials.
 %   P = ULTRAPOLY(N, LAM) computes a CHEBFUN of the ultraspherical polynomial of
 %   degree N with parameters LAM, where the weight function is defined by w(x) =
-%   (1-x^2)^(LAM-.5). N may be a vector of integers.
+%   (1-x^2)^(LAM-.5). N may be a vector of integers. LAM must be positive.
 %
 %   Normalization is chosen to be consistent with the formulas in [1, $18]. In
 %   particular, feval(P, 1) = (2*LAM)_n/n! and feval(P, 0) = (-1)^n(LAM)_n/n!,
@@ -35,6 +35,12 @@ if ( any(isinf(dom)) )
     error('CHEBFUN:ultrapoly:infdomain', ...
         'Ultraspherical polynomials are not defined over an unbounded domain.');
 end
+if ( lam <= 0 )
+    error('CHEBFUN:ultrapoly:infdomain', ...
+        'Ultraspherical polynomials are not defined for LAMBA <= 0.');
+end
+
+
 
 if ( lam == .5 ) 
    % Equivalent to LEGPOLY: 

--- a/ultrapoly.m
+++ b/ultrapoly.m
@@ -40,8 +40,6 @@ if ( lam <= 0 )
         'Ultraspherical polynomials are not defined for LAMBA <= 0.');
 end
 
-
-
 if ( lam == .5 ) 
    % Equivalent to LEGPOLY: 
    p = legpoly(n, dom);


### PR DESCRIPTION
This is branched off of `fix-dct-real`.

The images below demonstrate the speed up relative to the DST-III (which was unchanged here):

Old:
![dct_time_old](https://cloud.githubusercontent.com/assets/2035010/6062437/7733e812-ad58-11e4-9349-3f21f76555af.png)

New:
![dct_time_new](https://cloud.githubusercontent.com/assets/2035010/6062436/7730a260-ad58-11e4-8c9a-ab244ed7dce1.png)

I don't understand why the higher-number DCTs have gotten worse, however..

Edit: Actually, DCT-III was changed - it got *faster*. This is why DCT-V--VIII appear to have gotten worse.

