### PR TITLE
some minor display changes.

### DIFF
--- a/@chebfun/disp.m
+++ b/@chebfun/disp.m
@@ -76,7 +76,7 @@ end
 [extraItem, extraData] = dispData(f);
 
 % Loop through each of the funs to display the following information:
-s = [s, sprintf('\n       interval       length   endpoint values %s\n', extraItem)];
+s = [s, sprintf('\n       interval       length     endpoint values %s\n', extraItem)];
 len = zeros(numFuns, 1);
 for j = 1:numFuns
     len(j) = length(f.funs{j});
@@ -113,12 +113,12 @@ for j = 1:numFuns
 end
 
 % Display epslevel:
-s = [s, sprintf('Epslevel = %i.', epslevel(f))];
-s = [s, sprintf('  Vscale = %i.', vscale(f, 'sup'))];
+s = [s, sprintf('epslevel = %i', epslevel(f))];
+s = [s, sprintf('   vscale = %i', vscale(f, 'sup'))];
 
 % Display total length for piecewise chebfuns:
 if ( numFuns > 1 )
-    s = [s, sprintf('  Total length = %i.', sum(len))];
+    s = [s, sprintf('   Total length = %i', sum(len))];
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
This addresses #1445. This is what things look now:
```
>> x
x =
   chebfun column (1 smooth piece)
       interval       length     endpoint values  
[      -1,       1]        2        -1        1 
epslevel = 1.110223e-15   vscale = 1
>> h = heaviside(x)
h =
   chebfun column (2 smooth pieces)
       interval       length     endpoint values  
[      -1,       0]        1         0        0 
[       0,       1]        1         1        1 
epslevel = 2.220446e-16   vscale = 1   Total length = 2
```