### PR TITLE
Fix cumsum of an even trigfun (and trigtech)

### DIFF
--- a/@chebfun/cumsum.m
+++ b/@chebfun/cumsum.m
@@ -71,7 +71,7 @@ if ( isPeriodicTech(f) )
     c = trigcoeffs(f); 
     numCoeffs = size(c, 1);
     fIsEven = mod(numCoeffs,2) == 0;
-    if any(abs(c((numCoeffs+1-fIsEven)/2,:)) > f.vscale.*f.epslevel)
+    if any(abs(c((numCoeffs+1+fIsEven)/2,:)) > f.vscale.*f.epslevel)
         % Mean is not zero, convert it to a CHEBTECH based chebfun:
         f = chebfun(f);
     end

--- a/@trigtech/cumsum.m
+++ b/@trigtech/cumsum.m
@@ -80,7 +80,7 @@ function f = cumsumContinuousDim(f, m)
 
     % Check that the mean of the TRIGtech is zero.  If it is not, then
     % throw an error.
-    if any(abs(c((numCoeffs+1-fIsEven)/2,:)) > f.vscale.*f.epslevel)
+    if any(abs(c((numCoeffs+1+fIsEven)/2,:)) > f.vscale.*f.epslevel)
         error('CHEBFUN:TRIGTECH:cumsum:meanNotZero', 'Indefinite integrals are only possible for TRIGTECH objects with zero mean.');
     end
     

--- a/@trigtech/cumsum.m
+++ b/@trigtech/cumsum.m
@@ -81,7 +81,8 @@ function f = cumsumContinuousDim(f, m)
     % Check that the mean of the TRIGtech is zero.  If it is not, then
     % throw an error.
     if any(abs(c((numCoeffs+1+fIsEven)/2,:)) > f.vscale.*f.epslevel)
-        error('CHEBFUN:TRIGTECH:cumsum:meanNotZero', 'Indefinite integrals are only possible for TRIGTECH objects with zero mean.');
+        error('CHEBFUN:TRIGTECH:cumsum:meanNotZero', ...
+              'Indefinite integrals are only possible for TRIGTECH objects with zero mean.');
     end
     
     % Force the mean to be exactly zero.

--- a/tests/chebfun/test_cumsum.m
+++ b/tests/chebfun/test_cumsum.m
@@ -248,6 +248,50 @@ S = cumsum(s);
 pass(18) = norm(S(:,1) - f) < 100*eps;
 pass(19) = norm(S(:,2) - g) < 100*eps;
 
+%% Check on trigfuns
+xr = pi*xr;
+% trigfun with zero mean
+f = chebfun(@(x) cos(x+sqrt(3)) + sin(x-sqrt(2.1)), [-pi,pi], 'trig', pref);
+If = cumsum(f);
+If_exact = @(x) sin(x+sqrt(3)) - cos(x-sqrt(2.1)) - (sin(-pi+sqrt(3)) - cos(-pi-sqrt(2.1)));
+pass(20) = max(max(abs(feval(If, xr) - If_exact(xr)))) < ...
+    10*vscale(If)*epslevel(If);
+pass(21) = isPeriodicTech(If);
+
+% trigfun without zero mean - should be converted to chebfun
+f = chebfun(@(x) 1 + cos(x+sqrt(3)) + sin(x-sqrt(2.1)), [-pi,pi], 'trig', pref);
+If = cumsum(f);
+If_exact = @(x) x + sin(x+sqrt(3)) - cos(x-sqrt(2.1)) - ...
+    (-pi + sin(-pi+sqrt(3)) - cos(-pi-sqrt(2.1)));
+pass(22) = max(max(abs(feval(If, xr) - If_exact(xr)))) < ...
+    10*vscale(If)*epslevel(If);
+pass(23) = ~isPeriodicTech(If);
+
+% Array-valued trigfuns with zero-mean
+f3 = chebfun(@(x) [cos(x) -sin(x) cos(x+sqrt(3))], [-pi,pi], 'trig', pref);
+If3 = cumsum(f3);
+If3_exact = @(x) [sin(x) cos(x) sin(x+sqrt(3))] - ...
+    repmat([sin(-pi) cos(-pi) sin(-pi+sqrt(3))], size(x, 1), 1);
+pass(24) = max(max(abs(feval(If3, xr) - If3_exact(xr)))) < ...
+    10*vscale(If3)*epslevel(If3);
+pass(25) = isPeriodicTech(f3);
+
+% Even length with non-zero mean
+f = chebfun( ones(32,1), [-pi,pi], 'trig'  );
+If = cumsum(f);
+If_exact = @(x) x + pi;
+pass(26) = max(max(abs(feval(If, xr) - If_exact(xr)))) < ...
+    10*vscale(If)*epslevel(If);
+pass(27) = ~isPeriodicTech(If);
+
+% Even length with zero mean
+f = chebfun( sin(trigpts(33,[-pi,pi])), [-pi,pi], 'trig'  );
+If = cumsum(f);
+If_exact = @(x) -cos(x)-1;
+pass(28) = max(max(abs(feval(If, xr) - If_exact(xr)))) < ...
+    10*vscale(If)*epslevel(If);
+pass(29) = isPeriodicTech(If);
+
 
 % [TODO]:  Check fractional antiderivatives once implemented.
 


### PR DESCRIPTION
Fixed bug where cumsum of an even trigfun (and trigtech) was not working properly.
Added tests in chebfun/cumsum for cumsums of trigfuns (nothing was there previously).

Partially address #1460.