### PR TITLE
Feature chebop vectorize

### DIFF
--- a/@chebop/chebop.m
+++ b/@chebop/chebop.m
@@ -126,7 +126,7 @@ classdef (InferiorClasses = {?double}) chebop
 % 
 % Example (solving an IVP by automatically converting it to first order form):
 %
-% % Solve the van der Pol equation u'' - 25*(1-u^2)u' + u = 0, u(0)=2, u'(0)=0
+% % Solve the van der Pol equation u'' - 20*(1-u^2)u' + u = 0, u(0)=2, u'(0)=0
 % vdpFun = @(u) diff(u, 2) - 20*(1-u.^2).*diff(u) + u;
 % dom = [0 100];
 % N = chebop(vdpFun, dom);
@@ -161,7 +161,22 @@ classdef (InferiorClasses = {?double}) chebop
 %
 % %% AUTOMATIC VECTORIZATION %%
 %
-% TODO: Write
+% By default, CHEBOP will automatically try to vectorize anonymous function that
+% get passed as OP, BC, LBC and RBC. For example, the IVP example above could
+% equally have been written as
+%
+%   % Solve the van der Pol equation u'' - 20*(1-u^2)u' + u = 0, u(0)=2, u'(0)=0
+%   mu = 20;
+%   vdpFun = @(u) diff(u, 2) - mu*(1-u^2)*diff(u) + u;
+%   dom = [0 100];
+%   N = chebop(vdpFun, dom);
+%   N.lbc = @(u) [u - 2; diff(u)];
+%   u = N\0
+%   plot(u)
+%
+% To turn off the automatic vectorization, set N.vectorize = false, or change
+% the default CHEBOPPREF via cheboppref.setDefaults('vectorize', false).
+%
 %
 % See also CHEBOP/MTIMES, CHEBOP/MLDIVIDE, CHEBOPPREF.
 

--- a/@chebop/chebop.m
+++ b/@chebop/chebop.m
@@ -126,13 +126,13 @@ classdef (InferiorClasses = {?double}) chebop
 % 
 % Example (solving an IVP by automatically converting it to first order form):
 %
-% % Solve the van der Pol equation u'' - 20*(1-u^2)u' + u = 0, u(0)=2, u'(0)=0
-% vdpFun = @(u) diff(u, 2) - 20*(1-u.^2).*diff(u) + u;
-% dom = [0 100];
-% N = chebop(vdpFun, dom);
-% N.lbc = @(u) [u - 2; diff(u)];
-% u = N\0
-% plot(u)
+%   % Solve the van der Pol equation u'' - 20*(1-u^2)u' + u = 0, u(0)=2, u'(0)=0
+%   vdpFun = @(u) diff(u, 2) - 20*(1-u.^2).*diff(u) + u;
+%   dom = [0 100];
+%   N = chebop(vdpFun, dom);
+%   N.lbc = @(u) [u - 2; diff(u)];
+%   u = N\0
+%   plot(u)
 %
 % %% PARAMETER DEPENDENT PROBLEMS %%
 %
@@ -162,17 +162,14 @@ classdef (InferiorClasses = {?double}) chebop
 % %% AUTOMATIC VECTORIZATION %%
 %
 % By default, CHEBOP will automatically try to vectorize anonymous function that
-% get passed as OP, BC, LBC and RBC. For example, the IVP example above could
-% equally have been written as
+% get passed as OP, BC, LBC and RBC. For example, the function VDPFUN from the
+% IVP example above,
 %
-%   % Solve the van der Pol equation u'' - 20*(1-u^2)u' + u = 0, u(0)=2, u'(0)=0
-%   mu = 20;
-%   vdpFun = @(u) diff(u, 2) - mu*(1-u^2)*diff(u) + u;
-%   dom = [0 100];
-%   N = chebop(vdpFun, dom);
-%   N.lbc = @(u) [u - 2; diff(u)];
-%   u = N\0
-%   plot(u)
+%   vdpFun = @(u) diff(u, 2) - 20*(1-u.^2).*diff(u) + u;
+%
+% could have equally been written as
+%
+%   vdpFun = @(u) diff(u, 2) - 20*(1-u^2)*diff(u) + u;
 %
 % To turn off the automatic vectorization, set N.vectorize = false, or change
 % the default CHEBOPPREF via cheboppref.setDefaults('vectorize', false).

