### PR TITLE
Fix chebop display

### DIFF
--- a/@chebop/chebop.m
+++ b/@chebop/chebop.m
@@ -198,8 +198,11 @@ classdef (InferiorClasses = {?double}) chebop
         domain = [];    % Domain of the operator
         op = [];        % The operator
         lbc = [];       % Left boundary condition(s)
+        lbcShow = [];   % Pretty print left boundary condition(s)
         rbc = [];       % Right boundary condition(s)
+        rbcShow = [];   % Pretty print right boundary condition(s)
         bc = [];        % Other/internal/mixed boundary conditions
+        bcShow = [];   % Pretty print other boundary condition(s)
         init = [];      % Initial guess of a solution
         numVars = [];   % Number of variables the CHEBOP operates on.
         vectorize = []; % Automatic vectorization?
@@ -406,7 +409,12 @@ classdef (InferiorClasses = {?double}) chebop
             %   conditions than simply accessing the .lbc field, or using standard
             %   subsref.
             
-            N.lbc = parseBC(N, val, 'lrbc');            
+            N.lbc = parseBC(N, val, 'lrbc'); 
+            N.lbcShow = val;
+            % Clear periodic boundary conditions if they were present
+            if ( strcmp(N.bc, 'periodic') )
+                N.bc = [];
+            end
         end
         
         function N = set.rbc(N, val)
@@ -416,6 +424,12 @@ classdef (InferiorClasses = {?double}) chebop
             %   subsref.
             
             N.rbc = parseBC(N, val, 'lrbc');
+            N.rbcShow = val;
+            
+            % Clear periodic boundary conditions if they were present
+            if ( strcmp(N.bc, 'periodic') )
+                N.bc = [];
+            end
         end
         
         function N = set.bc(N, val)
@@ -437,26 +451,32 @@ classdef (InferiorClasses = {?double}) chebop
                 end
                 if ( isfield(val, 'other') )
                     N.bc = parseBC(N, val.other, 'bc');
+                    N.bcShow = val;
                 end
                 
             elseif ( strcmpi(val, 'periodic') )
                 N.lbc = [];
                 N.rbc = [];
                 N.bc = 'periodic';
+                N.bcShow = val;
                 
                 
             elseif ( ischar(val) || isstruct(val) || isnumeric(val) )
                 % V4 style keywords and numeric settings are understood to
                 % apply to both ends.
                 N.bc = [];
-                result = parseBC(N, val, 'bc');
-                N.lbc = result; %#ok<MCSUP>
-                N.rbc = result; %#ok<MCSUP>
-                
+                N.bcShow = [];
+                if ( ~isempty(val) )
+                    result = parseBC(N, val, 'bc');
+                    N.lbc = result; %#ok<MCSUP>
+                    N.lbcShow = val;
+                    N.rbc = result; %#ok<MCSUP>
+                    N.rbcShow = val;
+                end
             else
                 % A proper function was supplied.
                 N.bc = parseBC(N, val, 'bc');
-                
+                N.bcShow = val;
             end
             
         end

--- a/@chebop/disp.m
+++ b/@chebop/disp.m
@@ -151,12 +151,12 @@ else
         
         % Replace ; with the ASCII character for new line. Add indentation to
         % make it look nice
-        wSpace = repmat(' ', 1, length(args) + 11);
+        wSpace = repmat(' ', 1, length(args) + 12);
         op = strrep(op, ';', [char(13), wSpace]);
     end
 
     % Output string
-    str = [args, ' |-> ', op];
+    str = [args, ' |--> ', op];
 end
 
 end

--- a/@chebop/disp.m
+++ b/@chebop/disp.m
@@ -15,6 +15,9 @@ if ( isempty(A) )
     end
     
 else
+    % Store the name of the variable(s) to the operator
+    args = [];
+    
     % Check whether the chebop is linear in order to be able to display
     % linearity information. 
     if ( isempty(A.op) )
@@ -26,7 +29,7 @@ else
     end
     if ( ~isempty(A.op) )
         fprintf(':\n')
-        str = formatOperator(A.op);
+        [str, args] = formatOperator(A.op);
         fprintf('      %s\n', str);
         if ( loose )
             fprintf('\n')
@@ -48,33 +51,13 @@ else
     end
     
     if ( ~isempty(A.lbc) )
-        fprintf('    left boundary conditions:\n');
-        if ( ischar(A.lbc) )
-            fprintf('      %s\n', A.lbc);
-        elseif ( isnumeric(A.lbc) )
-            fprintf('      %s\n', num2str(A.lbc));
-        else
-            str = stripHandle(func2str(A.lbc));
-            fprintf('      %s = 0\n', str);
-        end
-        if ( loose )
-            fprintf('\n')
-        end
+        fprintf('    left boundary condition(s):\n');
+        printLRbc(A.lbc, A.lbcShow, args, loose);
     end
     
     if ( ~isempty(A.rbc) )
-        fprintf('    right boundary conditions:\n');
-        if ( ischar(A.rbc) )
-            fprintf('      %s\n', A.rbc);
-        elseif ( isnumeric(A.rbc) )
-            fprintf('      %s\n', num2str(A.rbc));
-        else
-            str = stripHandle(func2str(A.rbc));
-            fprintf('      %s = 0\n', str);
-        end
-        if ( loose )
-            fprintf('\n')
-        end
+        fprintf('    right boundary condition(s):\n');
+        printLRbc(A.rbc, A.rbcShow, args, loose);
     end
     
     if ( ~isempty(A.bc) )
