### PR TITLE
Fix chebgui eig2

### DIFF
--- a/@chebgui/demo2chebgui.m
+++ b/@chebgui/demo2chebgui.m
@@ -20,8 +20,9 @@ inputEnded = 0;
 while ( ~inputEnded )
     tline = fgetl(fid);
 
-    % Don't eval names and demotypes
-    if ( isempty(strfind(tline, '=')) )
+    % Don't eval names and demotypes. Also, don't eval lines that start at #, as
+    % those are problem description lines needed for testing.
+    if ( isempty(tline) || isempty(strfind(tline, '=')) || tline(1) == '#' )
         continue
     end
 

--- a/@chebgui/solveGUIeig.m
+++ b/@chebgui/solveGUIeig.m
@@ -35,7 +35,7 @@ end
 expInfo = chebguiExporterEIG.exportInfo(guifile);
 
 % Extract the needed fields from the EXPINFO struct.
-dom = str2num(expInfo.dom);
+dom = str2num(expInfo.dom); %#ok<ST2NM>
 allVarNames = expInfo.allVarNames;
 indVarName = expInfo.indVarName;
 eigVarName = expInfo.lname;
@@ -77,7 +77,7 @@ end
 if ( ~isempty(rhsString) )
     RHS = eval(rhsString);
     N_RHS = chebop(RHS, dom);
-
+    [VV, DD] = eigs(N_LHS, N_RHS);
     try
         B = linop(N_RHS);
     catch ME
@@ -153,6 +153,9 @@ else
     end
 end
 
+% norm(chebfun(A*V-B*V*D))
+
+
 % Sort the eigenvalues.
 [D, idx] = sort(diag(D));
 
@@ -163,10 +166,10 @@ V = V(:,idx);
 if ( ~guiMode )
     % If we're not in GUI mode, we can finish here.
     if ( nargout == 1 )
-        varargout = diag(D);
+        varargout = D;
     else
-        varargout{1} = D;
-        varargout{2} = V;
+        varargout{1} = V;
+        varargout{2} = diag(D);
     end
     
 else

--- a/@chebguiController/loadDemoMenu.m
+++ b/@chebguiController/loadDemoMenu.m
@@ -146,8 +146,21 @@ function [demoName, demoFun, demoType] = parseDemoFile(demoPath, handles)
     % Need to obtain the name and type of the demo as well
     fid = fopen(demoPath);
 
+    % Loop through the problem descriptions for testing at the top of the files.
+    while ( true )
+        tline = fgetl(fid);
+        % Once we don't have a # at the start, we longer are in the problem
+        % description part of the file.
+        if ( isempty(tline) || tline(1) ~= '#')
+            break
+        end
+    end
+
+    % Now load the problem description and type lines, which will be the next
+    % lines up.
+    
     % Throw away ' at the ends of the string
-    demoName = fgetl(fid);
+    demoName = tline;
     demoName = demoName(2:end-1);
     demoType = fgetl(fid);
     demoType = demoType(2:end-1);

--- a/@chebguiExporterEIG/exportInfo.m
+++ b/@chebguiExporterEIG/exportInfo.m
@@ -184,7 +184,7 @@ if ( ~isempty(rhsString) )
         
         opDifference = Bdisc - Idisc;
         opSum = Bdisc + Idisc;
-        tol = 10*(length(d) - 1)*size(B, 2);
+        tol = 10*(length(d) - 1)*size(B, 2)*eps;
         % Check whether B matches identity (allow for numerical roundoff errors)
         if ( norm(opDifference) < tol )
             generalized = 0;

--- a/chebguiDemos/eigdemos/advection_diffusion.guifile
+++ b/chebguiDemos/eigdemos/advection_diffusion.guifile
@@ -1,3 +1,7 @@
+# dom = [0, 10];
+# N = chebop(@(u) diff(u, 2) + diff(u), dom);
+# N.bc = 0;
+# [V, D] = eigs(N, 6);
 'Advection-diffusion'
 'scalar'
 domain = '[0 10]';