--- a/@chebop/chebop.m
+++ b/@chebop/chebop.m
@@ -228,7 +228,7 @@ classdef (InferiorClasses = {?double}) chebop
                 N.bc = lbcIn;
             elseif ( nargin == 4 )
                 if ( isa(rbcIn, 'function_handle') || ischar(rbcIn) || ...
-                        isnumeric(rbcIn))
+                        isnumeric(rbcIn) )
                     % CHEBOP(OP, DOM, LBC, RBC):
                     N.lbc = lbcIn;
                     N.rbc = rbcIn;

--- a/@chebop/chebop.m
+++ b/@chebop/chebop.m
@@ -426,6 +426,11 @@ classdef (InferiorClasses = {?double}) chebop
             
             % We're happy with function handles
             if ( isa(val, 'function_handle') || isempty(val) )
+                % If the function is not identical to its vectorized form, we
+                % vectorize it
+                if ( ~strcmp(func2str(val), vectorize(val)) )
+                    val = myVectorize(val);
+                end
                 N.op = val;
             elseif ( iscell(val) )
                 error('CHEBFUN:CHEBOP:setOp:type', ...

--- a/@chebop/parseBC.m
+++ b/@chebop/parseBC.m
@@ -36,7 +36,13 @@ elseif ( isa(BC, 'function_handle') )
             ( strcmp(type,'lrbc') && (nargin(BC) == (numIn - 1)) ) || ...
             ( strcmp(type,'bc') && (nargin(BC) == numIn) ) || ...
             ( strcmp(type,'bc') && (nargin(BC) == numIn + 1) ) )
-        result = BC;
+        % We've got an anonymous function we're happy with. Do we need to
+        % vectorize it?
+        if ( N.vectorize && ~strcmp(func2str(BC), vectorize(BC)) )
+            result = N.vectorizeOp(BC);
+        else
+            result = BC;
+        end
     else
         error('CHEBFUN:CHEBOP:parseBC:inputs', ...
             'Number of inputs to BCs do not match operator.');

--- a/@chebop/vectorizeOp.m
+++ b/@chebop/vectorizeOp.m
@@ -19,19 +19,20 @@ function funOut = vectorizeOp(funIn)
 %   funVecBuiltIn = str2func(vectorize(fun))
 %   funVecBuiltIn(x) % This returns an error, b is undefined
 %
-% See also: vectorize
+% See also: vectorize, chebop.set.op
 
+% Copyright 2015 by The University of Oxford and The Chebfun Developers. See
+% http://www.chebfun.org/ for Chebfun information.
 
-% The input function on vectorized form
+% The input function on vectorized form:
 fVec = vectorize(funIn);
 
-% Begin by obtaining information about potential variables in funIn
+% Begin by obtaining information about potential parameters in funIn
 fFunc = functions(funIn);
 fWork = fFunc.workspace;
 
 % Load the variables in the input function to the current workspace
 loadVariables(fWork)
-
 
 % Ideally, here, we'd call func2str. However, MATLAB will not recognize the
 % variables in the workspace if we call it like that. Hence, we need to call
@@ -40,13 +41,20 @@ funOut = eval(fVec);
 
 end
 
-function loadVariables(work)
+function loadVariables(wSpace)
+%LOADVARIABLES    Load variables into the caller workspace
 
-for wCounter = 1:length(work)
-    ws = work{wCounter};
+% Loop over the cells in WSPACE
+for wCounter = 1:length(wSpace)
+    % Current WS cell we're working with
+    ws = wSpace{wCounter};
+    % Names of the variables in WS
     wsFields = fieldnames(ws);
+    % Loop over the variables in WS
     for varCounter = 1:length(wsFields)
+        % Name of current variables
         varName = wsFields{varCounter};
+        % Assign the variables its value in the caller workspace
         assignin('caller', varName, ws.(varName))
     end
 end

