### PR TITLE
Feature outer product operator

### DIFF
--- a/@blockFunction/blockFunction.m
+++ b/@blockFunction/blockFunction.m
@@ -118,9 +118,9 @@ classdef blockFunction
         end
 
         function F = mult(A, f)
-            %MULT
-            %
-            % Returns a BLOCKFUNCTION corresponding to a call to CHEBFUN/TIMES.
+        %MULT
+        %
+        % Returns a BLOCKFUNCTION corresponding to a call to CHEBFUN/TIMES.
             
             % Note, we wrap this in a nested function to support scalar
             % expansion.
@@ -145,18 +145,26 @@ classdef blockFunction
             C = blockFunction( @(z) A.func(z) + B.func(z) );
         end
 
+        function F = outer(A, f, g)
+        %OUTER
+        %
+        % Returns a BLOCKFUNCTION corresponding to a call to CHEBFUN/MTIMES
+        % with the outer product of two CHEBFUNs F and G.         
+            F = blockFunction( @(z) f * (g*z) );      
+        end
+
         function S = sum(A)
         %SUM
         %
         % Returns a BLOCKFUNCTION corresponding to a call to chebfun/sum.
             S = blockFunction( @(z) sum(z) );
         end
-        
+
         function C = uminus(A)
         %-     Unary minus of BLOCKFUNCTION.
             C = blockFunction( @(z) -A.func(z) );
         end
-        
+
         function A = uplus(A)
         %-     Unary plus of BLOCKFUNCTION.
         end      
@@ -168,7 +176,7 @@ classdef blockFunction
         % zero scalar.
             z = blockFunction( @(u) 0 );
         end
-        
+
         function Z = zeros(A)
         %ZEROS
         %
@@ -176,7 +184,7 @@ classdef blockFunction
         % zero chebfun.
             Z = blockFunction( @(z) chebfun(0, A.domain) );
         end
-        
+
     end
     
 end

--- a/@chebfun/chebfun.m
+++ b/@chebfun/chebfun.m
@@ -353,7 +353,7 @@ classdef chebfun
         out = iszero(f)
         
         % Kronecker product of two CHEBFUN object.
-        out = kron(f, g)
+        out = kron(f, g, varargin)
         
         % Length of a CHEBFUN.
         [out, out2] = length(f);

--- a/@chebfun/kron.m
+++ b/@chebfun/kron.m
@@ -70,21 +70,15 @@ elseif ( nargin == 3 )
         'CHEBFUN:CHEBFUN:kron:domain',...
         'Domains must be identical for Kronecker products returning operators.')
     
-    for i = 1:size(numColumns(f))
+    for i = 1:size(numel(f))
         fi = f(:, i);
         gi = g(:, i);