--- a/chebguiDemos/eigdemos/advection_diffusion_periodic.guifile
+++ b/chebguiDemos/eigdemos/advection_diffusion_periodic.guifile
@@ -1,3 +1,7 @@
+# dom = [0, 2*pi];
+# N = chebop(@(u) diff(u, 2) + diff(u), dom);
+# N.bc = 'periodic';
+# [V, D] = eigs(N, 15);
 'Advection-diffusion with periodic BCs'
 'scalar'
 domain = '[0 2*pi]';

--- a/chebguiDemos/eigdemos/airy.guifile
+++ b/chebguiDemos/eigdemos/airy.guifile
@@ -1,3 +1,7 @@
+# dom = [-1, 1];
+# N = chebop(@(x,u) 0.002*diff(u, 2) + 1i*x*u, dom);
+# N.bc = 0;
+# [V, D] = eigs(N, 25);
 'Complex Airy operator'
 'scalar'
 domain = '[-1 1]';

--- a/chebguiDemos/eigdemos/cross.guifile
+++ b/chebguiDemos/eigdemos/cross.guifile
@@ -1,3 +1,8 @@
+# dom = [0, 2*pi];
+# N = chebop(@(u) -diff(u, 2), dom);
+# B = chebop(@(u) u + diff(u), dom);
+# N.bc = 0;
+# [V, D] = eigs(N, B, 12);
 'A cross of eigenvalues'
 'scalar'
 domain = '[0 2*pi]';

--- a/chebguiDemos/eigdemos/davies.guifile
+++ b/chebguiDemos/eigdemos/davies.guifile
@@ -1,3 +1,7 @@
+# dom = [-8, 8];
+# N = chebop(@(x, u) -diff(u, 2) + 1i*x.^2.*u, dom);
+# N.bc = 0;
+# [V, D] = eigs(N, 6);
 'Davies complex harmonic oscillator'
 'scalar'
 domain = '[-8 8]';

--- a/chebguiDemos/eigdemos/derivative.guifile
+++ b/chebguiDemos/eigdemos/derivative.guifile
@@ -1,3 +1,7 @@
+# dom = [-pi pi];
+# N = chebop(@(u) -diff(u), dom);
+# N.bc = 'periodic';
+# [V, D] = eigs(N, 16);
 'Derivative operator on periodic domain'
 'scalar'
 domain = '[-pi pi]';

--- a/chebguiDemos/eigdemos/double_well.guifile
+++ b/chebguiDemos/eigdemos/double_well.guifile
@@ -1,3 +1,7 @@
+# dom = [-5 5];
+# N = chebop(@(x,u) -.1*diff(u, 2) + 4*(sign(x+1)-sign(x-.9))*u, dom);
+# N.bc = 0;
+# [V, D] = eigs(N, 4);
 'Double well Schrodinger'
 'scalar'
 domain = '[-5 5]';

--- a/chebguiDemos/eigdemos/harmonic.guifile
+++ b/chebguiDemos/eigdemos/harmonic.guifile
@@ -1,3 +1,7 @@
+# dom = [-8 8];
+# N = chebop(@(x,u) -diff(u, 2) + x.^2*u, dom);
+# N.bc = 0;
+# [V, D] = eigs(N, 6);
 'Harmonic oscillator'
 'scalar'
 domain = '[-8 8]';

--- a/chebguiDemos/eigdemos/harmonic_system.guifile
+++ b/chebguiDemos/eigdemos/harmonic_system.guifile
@@ -1,3 +1,9 @@
+# dom = [0, pi];
+# N = chebop(@(x,u,v) [diff(u); diff(v)], dom);
+# B = chebop(@(x,u,v) [v; -u], dom);
+# N.lbc = @(u,v) u;
+# N.rbc = @(u,v) u;
+# [V, D] = eigs(N, B, 6);
 'Harmonic oscillator as 1st-order system'
 'system'
 domain = '[0 pi]';

