### PR TITLE
Fast tall-skinny QR

### DIFF
--- a/@chebtech/qr.m
+++ b/@chebtech/qr.m
@@ -110,91 +110,89 @@ if ( n < m )
     n = m;
 end
 
-% Project the values onto a Legendre grid: (where integrals of polynomials
-% p_n*q_n will be computed exactly and on an n-point grid)
-if ( (length(WP) ~= n && n <= 4000) || ((~isempty(type) && isa(f, type)) && n <= 4000)  )
-    xc = f.chebpts(n);
-    vc = f.barywts(n);
-    [xl, wl, vl] = legpts(n);
-    P = barymat(xl, xc, vc);     % Map from Chebyshev values to Legendre values.
-    W = spdiags(sqrt(wl.'), 0, n, n); % Weighted QR with Gauss-Legendre weights.
-    Winv = spdiags(1./sqrt(wl.'), 0, n, n);    % Undo the weighting used for QR.
-    Pinv = barymat(xc, xl, vl); % Revert to Chebyshev grid (from Legendre grid).
-    % Persistent storage:
-    WP = W*P;
-    invWP = Pinv*Winv;
-    type = class(f);
-end
-
 if ( n <= 4000 )
+    
+    % Project the values onto a Legendre grid: (where integrals of polynomials
+    % p_n*q_n will be computed exactly and on an n-point grid)
+    if ( (length(WP) ~= n) || (~isempty(type) && isa(f, type)) )
+        % The matrices WP and inv(WP) depends only on the length of the
+        % discretization and the cheb-type of f (i.e., not the function values
+        % themselves.) We therefore store these persistently which save a lot of
+        % times in situations where we performa number of QR factorizations of
+        % the same length (for example, in Chebfun2).
+        xc = f.chebpts(n);
+        vc = f.barywts(n);
+        [xl, wl, vl] = legpts(n);
+        P = barymat(xl, xc, vc);     % Map from Chebyshev values to Legendre values.
+        W = spdiags(sqrt(wl.'), 0, n, n); % Weighted QR with Gauss-Legendre weights.
+        Winv = spdiags(1./sqrt(wl.'), 0, n, n);    % Undo the weighting used for QR.
+        Pinv = barymat(xc, xl, vl); % Revert to Chebyshev grid (from Legendre grid).
+        % Persistent storage:
+        WP = W*P;
+        invWP = Pinv*Winv;
+        type = class(f);
+    end
+    
     % Compute the weighted QR factorisation:
     values = f.coeffs2vals(f.coeffs);
     if ( nargout == 3 )
         [Q, R, E] = qr(WP * values, 0);
         % For consistency with the MATLAB QR behavior:
-        if ( (nargin == 1) || ...
-                ~(strcmpi(outputFlag, 'vector') || isequal(outputFlag, 0)) )
+        if ( (nargin == 1) || ~(strcmpi(outputFlag, 'vector') || isequal(outputFlag, 0)) )
             % Return E in matrix form:
             I = eye(m);
             E = I(:,E);
         end
     else
-        %converted = chebfun.ndct( f.coeffs );
         converted = WP * values;
         [Q, R] = qr(converted, 0);
     end
     
-    % Revert to the Chebyshev grid (and remove the weight and enforce diag(R) >= 0).
-    s = sign(diag(R));
-    s(~s) = 1;
-    S = spdiags(s, 0, m, m);
+    % Remove the weighting and revert to the Chebyshev grid.
+    s = sign(diag(R));             % }
+    s(~s) = 1;                     %  } Enforce diag(R) >= 0
+    S = spdiags(s, 0, m, m);       % }
     Q = invWP*Q*S;                 % Fix Q.
+    Q_coeffs = f.vals2coeffs(Q);   % Compute new coefficients.
     R = S*R;                       % Fix R.
-    
-    % Apply data to chebtech:
-    f.coeffs = f.vals2coeffs(Q);   % Compute new coefficients.
-    f.vscale = max(abs(Q), [], 1); % Update vscale
-        
+                
 else
-    % Got to use fast transforms now because we cannot store nxn matrices,
-    % where n>>4000. (Same algorithm as when n <= 4000, except we never form
-    % a large dense matrix.)
+    % Where n >> 4000 we must use fast transforms as we cannot store the n x n
+    % matrices. Below is the same algorithm as the n <= 4000 above, except that
+    % we never form a large dense matrix.
     
     % Compute the weighted QR factorisation:
     [ignored, wl, ignored] = legpts(n);
-    W = spdiags(sqrt(wl.'), 0, n, n);
+    W = spdiags(sqrt(wl.'), 0, n, n); % Weighted QR with Gauss-Legendre weights.
+    Winv = spdiags(1./sqrt(wl.'), 0, n, n);    % Undo the weighting used for QR.
     if ( nargout == 3 )
-        converted = W*chebfun.ndct( f.coeffs ); % does WP * values
+        converted = W*chebfun.ndct( f.coeffs ); % WP * values.
         [Q, R, E] = qr( converted , 0);
         % For consistency with the MATLAB QR behavior:
-        if ( (nargin == 1) || ...
-                ~(strcmpi(outputFlag, 'vector') || isequal(outputFlag, 0)) )
+        if ( (nargin == 1) || ~(strcmpi(outputFlag, 'vector') || isequal(outputFlag, 0)) )
             % Return E in matrix form:
             I = eye(m);
             E = I(:,E);
         end
     else
-        converted = W*chebfun.ndct( f.coeffs ); % does WP * values
+        converted = W*chebfun.ndct( f.coeffs ); % WP * values.
         [Q, R] = qr(converted, 0);
     end
     
-    % Revert to the Chebyshev grid (and remove the weight and enforce diag(R) >= 0).
-    s = sign(diag(R));
-    s(~s) = 1;
-    S = spdiags(s, 0, m, m);
-    Winv = spdiags(1./sqrt(wl.'), 0, n, n);
-    Q = Winv*Q*S;                 % Fix Q.
-    Q_coeffs = leg2cheb( chebfun.idlt( Q ) );
-    Q = f.coeffs2vals( Q_coeffs ); 
+    % Remove the weighting and revert to the Chebyshev grid.
+    s = sign(diag(R));             % }
+    s(~s) = 1;                     %  } Enforce diag(R) >= 0
+    S = spdiags(s, 0, m, m);       % }
+    Q = Winv*Q*S;                  % Fix Q. (Note, Q is still on Legendre grid.)
+    Q_coeffs = leg2cheb( chebfun.idlt( Q ) ); % Chebyshev coefficients.
+    Q = f.coeffs2vals( Q_coeffs ); % Values on Chebyshev grid.
     R = S*R;                       % Fix R.
-    
-    % Apply data to chebtech:
-    f.coeffs = Q_coeffs;           % Compute new coefficients.
-    f.vscale = max(abs(Q), [], 1); % Update vscale     
     
 end
 
-
+% Apply data to CHEBTECH:
+f.coeffs = Q_coeffs;           % Store coefficients. 
+f.vscale = max(abs(Q), [], 1); % Update vscale. 
 
 end
 

--- a/@chebtech/qr.m
+++ b/@chebtech/qr.m
@@ -112,7 +112,7 @@ end
 
 % Project the values onto a Legendre grid: (where integrals of polynomials
 % p_n*q_n will be computed exactly and on an n-point grid)
-if ( (length(WP) ~= n && n <= 5000) || ((~isempty(type) && isa(f, type)) && n <= 5000)  )
+if ( (length(WP) ~= n && n <= 4000) || ((~isempty(type) && isa(f, type)) && n <= 4000)  )
     xc = f.chebpts(n);
     vc = f.barywts(n);
     [xl, wl, vl] = legpts(n);
@@ -126,7 +126,7 @@ if ( (length(WP) ~= n && n <= 5000) || ((~isempty(type) && isa(f, type)) && n <=
     type = class(f);
 end
 
-if ( n <= 5000 )
+if ( n <= 4000 )
     % Compute the weighted QR factorisation:
     values = f.coeffs2vals(f.coeffs);
     if ( nargout == 3 )
@@ -157,7 +157,7 @@ if ( n <= 5000 )
         
 else
     % Got to use fast transforms now because we cannot store nxn matrices,
-    % where n>>5000. (Same algorithm as when n < 5000, except we never form
+    % where n>>4000. (Same algorithm as when n <= 4000, except we never form
     % a large dense matrix.)
     
     % Compute the weighted QR factorisation:

--- a/@chebtech/qr.m
+++ b/@chebtech/qr.m
@@ -184,7 +184,7 @@ else
     S = spdiags(s, 0, m, m);
     Winv = spdiags(1./sqrt(wl.'), 0, n, n);
     Q = Winv*Q*S;                 % Fix Q.
-    Q_coeffs = leg2cheb( chebfun.dlt( Q ) );
+    Q_coeffs = leg2cheb( chebfun.idlt( Q ) );
     Q = f.coeffs2vals( Q_coeffs ); 
     R = S*R;                       % Fix R.
     

--- a/tests/chebtech/test_qr.m
+++ b/tests/chebtech/test_qr.m
@@ -73,6 +73,19 @@ for n = 1:4
     pass(n, 20) = isequal(size(Q.vscale), [1 3]) && ...
         isequal(size(Q.epslevel), [1 3]);
 end
+
+n = 4999; 
+L = legpoly( n:n+1 ); 
+[Q, R] = qr( L ) ;
+pass(:, 21) = ones(4,1) * (  norm(Q*diag(sqrt(1./((n:n+1)+.5))) - L) < ...
+                                         1e4*max(f.vscale.*f.epslevel)  );  
+
+n = 10000; 
+L = legpoly( n:n+5 ); 
+[Q, R] = qr( L ) ;
+pass(:, 22) = ones(4,1) * (  norm(Q*diag(sqrt(1./((n:n+5)+.5))) - L) < ...
+                                         1e4*max(f.vscale.*f.epslevel)  );  
+
 end
 
 % Tests the QR decomposition for a CHEBTECH object F using a grid of points X

--- a/tests/chebtech/test_qr.m
+++ b/tests/chebtech/test_qr.m
@@ -1,7 +1,6 @@
 % Test file for chebtech/qr.m
 
 function pass = test_qr(pref)
-
 % Get preferences.
 if ( nargin < 1 )
     pref = chebtech.techPref();
@@ -74,7 +73,6 @@ for n = 1:4
     pass(n, 20) = isequal(size(Q.vscale), [1 3]) && ...
         isequal(size(Q.epslevel), [1 3]);
 end
-
 end
 
 % Tests the QR decomposition for a CHEBTECH object F using a grid of points X


### PR DESCRIPTION
I am excited by this.  It is the first algorithmic speed up of the quasimatrix QR factorization in Chebfun for years.  It is also the first `dlt()` and `idlt()` Chebfun application.  

Let `A` be a `inf x m` quasimatrix with columns of maximum polynomial degree `n`.  The current QR factorization algorithm has a complexity of    `O( n^2m + nm^2 )`.   Using `ndct` and `idlt`, I changed the algorithm slightly so the QR factorization now costs  `O(nm (log n)^2/loglog n + nm^2 )` operations.  This is a big win for tall-skinny quasimatrices. 

For example (do not try this if you are not on this branch!): 
```
A = chebpoly(1e4:1e4+1);        % inf x 2 quasimatrix 
tic, [Q, R] = qr( A ); toc 
Elapsed time is 0.843294 seconds.
```
In `development` this crashes MATLAB as it tries to construct an `10000x10000` dense matrix. 

We can work out orthogonal bases for sets of functions with *extremely* high degree: 
```
x = chebfun('x'); 
f = cos( x * (1e4:1e4:5e4) );
tic, [Q, R] = qr( f ); toc 
Elapsed time is 9.336177 seconds.
```
Here, the maximum degree in a column of f was 50336... so I am happy with 10 seconds. 

The algorithm currently in development cannot get over `n = 5000`.  I wish I knew about this a week ago, but it will probably appear in the DLT paper after it is back from the review. 
