### PR TITLE
Fix chebmatrix domain checking

### DIFF
--- a/@chebmatrix/chebmatrix.m
+++ b/@chebmatrix/chebmatrix.m
@@ -141,12 +141,6 @@ classdef (InferiorClasses = {?chebfun, ?operatorBlock, ?functionalBlock}) chebma
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     methods
                    
-%         function A = set.domain(A, d)
-%         %SET.DOMAIN   Insert breakpoints in the domain of the CHEBMATRIX.
-%         %   We don't allow removing breakpoints, or changing endpoints.
-%             A.domain = A.mergeDomains(d, A.domain);
-%         end
-        
         function d = get.diffOrder(L)
         %GET.DIFFORDER    Differential order of each CHEBMATRIX block. 
         %   Also accessible via property: get(A, 'diffOrder');

--- a/@chebmatrix/chebmatrix.m
+++ b/@chebmatrix/chebmatrix.m
@@ -141,11 +141,11 @@ classdef (InferiorClasses = {?chebfun, ?operatorBlock, ?functionalBlock}) chebma
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     methods
                    
-        function A = set.domain(A, d)
-        %SET.DOMAIN   Insert breakpoints in the domain of the CHEBMATRIX.
-        %   We don't allow removing breakpoints, or changing endpoints.
-            A.domain = A.mergeDomains(d, A.domain);
-        end
+%         function A = set.domain(A, d)
+%         %SET.DOMAIN   Insert breakpoints in the domain of the CHEBMATRIX.
+%         %   We don't allow removing breakpoints, or changing endpoints.
+%             A.domain = A.mergeDomains(d, A.domain);
+%         end
         
         function d = get.diffOrder(L)
         %GET.DIFFORDER    Differential order of each CHEBMATRIX block. 

--- a/@chebmatrix/mergeDomains.m
+++ b/@chebmatrix/mergeDomains.m
@@ -24,8 +24,13 @@ end
 doms(cellfun(@isempty, doms)) = [];
 
 % If we're left with one domain, return it!
-if ( length(doms) == 1)
+if ( length(doms) == 1 )
     d = doms{1};
+    return
+    
+% If we're left with an empty domain, return it as well.
+elseif ( isempty(doms) )
+    d = [];
     return
 end
 

--- a/@chebmatrix/mergeDomains.m
+++ b/@chebmatrix/mergeDomains.m
@@ -9,14 +9,59 @@ function d = mergeDomains(varargin)
 % Copyright 2014 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.
 
-d = [];
-for i = 1:nargin
-    item = varargin{i};
+% Start by getting all the domains from VARARGIN
+doms = cell(size(varargin));
+for argCounter = 1:nargin
+    item = varargin{argCounter};
     if ( isnumeric(item) && (length(item) > 1) )
-        d = domain.merge(d, item);
+        doms{argCounter} = item;
     elseif ( isa(item, 'chebfun') || isa(item, 'linBlock') )
-        d = domain.merge(d, item.domain);
+        doms{argCounter} = item.domain;
     end
+end
+
+% Throw away empties
+doms(cellfun(@isempty, doms)) = [];
+
+% If we're left with one domain, return it!
+if ( length(doms) == 1)
+    d = doms{1};
+    return
+end
+
+% Often in the CHEBMATRIX case, we're dealing with objects that live on the same
+% domains. The DOMAIN.MERGE() method is pretty expensive, so we check whether we
+% can get away with a cheaper version of merging the domains -- namely, if
+% they're all of the same size, we check their diffs, and if they agree, we're
+% happy!
+
+% Start off by assuming that the domains don't match:
+domainMatch = false;
+% 
+% Get the lengths of all the domains:
+domLengths = cellfun(@length, doms);
+% Do the length of the domains agree?
+lengthMatch = ~any(domLengths - domLengths(1));
+if ( lengthMatch )
+    % Compare the other entries of DOMS with the first entry.
+    % The row vector with the first domain:
+    dom1 = doms{1};
+    % A matrix with the rest of the domains:
+    domMat = cell2mat(doms(2:end)');
+    
+    % Subtract the first row from the matrix, and check whether we get any
+    % non-zero entries:
+    domainMatch = ~any(any(bsxfun(@minus, domMat, dom1)));
+    
+end
+
+% Did the domains match?
+if ( domainMatch )
+    % Return the first entry of DOMS:
+    d = dom1;
+else
+    % We need to merge all the domains:
+    d = domain.merge(doms{:});
 end
 
 end

--- a/@domain/merge.m
+++ b/@domain/merge.m
@@ -22,11 +22,7 @@ doms = varargin;
 doms = cellfun(@(dom) double(dom), doms, 'UniformOutput', false);
 
 % Ignore empties:
-for k = numel(doms):-1:1
-    if ( isempty(doms{k}) )
-        doms(k) = []; % Discard if this domain is now empty.
-    end
-end
+doms(cellfun(@isempty, doms)) = [];
 
 % Initialise newDom:
 newDom = [];


### PR DESCRIPTION
At the moment, there's a lot of inefficiencies in how we deal with checking and merging of domains in `chebmatrix`. Take for example this script brought to my attention by @trefethen , it solves an ODE with a right hand side with a lot of pieces:
```
tic
dom = [0 16];
x = chebfun('x',dom);
f = (x-floor(x))<sqrt(2)/7;
L = chebop(dom);
L.lbc = 0; L.rbc = 1;
L.op = @(x,u) diff(u,2);
tic, u = L\f;
toc
```

On development, I get a running time of 12.93 seconds. On this branch, I get 4.50 seconds.

The main changes it does are as follows:

* Rather than repeatedly calling `domain.merge` as we loop through blocks of a `chebmatrix` in `chebmatrix.mergeDomains`, it starts by building a cell with all the domains, then calls `domain.merge` once.
* It also does more clever checking in `chebmatrix.mergeDomains`, saving a lot of redundant calls to `domain.merge`.
* In the `domain` methods for creating linops (which we included for backwards compatibility), we start by casting domains back to doubles, rather than calling the `operatorBlock/functionalBlock` methods with `domain` arguments.

I'm aware that chebtests should not be used for speed comparison, but as a reference, for a selected sets of tests (which involve the `chebmatrix` class in one way or the other), namely,
```
chebtest('adchebfun','chebgui','chebmatrix','chebop','domain','linop','functionalBlock', 'operatorBlock')
``` 
I get 414 seconds on development, 368 seconds on this branch.

Finally, there are further speedups to be achieved for piecewise BVPs, however, #1482 needs to be dealt with first before those can be introduced.