--- a/@chebop/vectorizeOp.m
+++ b/@chebop/vectorizeOp.m
@@ -1,0 +1,53 @@
+function funOut = vectorizeOp(funIn)
+%VECTORIZEOP    Vectorize anonymous functions used for CHEBOP op fields
+%
+% FUNOUT = VECTORIZEOP(FUNIN), where FUNIN is an anonymous function, returns
+% FUNOUT, another anonymous function that corresponds to FUNIN on vectorized
+% form.
+%
+% This method differs from the built-in MATLAB VECTORIZE method in that
+% parameters that appear in the original function do get carried over to the 
+% vectorized function.
+%
+% Example:
+%   b = 3;
+%   fun = @(x) b*x^3;
+%   x = 0:0.1:0;
+%   % fun(x) % This returns an error, suggesting using .^ instead
+%   funVec = chebop.vectorizeOp(fun);
+%   funVec(x)
+%   funVecBuiltIn = str2func(vectorize(fun))
+%   funVecBuiltIn(x) % This returns an error, b is undefined
+%
+% See also: vectorize
+
+
+% The input function on vectorized form
+fVec = vectorize(funIn);
+
+% Begin by obtaining information about potential variables in funIn
+fFunc = functions(funIn);
+fWork = fFunc.workspace;
+
+% Load the variables in the input function to the current workspace
+loadVariables(fWork)
+
+
+% Ideally, here, we'd call func2str. However, MATLAB will not recognize the
+% variables in the workspace if we call it like that. Hence, we need to call
+% EVAL, which will include the variables we've loaded into the workspace above
+funOut = eval(fVec);
+
+end
+
+function loadVariables(work)
+
+for wCounter = 1:length(work)
+    ws = work{wCounter};
+    wsFields = fieldnames(ws);
+    for varCounter = 1:length(wsFields)
+        varName = wsFields{varCounter};
+        assignin('caller', varName, ws.(varName))
+    end
+end
+end

--- a/@chebop/vectorizeOp.m
+++ b/@chebop/vectorizeOp.m
@@ -29,6 +29,12 @@ fVec = vectorize(funIn);
 
 % Begin by obtaining information about potential parameters in funIn
 fFunc = functions(funIn);
+% We only want to convert proper anonymous functions, not function handles
+if ( ~strcmp(fFunc.type, 'anonymous') )
+    funOut = funIn;
+    return
+end
+
 fWork = fFunc.workspace;
 
 % Load the variables in the input function to the current workspace

--- a/@cheboppref/cheboppref.m
+++ b/@cheboppref/cheboppref.m
@@ -130,6 +130,15 @@ classdef cheboppref < chebpref
 %   paused and the plots are shown until the user presses a button. If plotting
 %   = 'off', no plots are shown during the Newton iteration.
 %
+%   vectorize                   - Automatic vectorization of anon. functions
+%     [true]
+%     false
+%
+%   Determines whether the CHEBOP class should try to automatically try to
+%   vectorize anonymous functions used for describing the differential equation
+%   and boundary condition(s).
+%
+%
 % The default values for any of these preferences may be globally overridden
 % using CHEBOPPREF.SETDEFAULTS(); see the documentation for that function for
 % further details.
@@ -255,6 +264,8 @@ classdef cheboppref < chebpref
                 prefList.minDimension);
             fprintf([padString('    plotting:') '%s\n'], ...
                 prefList.plotting);
+            fprintf([padString('    vectorize:') '%i\n'], ...
+                prefList.vectorize);
        end
 
         function pref = subsasgn(pref, ind, val)
@@ -421,6 +432,7 @@ classdef cheboppref < chebpref
             factoryPrefs.maxIter = 25;
             factoryPrefs.minDimension = 32;
             factoryPrefs.plotting = 'off';
+            factoryPrefs.vectorize = true;
         end
         
         function val = parseDiscretization(val)

