### PR TITLE
Features GAMMA and NCHOOSEK for chebfuns

### DIFF
--- a/@chebfun/gamma.m
+++ b/@chebfun/gamma.m
@@ -1,0 +1,21 @@
+function F = gamma(F, varargin)
+%GAMMA   Gamma function of a CHEBFUN.
+%   GAMMA(F) computes the composition of the gamma function with F.
+%
+%   GAMMA(F, PREF) does the same but uses the CHEBFUNPREF object PREF when
+%   computing the composition.
+
+% Copyright 2014 by The University of Oxford and The Chebfun Developers. See
+% http://www.chebfun.org/ for Chebfun information.
+
+% [TODO]:  Restore or change this once we have decided the proper behavior or
+% isfinite() and defined that function.
+%if ( ~isfinite(f) )
+%    error('CHEBFUN:CHEBFUN:cos:inf',...
+%        'COS is not defined for functions which diverge to infinity');
+%end
+
+% Call the compose method:
+F = compose(F, @gamma, varargin{:});
+
+end

--- a/@chebfun/gamma.m
+++ b/@chebfun/gamma.m
@@ -8,13 +8,6 @@ function F = gamma(F, varargin)
 % Copyright 2014 by The University of Oxford and The Chebfun Developers. See
 % http://www.chebfun.org/ for Chebfun information.
 
-% [TODO]:  Restore or change this once we have decided the proper behavior or
-% isfinite() and defined that function.
-%if ( ~isfinite(f) )
-%    error('CHEBFUN:CHEBFUN:cos:inf',...
-%        'COS is not defined for functions which diverge to infinity');
-%end
-
 % Call the compose method:
 F = compose(F, @gamma, varargin{:});
 

--- a/@chebfun/nchoosek.m
+++ b/@chebfun/nchoosek.m
@@ -1,0 +1,19 @@
+function F = nchoosek(F, G, varargin)
+%NCHOOSEK   Choose function for CHEBFUN objects.
+%   NCHOOSEK(F, G) computes the continuous analogue of the CHOOSE function
+%   for CHEBFUN objects F and G. The result is defined pointwise as
+%
+%       NCHOOSEK(F,G) = GAMMA(F+1) ./ (GAMMA(G+1) .* GAMMA(F-G+1))
+%
+%   NCHOOSEK(F, G, PREF) does the same but uses the CHEBFUNPREF object PREF
+%   when computing the composition.
+%
+% See also GAMMA.
+
+% Copyright 2014 by The University of Oxford and The Chebfun Developers. See
+% http://www.chebfun.org/ for Chebfun information.
+
+% Call the compose method on the continuous analogue of the choose function:
+F = compose(F, @(f,g) gamma(f+1)./(gamma(g+1).*gamma(f-g+1)), G, varargin{:});
+
+end


### PR DESCRIPTION
Two functions that have not yet been implemented in Chebfun.

    >> x = cheb.x; f = cos(x); g = exp(x);
    >> nchoosek(f,g)
    ans =
       chebfun column (1 smooth piece)
           interval       length   endpoint values  
    [      -1,       1]       35       1.1    0.038 
    Epslevel = 1.776357e-15.  Vscale = 1.184722e+00.