-        op = @(u) fi * (gi*u);  % operational form
-        h = operatorBlock.outer(fi, gi, fDom);
-%         % Matrix form available only for unsplit functions.
-%         if fi.nfuns==1 && gi.nfuns==1
-%             x = @(n) d(1) + (1+sin(pi*(2*(1:n)'-n-1)/(2*n-2)))/2*length(d);
-%             C = cumsum(d);
-%             w = C(end,:);  % Clenshaw-Curtis weights, any n
-%             mat = @(n) matfun(n,w,x,fi,gi);
-%         else
-%             mat = [];
-%         end
-%         h = h + linop(mat,op,d);
+        
+        assert( numColumns(fi) == numColumns(gi), ...
+            'CHEBFUN:CHEBFUN:kron:nomColumns', ...
+            'The number of columns in input CHEBFUNs must agree');
+        
+        h = h + operatorBlock.outer(fi, gi, fDom);
     end
 else
     error('CHEBFUN:CHEBFUN:kron:nargin','Too many input arguments.');

--- a/@chebfun/kron.m
+++ b/@chebfun/kron.m
@@ -1,58 +1,95 @@
-function h = kron(f, g)
-%KRON   Kronecker/outer product of two chebfuns.
-%   H = KRON(F,G) where F and G are array-valued CHEBFUN objects constructs a
-%   CHEBFUN2.  If size(F) = [Inf, K] and size(G) = [K, Inf] then H is a rank K
-%   CHEBFUN2 such that
-%       H(x,y) = F(y,1)G(x,1) + ... + F(y,K)G(x,K).
+function h = kron(f, g, varargin)
+%KRON   Kronecker/outer product of two CHEBFUNs.
 %
-%   If size(F) = [K,Inf] and size(G) = [Inf, K] then H is a chebfun2 such that
-%       H(x,y) = G(y,1)F(x,1) + ... + G(y,K)F(x,K).
+% H = KRON(F,G) where F and G are array-valued CHEBFUN objects constructs a
+% CHEBFUN2.  If size(F) = [Inf, K] and size(G) = [K, Inf] then H is a rank K
+% CHEBFUN2 such that
+%
+%   H(x,y) = F(y,1)G(x,1) + ... + F(y,K)G(x,K).
+%
+% If size(F) = [K,Inf] and size(G) = [Inf, K] then H is a chebfun2 such that
+% 
+%   H(x,y) = G(y,1)F(x,1) + ... + G(y,K)F(x,K).
+%
+% This is function analogue of the MATLAB command KRON.
+%
+% H = KRON(F, G, 'op') or H = KRON(F, G, 'operator') if size(F) = [Inf, K] and
+% size(G) = [K, Inf], results in a rank-k CHEBMATRIX A such that A*U = F*(G*U)
+% for any CHEBFUN U.
 %
 % See also KRON.
 
 % Copyright 2014 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-% TODO: Add a third argument to this command to allow the outerproduct of
-% LINOPs/CHEBOPs. 
-
-if ( ( ~isa(f, 'chebfun') || ~isa(g, 'chebfun') ) )
-    error('CHEBFUN:CHEBFUN:kron:inputs', 'Both inputs should be CHEBFUNs.');
-end
+assert( isa(f, 'chebfun') && isa(g, 'chebfun'), ...
+    'CHEBFUN:CHEBFUN:kron:inputs', ...
+    'Both inputs should be CHEBFUNs.')
 
 if ( isempty(f) || isempty(g) )
     h = chebfun2();  % Return empty CHEBFUN2.
     return
 end
 
-% Get domains of CHEBFUNs:
+% Get domains of CHEBFUNs, and check that they don't contain breakpoints:
 fDom = f.domain;
 gDom = g.domain;
+assert( length(fDom) <=2 && length(gDom) <=2, ...
+    'CHEBFUN:CHEBFUN:kron:breakpts', ...
+     'The two CHEBFUNs must be smooth and contain no break points.')
 
-if ( (length(fDom) > 2) || (length(gDom) > 2) )
-    error('CHEBFUN:CHEBFUN:kron:breakpts',...
-        'The two CHEBFUNs must be smooth and contain no break points.');
-end
-
-% check if we have the right sizes:
+% Check if we have the right sizes:
 [mf, nf] = size( f );
 [mg, ng] = size( g );
+assert( (mf == ng) && (nf == mg), ...
+    'CHEBFUN:CHEBFUN:kron:sizes',...
+    'Inconsistent sizes for the Kronecker product of CHEBFUNs.');
 
-if ( (mf ~= ng) || (nf ~= mg) )
-    error('CHEBFUN:CHEBFUN:kron:sizes',...
-        'Inconsistent sizes for the Kronecker product of CHEBFUNs.');
-end
+if ( nargin <= 2 )
 
-if ( isinf( nf ) )  
-    % size(F) = [K,Inf] and size(G) = [Inf, K]
-    h = chebfun2.outerProduct(g, f);
+    if ( isinf( nf ) )
+        % size(F) = [K,Inf] and size(G) = [Inf, K]
+        h = chebfun2.outerProduct(g, f);
+        
+    else
+        % size(F) = [Inf, K] and size(G) = [K, Inf]
+        h = chebfun2.outerProduct(f, g);
+    end
     
+elseif ( nargin == 3 )
+    % Historically, this used to be called by F*G', where F and G where two
+    % CHEBFUNs.  Thus functionality has been moved to here since F*G' now
+    % returns a low rank CHEBFUN2.
+    
+    assert( strcmpi(varargin{1}, 'op') || strcmpi(varargin{1}, 'operator'), ...
+        'CHEBFUN:CHEBFUN:kron:opts', ...
+        'Unrecognized optional parameter.');
+
+    h = 0;
+    assert( all(fDom == gDom), ...
+        'CHEBFUN:CHEBFUN:kron:domain',...
+        'Domains must be identical for Kronecker products returning operators.')
+    
+    for i = 1:size(numColumns(f))
+        fi = f(:, i);
+        gi = g(:, i);
+        op = @(u) fi * (gi*u);  % operational form
+        h = operatorBlock.outer(fi, gi, fDom);
+%         % Matrix form available only for unsplit functions.
+%         if fi.nfuns==1 && gi.nfuns==1
+%             x = @(n) d(1) + (1+sin(pi*(2*(1:n)'-n-1)/(2*n-2)))/2*length(d);
+%             C = cumsum(d);
+%             w = C(end,:);  % Clenshaw-Curtis weights, any n
+%             mat = @(n) matfun(n,w,x,fi,gi);
+%         else
+%             mat = [];
+%         end
+%         h = h + linop(mat,op,d);
+    end
 else
-    % size(F) = [Inf, K] and size(G) = [K, Inf]
-    h = chebfun2.outerProduct(f, g);
-    
+    error('CHEBFUN:CHEBFUN:kron:nargin','Too many input arguments.');
 end
-
+    
 
 end
 

--- a/@colloc/outer.m
+++ b/@colloc/outer.m
@@ -1,0 +1,19 @@
+function F = outer(disc, f, g)
+%OUTER   Outer product operator in COLLOC.
+
+% Copyright 2014 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+% Obtain the collocation points and associated weights.
+[x, w] = functionPoints(disc);
+
+% Evaluate F and G at the grid:
+fx = feval(f, x);
+gx = feval(g, x);
+
+% Repmat the weights W if needed (in case of array valued CHEBFUNs)
+w = repmat(w, size(fx, 2), 1);
+% Take the outer product to obtain the matrix we desire.
+F = fx * (w .* gx);
+
+end

--- a/@operatorBlock/operatorBlock.m
+++ b/@operatorBlock/operatorBlock.m
@@ -369,6 +369,37 @@ classdef (InferiorClasses = {?chebfun}) operatorBlock < linBlock
             M.stack = @(z) mult(z, u);
             M.diffOrder = 0;
         end
+        
+        function M = outer(f, g, dom)
+        %OPERATORBLOCK.OUTER   Outer product operator.
+        %   M = OPERATORBLOCK.MULT(F, G) returns the outer product operator from
+        %   the column CHEBFUN f and the row CHEBFUN g, i.e. the operator that
+        %   maps a CHEBFUN h(x) to f(x) * (g(x)*h(x)). Note that the second
+        %   multiplication corresponds to taking the inner product between g and
+        %   h.
+        %
+        %   M = OPERATORBLOCK.MULT(F, G, DOM) allows passing a domain on which
+        %   the multiplication operator is to be constructed.
+
+            % Check whether domain information was passed
+            if ( nargin < 3 )
+                % Ensure that F and G have the same domains, without any
+                % breakpoints
+                fDom = f.domain;
+                gDom = g.domain;
+                assert( (length(fDom) <= 2) && (length(gDom) <=2) && ...
+                    all(fDom == gDom), ...
+                    'CHEBFUN:OPERATORBLOCK:outer:domain', ...
+                    ['The domains of the inputs must be the same, and not ' ...
+                     'contain any breakpoints.']);
+                dom = f.domain(1:2);
+            end
+
+            % Create the OPERATORBLOCK with information now available.
+            M = operatorBlock(dom);
+            M.stack = @(z) outer(z, f, g);
+            M.diffOrder = 0;
+        end
 
         function V = volt(kernel, domain, varargin)
         %VOLT   Volterra integral operator.

--- a/tests/chebfun/test_kron.m
+++ b/tests/chebfun/test_kron.m
@@ -7,6 +7,8 @@ end
 
 tol = 200*pref.eps; 
 
+%% Kronecker products resulting in CHEBFUN2 objects
+
 % Rank 1 chebfun2 
 f = chebfun(@(x) x.^2, pref);
 g = chebfun(@(y) sin(y), pref);

--- a/tests/chebfun/test_kronOp.m
+++ b/tests/chebfun/test_kronOp.m
@@ -1,0 +1,54 @@
+function pass = test_kronOp(pref) 
+% Test the chebfun/kron() command, resulting in OPERATORBLOCK objects. 
+
+if ( nargin < 1 ) 
+    pref = chebfunpref(); 
+end 
+
+tol = 200*pref.eps; 
+d = [0,1];
+x = chebfun(@(x) x, d); 
+xx1 = chebpts(200, d, 1);
+xx2 = chebpts(200, d, 2);
+xxe = trigpts(200, d);
+%% Simple outer product, only single column CHEBFUNs involved
+f = sin(x);
+g = tanh(x);
+h = cos(x);
+A = kron(f, g', 'op');
+Ah = f * (g'*h);
+AC = chebmatrix(A);
+% Operational form
+pass(1) = norm(Ah - A*h) < tol;
+% Discrete form
+pass(2) = norm(Ah(xx1) - matrix(AC, 200, @chebcolloc1)*h(xx1)) < tol;
+pass(3) = norm(Ah(xx2) - matrix(AC, 200, @chebcolloc2)*h(xx2)) < tol;
+%% Single column CHEBFUNs, periodic to test trigcolloc as well
+f = exp(sin(4*pi*x));
+g = tanh(.5*cos(2*pi*x));
+h = cos(2*pi*x);
+A = kron(f, g', 'op');
+Ah = f * (g'*h);
+AC = chebmatrix(A);
+% Operational form
+pass(4) = norm(Ah - A*h) < tol;
+% Discrete form
+pass(5) = norm(Ah(xx1) - matrix(AC, 200, @chebcolloc1)*h(xx1)) < tol;
+pass(6) = norm(Ah(xx2) - matrix(AC, 200, @chebcolloc2)*h(xx2)) < tol;
+pass(7) = norm(Ah(xxe) - matrix(AC, 200, @trigcolloc)*h(xxe)) < tol;
+%% Multiple columns/rows (taken from v4 test)
+f = [ exp(x), tanh(x) ];
+g = [ exp(x), x./(1+x.^2) ];
+u = x;
+
+A = kron(f,g','op');
+AC = chebmatrix(A);
+Au = (exp(x) + (1-pi/4)*tanh(x));
+
+% Operational form
+pass(8) = norm( Au - A*u ) < tol;
+% Discrete form
+pass(9)  = norm( Au(xx1) - matrix(AC, 200, @chebcolloc1)*u(xx1) ) < tol;
+pass(10) = norm( Au(xx2) - matrix(AC, 200, @chebcolloc2)*u(xx2) ) < tol;
+
+end

--- a/tests/chebfun/test_mtimes.m
+++ b/tests/chebfun/test_mtimes.m
@@ -1,9 +1,6 @@
 % Test file for @chebfun/mtimes.m.
 
 function pass = test_mtimes(pref)
-
-% TODO: Test Chebfun2 outerproducts!
-
 % Get preferences.
 if (nargin < 1)
     pref = chebfunpref();
@@ -209,6 +206,60 @@ pass(60) = causesDimensionError(@() A*A);
 pass(61) = causesDimensionError(@() A'*A');
 pass(62) = causesDimensionError(@() Q*Q);
 pass(63) = causesDimensionError(@() Q'*Q');
+
+%% Chebfun2 outerproducts
+% These are the same as in test_kron, just want to ensure that the syntax works!
+% Rank 1 chebfun2 
+f = chebfun(@(x) x.^2, pref);
+g = chebfun(@(y) sin(y), pref);
+ 
+h1 = chebfun2(@(x,y) x.^2.*sin(y));
+h2 = chebfun2(@(x,y) y.^2.*sin(x)); 
+
+pass(64) = (norm(h1 - kron(f', g)) < tol);
+pass(65) = (norm(h2 - kron(f, g')) < tol); 
+pass(66) = (norm(h1 - g*f') < tol); 
+pass(67) = (norm(h2 - f*g') < tol); 
+
+% Different domain in x and y  
+d = [-2 pi -pi 2];
+f = chebfun(@(x) x.^2, d(1:2), pref);
+g = chebfun(@(y) sin(y), d(3:4), pref);
+ 
+h1 = chebfun2(@(x,y) x.^2.*sin(y), d);
+h2 = chebfun2(@(x,y) y.^2.*sin(x), [d(3:4) d(1:2)]); 
+
+pass(68) = ( norm(h1 - kron(f', g)) < tol); 
+pass(69) = (norm(h2 - kron(f, g')) < tol);
+pass(70) = ( norm(h1 - g*f') < tol);
+pass(71) = (norm(h2 - f*g') < tol); 
+
+% Quasimatrices and rank 4 chebfun2
+x = chebfun('x', [-1 1], pref);
+F = [1 x x.^2 x.^4]; 
+G = [1 cos(x) sin(x) x.^5]; 
+
+h1 = chebfun2(@(x,y) 1 + x.*cos(y) + x.^2.*sin(y) + x.^4.*y.^5);
+h2 = chebfun2(@(x,y) 1 + y.*cos(x) + y.^2.*sin(x) + y.^4.*x.^5);
+
+pass(72) = (norm(h1 - kron(F', G)) < tol); 
+pass(73) = (norm(h2 - kron(F, G')) < tol); 
+pass(74) = (norm(h1 - G*F') < tol); 
+pass(75) = (norm(h2 - F*G') < tol); 
+
+% Different domains and quasimatrices 
+x = chebfun('x',[-2 1], pref); 
+y = chebfun('x',[-1 1], pref); 
+d = [-2 1 -1 1]; 
+F = [1 x x.^2 x.^4]; 
+G = [1 cos(y) sin(y) y.^5]; 
+h1 = chebfun2(@(x,y) 1 + x.*cos(y) + x.^2.*sin(y) + x.^4.*y.^5,d);
+h2 = chebfun2(@(x,y) 1 + y.*cos(x) + y.^2.*sin(x) + y.^4.*x.^5,[d(3:4) d(1:2)]);
+
+pass(76) = (norm(h1 - kron(F', G)) < tol); 
+pass(77) = (norm(h2 - kron(F, G')) < tol); 
+pass(78) = (norm(h1 - G*F') < tol);
+pass(79) = (norm(h2 - F*G') < tol);
 
 end
 


### PR DESCRIPTION
Introducing capabilities for taking the outer product of two CHEBFUNs and getting an OPERATORBLOCK, rather than a CHEBFUN2.

Closes #180 (an issue that's precisely one year old today!) and #1382.