--- a/tests/chebop/test_autoVectorize.m
+++ b/tests/chebop/test_autoVectorize.m
@@ -1,0 +1,92 @@
+function pass = test_autoVectorize
+%TEST_AUTOVECTORIZE    Test the automatic vectorization works for CHEBOPs
+%
+% Note: This test only checks whether things run, not the correctness of the
+% results.
+%% Setup
+% Domain and some of CHEBFUNs
+d = [0, 1];
+x = chebfun(@(x) x, d);
+f = exp(sin(4*x));
+g = cos(x.^2).^2;
+h = 1./(5+x.^2);
+u = sin(5*x.^2);
+v = exp(x/2);
+% Some parameters
+a = 5;
+b = 4*pi;
+c = -5*exp(1);
+
+%% Scalar problem -- IVP, pass OP to constructor.
+fun = @(u) diff(u, 2) - a*(1-u^2)*diff(u) + u;
+N = chebop(fun, d);
+N.lbc = @(u) [u - 2; diff(u)];
+try
+    u = N\0;
+    pass(1) = 1;
+catch ME
+    pass(1) = 0;
+end
+
+%% Scalar problem -- IVP, pass OP after constructing.
+fun = @(x,u) diff(u, 2) - f*(1-u^2)*diff(u) + u;
+N = chebop(d);
+N.op = fun;
+N.lbc = @(u) [u - 2; diff(u)];
+try
+    u = N\0;
+    pass(2) = 1;
+catch ME
+    pass(2) = 0;
+end
+
+%% Scalar problem -- BVP, pass OP to constructor.
+fun = @(u) diff(u, 2) - a*(1-u^2)*diff(u) + u;
+N = chebop(fun, d);
+N.bc = @(x,u) [u(0) - 2; u(1) - 3];
+try
+    u = N\0;
+    pass(3) = 1;
+catch ME
+    pass(3) = 0;
+end
+
+%% Scalar problem -- BVP, pass OP after constructing.
+fun = @(x,u) diff(u, 2) - .2*f*(1-u^2)*diff(u) + u;
+N = chebop(d);
+N.op = fun;
+N.bc = @(x,u) [u(0) - 2; u(1) - 3];
+try
+    u = N\0;
+    pass(4) = 1;
+catch ME
+    pass(4) = 0;
+end
+
+%% Coupled problem -- BVP, pass OP to constructor, also need to vectorize BCs
+fun = @(x,u,v) [diff(u, 2) - a*u^2*diff(v); diff(v,2) + diff(u)/(v+2)^2];
+N = chebop(fun, d);
+N.bc = @(x,u,v) [u(0) - 2; u(1) - 3; v(0)-1; v(1)*feval(diff(u), 1) - 17.909];
+u0 = chebfun([2.0000 1.5059  1.2210 2.0354 3.0000]', d);
+v0 = chebfun([1; 2], d);
+N.init = [u0; v0];
+try
+    uv = N\0;
+    pass(5) = 1;
+catch ME
+    pass(5) = 0;
+end
+
+%% Scalar problem -- BVP. Vectorization off, should give an error
+fun = @(u) diff(u, 2) - u*diff(u);
+N = chebop(d);
+N.vectorize = false;
+N.op = fun;
+N.bc = @(x,u) [u(0) - 2; u(1) - 3];
+try
+    u = N\0;
+    % We should have been able to solve this!
+    pass(6) = 0;
+catch ME
+    pass(6) = strcmp(ME.identifier, 'CHEBFUN:ADCHEBFUN:mtimes:dims');
+end

--- a/tests/chebop/test_vectorizeOp.m
+++ b/tests/chebop/test_vectorizeOp.m
@@ -1,0 +1,115 @@
+function pass = test_vectorizeOp()
+%TEST_VECTORIZEOP    Test that the CHEBOP vectorization method works as expected
+
+%% Setup
+% Domain and some of CHEBFUNs
+d = [1, 3];
+x = chebfun(@(x) x, d);
+f = exp(sin(4*x));
+g = cos(x.^2).^2;
+h = 1./(5+x.^2);
+u = sin(5*x.^2);
+v = exp(x/2);
+% Some parameters
+b = 4*pi;
+c = -5*exp(1);
+
+%% Simple case, already vectorized
+fun = @(u) diff(u, 2) + b.*u.^3;
+% Automatically vectorized
+vecFun = chebop.vectorizeOp(fun);
+% The answer we expect (FUN above is already vectorized, so they're identical)
+exactFun = fun;
+% Check that we got the correct string and the correct function
+pass(1,1) = strcmp(func2str(exactFun), func2str(vecFun));
+pass(1,2) = norm(exactFun(u) - vecFun(u)) == 0;
+
+%% Simple case, already vectorized, with both x and u
+fun = @(x,u) diff(u, 2) + b.*u.^3;
+% Automatically vectorized
+vecFun = chebop.vectorizeOp(fun);
+% The answer we expect (FUN above is already vectorized, so they're identical)
+exactFun = fun;
+% Check that we got the correct string and the correct function
+pass(2,1) = strcmp(func2str(exactFun), func2str(vecFun));
+pass(2,2) = norm(exactFun(x,u) - vecFun(x,u)) == 0;
+
+%% Vectorization needed, scalar case
+fun = @(u) diff(u, 2) + b*u^3;
+% Automatically vectorized
+vecFun = chebop.vectorizeOp(fun);
+% The answer we expect
+exactFun = @(u) diff(u, 2) + b.*u.^3;
+% Check that we got the correct string and the correct function
+pass(3,1) = strcmp(func2str(exactFun), func2str(vecFun));
+pass(3,2) = norm(exactFun(u) - vecFun(u)) == 0;
+
+%% Vectorization needed, scalar case with both x and u
+fun = @(x,u) diff(u, 2) + b*u^3;
+% Automatically vectorized
+vecFun = chebop.vectorizeOp(fun);
+% The answer we expect
+exactFun = @(x,u) diff(u, 2) + b.*u.^3;
+% Check that we got the correct string and the correct function
+pass(4,1) = strcmp(func2str(exactFun), func2str(vecFun));
+pass(4,2) = norm(exactFun(x,u) - vecFun(x,u)) == 0;
+
+%% Vectorization needed, scalar case with a CHEBFUN
+fun = @(u) diff(u, 2) + f*u^3;
+% Automatically vectorized
+vecFun = chebop.vectorizeOp(fun);
+% The answer we expect
+exactFun = @(u) diff(u, 2) + f.*u.^3;
+% Check that we got the correct string and the correct function
+pass(5,1) = strcmp(func2str(exactFun), func2str(vecFun));
+pass(5,2) = norm(exactFun(u) - vecFun(u)) == 0;
+
+%% Vectorization needed, scalar case with a CHEBFUN, both x and u
+fun = @(x,u) diff(u, 2) + f*u^3;
+% Automatically vectorized
+vecFun = chebop.vectorizeOp(fun);
+% The answer we expect
+exactFun = @(x,u) diff(u, 2) + f.*u.^3;
+% Check that we got the correct string and the correct function
+pass(6,1) = strcmp(func2str(exactFun), func2str(vecFun));
+pass(6,2) = norm(exactFun(x,u) - vecFun(x,u)) == 0;
+
+%% System case, already vectorized
+fun = @(x,u,v) [diff(u, 2) + b.*u.^3+v.*u./h; diff(v,2) + v.^2./c + g.*u./v];
+% Automatically vectorized
+vecFun = chebop.vectorizeOp(fun);
+% The answer we expect (FUN above is already vectorized, so they're identical)
+exactFun = fun;
+% Check that we got the correct string and the correct function
+pass(7,1) = strcmp(func2str(exactFun), func2str(vecFun));
+pass(7,2) = norm(exactFun(x,u,v) - vecFun(x,u,v)) == 0;
+
+%% System case, partially vectorized
+fun = @(x,u,v) [diff(u, 2) + b*u.^3+v.*u/h; diff(v,2) + v.^2./c + g*u./v];
+% Automatically vectorized
+vecFun = chebop.vectorizeOp(fun);
+% The answer we expect
+exactFun = @(x,u,v) [diff(u, 2) + b.*u.^3+v.*u./h; ...
+    diff(v,2) + v.^2./c + g.*u./v];
+% Check that we got the correct string
+pass(8,1) = strcmp(func2str(exactFun), func2str(vecFun));
+pass(8,2) = norm(exactFun(x,u,v) - vecFun(x,u,v)) == 0;
+
+%% System case, no vectorization
+fun = @(x,u,v) [diff(u, 2) + b*u^3+v*u/h; diff(v,2) + v^2/c + g*u/v];
+% Automatically vectorized
+vecFun = chebop.vectorizeOp(fun);
+% The answer we expect
+exactFun = @(x,u,v) [diff(u, 2) + b.*u.^3+v.*u./h; ...
+    diff(v,2) + v.^2./c + g.*u./v];
+% Check that we got the correct string and the correct function
+pass(9,1) = strcmp(func2str(exactFun), func2str(vecFun));
+pass(9,2) = norm(exactFun(x,u,v) - vecFun(x,u,v)) == 0;
+
+%% For a function handle, will get the same results
+s = @sin;
+sVec = chebop.vectorizeOp(s);
+% Check that we got the correct string and the correct function
+pass(10,1) = strcmp(func2str(s), func2str(sVec));
+pass(10,2) = norm(s(u)-sVec(u)) == 0;
+end


### PR DESCRIPTION
Closes #1430.

By default, CHEBOPs will try to vectorize anonymous functions passed to them. It is possible to turn off this feature, either globablly via cheboppref or by setting the ```vectorize``` property of CHEBOPs. This is documented in the help text for CHEBOPs.