@@ -104,7 +87,28 @@ str = op(idx(1)+1:end);
 
 end
 
-function str = formatOperator(op)
+function printLRbc(bc, bcShow, args, loose)
+% Print left or right boundary condition(s)
+if ( ischar(bcShow) )
+    % We had an assignment such as N.lbc = 'neumann';
+    fprintf('      %s\n', bcShow);
+elseif ( isnumeric(bcShow) )
+    % We had an assignment such as N.lbc = 2;
+    if ( ~isempty(args) )
+        fprintf('      %s = %s\n', args, num2str(bcShow));
+    else
+        fprintf('      %s\n', num2str(bcShow));
+    end
+else
+    str = stripHandle(func2str(bc));
+    fprintf('      %s = 0\n', str);
+end
+if ( loose )
+    fprintf('\n')
+end
+end
+
+function [str, args] = formatOperator(op)
 % What type of a function did we get passed?
 opFunc = functions(op);
 
@@ -144,27 +148,6 @@ else
 
     % Output string
     str = [args, ' |-> ', op];
-end
-
-end
-
-
-function s = bc2char(b)
-
-% Make sure b is a cell:
-if ( ~iscell(b) )
-    b = {b}; 
-end
-
-s = repmat({'     '},1,length(b));
-for k = 1:length(b)
-    if isnumeric(b{k})  % number
-        s{k} = [s{k}, num2str(b{k})];
-    elseif ischar(b{k})  % string
-        s{k} = [s{k}, b{k}];
-    else  % function
-        s{k} = [s{k}, char(b{k}), ' = 0'];
-    end
 end
 
 end

--- a/@chebop/disp.m
+++ b/@chebop/disp.m
@@ -37,7 +37,16 @@ else
         fprintf('  ');
     end
     fprintf(' operating on chebfun objects defined on:\n')
-    dom = strtrim(sprintf('%g ', A.domain));
+    Adom = A.domain;
+    dom = strtrim(sprintf('%g ', Adom));
+    % Replace ' ' with commas in the domain for printing. If the numbers are not
+    % all integers, we also want to keep whitespace between the numbers.
+    if ( all(floor(Adom) == ceil(Adom)) )
+        dom = strrep(dom, ' ', ',');
+    else
+        dom = strrep(dom, ' ', ', ');
+    end
+    % Print the domain
     fprintf('      [%s]\n', dom);
     if ( loose )
         fprintf('\n')

--- a/@chebop/disp.m
+++ b/@chebop/disp.m
@@ -26,8 +26,8 @@ else
     end
     if ( ~isempty(A.op) )
         fprintf(':\n')
-        str = stripHandle(func2str(A.op));
-        fprintf('      %s = 0\n', str);
+        str = formatOperator(A.op);
+        fprintf('      %s\n', str);
         if ( loose )
             fprintf('\n')
         end
@@ -101,6 +101,50 @@ end  % End of function DISP().
 function str = stripHandle(op)
 idx = strfind(op, ')');
 str = op(idx(1)+1:end);
+
+end
+
+function str = formatOperator(op)
+% What type of a function did we get passed?
+opFunc = functions(op);
+
+% Convert the function to a string:
+op = func2str(op);
+
+if ( strcmp(opFunc.type, 'simple') )
+    % If the function passed was of the simple type, we simply return the
+    % results of func2str above
+    str = op;
+    
+else
+    % We got passed an anonymous function. Return a string to print on a nice
+    % form.
+    idx = strfind(op, ')');
+    args = op(3:idx(1)-1);
+    % If we have any commas in args, the independent variable (e.g. x) must be
+    % included. For nicer output, don't print it
+    idxCommas = strfind(args, ',');
+    if ( ~isempty(idxCommas) )
+        args = args(idxCommas(1)+1:end);
+    end
+    
+    % Isolate the actual operator part from the string
+    op = op(idx(1)+1:end);
+    
+    % If we're dealing with a system, throw away the end [ and ]. Also, split up
+    % components into lines.
+    if ( op(1) == '[' && op(end) == ']' )
+        op = op(2:end-1);
+        
+        % Replace ; with the ASCII character for new line. Add indentation to
+        % make it look nice
+        wSpace = repmat(' ', 1, length(args) + 11);
+        op = strrep(op, ';', [char(13), wSpace]);
+    end
+
+    % Output string
+    str = [args, ' |-> ', op];
+end
 
 end
 


### PR DESCRIPTION
Closes #1293 and #1443. Some example outputs for displaying ```chebops```:

```
>> N = chebop(@(u) diff(u,2)); N.lbc = 'neumann'; N.rbc = 2
N =
   Linear operator:
      u |-> diff(u,2)
   operating on chebfun objects defined on:
      [-1 1]
   with
    left boundary condition(s):
      neumann
    right boundary condition(s):
      u = 2
```

```
>> N = chebop(@(u) diff(u,2)); N.bc = 'dirichlet'
N =
   Linear operator:
      u |-> diff(u,2)
   operating on chebfun objects defined on:
      [-1 1]
   with
    left boundary condition(s):
      dirichlet
    right boundary condition(s):
      dirichlet
```

```
>> N = chebop(@(x, u, v) [diff(u) - v.^2 ; u - diff(v)], [0 3]); N.lbc = @(u,v) u-2; ...
N.rbc = @(u,v) diff(v) + u
N =
   Nonlinear operator:
      u,v |-> diff(u)-v.^2
              u-diff(v)
   operating on chebfun objects defined on:
      [0 3]
   with
    left boundary condition(s):
      u-2 = 0
    right boundary condition(s):
      diff(v)+u = 0
```