--- a/chebguiDemos/eigdemos/mathieu.guifile
+++ b/chebguiDemos/eigdemos/mathieu.guifile
@@ -1,3 +1,7 @@
+# dom = [-pi pi];
+# N = chebop(@(x, u) diff(u, 2) + 5*cos(2*x)*u, dom);
+# N.bc = 'periodic';
+# [V, D] = eigs(N, 6);
 'Mathieu equation'
 'scalar'
 domain = '[-pi pi]';

--- a/chebguiDemos/eigdemos/mathieu.guifile
+++ b/chebguiDemos/eigdemos/mathieu.guifile
@@ -1,5 +1,5 @@
 # dom = [-pi pi];
-# N = chebop(@(x, u) diff(u, 2) + 5*cos(2*x)*u, dom);
+# N = chebop(@(x, u) -diff(u, 2) + 5*cos(2*x)*u, dom);
 # N.bc = 'periodic';
 # [V, D] = eigs(N, 6);
 'Mathieu equation'

--- a/chebguiDemos/eigdemos/orr_sommerfeld.guifile
+++ b/chebguiDemos/eigdemos/orr_sommerfeld.guifile
@@ -1,8 +1,8 @@
 # dom = [-1 1];
-# N = chebop(@(x,u) (diff(u,4)-2*diff(u,2)u+u)/5772-2i*u-1i*(1-x^2)*(diff(u,2)-u), dom);
+# N = chebop(@(x,u) (diff(u,4)-2*diff(u,2)+u)/5772-2i*u-1i*(1-x^2)*(diff(u,2)-u), dom);
 # B = chebop(@(u) diff(u, 2) - u, dom);
-# N.lbc = (u) [u; diff(u)];
-# N.rbc = (u) [u; diff(u)];
+# N.lbc = @(u) [u; diff(u)];
+# N.rbc = @(u) [u; diff(u)];
 # [V, D] = eigs(N, B, 50);
 'Orr-Sommerfeld operator'
 'scalar'

--- a/chebguiDemos/eigdemos/orr_sommerfeld.guifile
+++ b/chebguiDemos/eigdemos/orr_sommerfeld.guifile
@@ -1,3 +1,9 @@
+# dom = [-1 1];
+# N = chebop(@(x,u) (diff(u,4)-2*diff(u,2)u+u)/5772-2i*u-1i*(1-x^2)*(diff(u,2)-u), dom);
+# B = chebop(@(u) diff(u, 2) - u, dom);
+# N.lbc = (u) [u; diff(u)];
+# N.rbc = (u) [u; diff(u)];
+# [V, D] = eigs(N, B, 50);
 'Orr-Sommerfeld operator'
 'scalar'
 domain = '[-1 1]';

--- a/chebguiDemos/eigdemos/variable_coeffs_system.guifile
+++ b/chebguiDemos/eigdemos/variable_coeffs_system.guifile
@@ -1,3 +1,8 @@
+# dom = [-2 2];
+# N = chebop(@(x,u,v) [diff(u,2) + u*x + v; diff(v,2) + sin(x)*u], dom);
+# N.lbc = @(u,v) [u;v];
+# N.rbc = @(u,v) [u;v];
+# [V, D] = eigs(N, 6);
 'System with variable coefficients'
 'system'
 domain = '[-2 2]';


### PR DESCRIPTION
Determine properly whether EIG problems are generalized or not.

Solve EIG problems in CHEBGUI in CHEBOP mode, rather than LINOP mode.

Cleaning up exporting code for EIG problems.

This fixes the broken EIG problems of Chebgui.

It also introduces capabilities for automatic testing of EIG demos (via code I haven't pushed yet to the dev-tools repo). This is done through the lines starting with `#` at the top of each `.guifile`, which contain Chebfun code to be executed. I'll issue a separate pull request for the automatic testing of BVPs, IVPs and PDEs.