### PR TITLE
Feature pde15s periodic

### DIFF
--- a/@chebfun/pdeSolve.m
+++ b/@chebfun/pdeSolve.m
@@ -68,6 +68,7 @@ else
 end
 
 userMassSet = false;
+isPeriodic = false;
 
 %% %%%%%%%%%%%%%%%%%%%%%%%%%%  PARSE INPUTS TO PDEFUN  %%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -185,7 +186,7 @@ end
                 
             % Reshape solution:
             Uk = reshape(U(:,kk), n, SYSSIZE);
-            uCurrent = chebfun(Uk, DOMAIN);
+            uCurrent = chebfun(Uk, DOMAIN, 'tech', tech);
             tCurrent = t(kk);
             % Store for output:
             ctr = ctr + 1;
@@ -218,8 +219,12 @@ end
             % Happiness check:
             c = (1+sin(1:SYSSIZE)).'; % Arbitrarily linear combination.
             Uk2 = (Uk*c/sum(c));
-            uk2 = chebtech2(Uk2, pref);
-            [ishappy, epslevel, cutoff] = classicCheck(uk2, Uk2, pref);
+            uk2 = tech.make(Uk2, pref);
+            if ( isPeriodic )
+                [ishappy, epslevel, cutoff] = classicCheck(uk2, pref);
+            else
+                [ishappy, epslevel, cutoff] = classicCheck(uk2, Uk2, pref);
+            end
 
             if ( ishappy )  
                 
@@ -230,17 +235,17 @@ end
 
                 % Store these values:
                 tCurrent = t(kk);
-                uCurrent = chebfun(Uk, DOMAIN, 'tech', @chebtech2);
+                uCurrent = chebfun(Uk, DOMAIN, 'tech', techHandle);
+                uCurrent = simplify(uCurrent, epslevel);
                 
-                % Shorten the representation. The happiness cutoff seems to
-                % be safer than the epslevel simplification.
-%                 uCurrent = simplify(uCurrent, epslevel);
-                uPoly = get(uCurrent, 'coeffs');
-                firstKept = size(uPoly, 2) - (cutoff-1);
-                if ( firstKept <= 0 )
-                    firstKept = 1;
-                end
-                uCurrent = chebfun(uPoly(firstKept:end,:), DOMAIN, 'coeffs');
+%                 % Shorten the representation. The happiness cutoff seems to
+%                 % be safer than the epslevel simplification.
+%                 uPoly = get(uCurrent, 'coeffs');
+%                 firstKept = size(uPoly, 2) - (cutoff-1);
+%                 if ( firstKept <= 0 )
+%                     firstKept = 1;
+%                 end
+%                 uCurrent = chebfun(uPoly(firstKept:end,:), DOMAIN, 'coeffs');
                 
                 ctr = ctr + 1;
                 uOut{ctr} = uCurrent;
@@ -410,21 +415,28 @@ rightNonlinBCLocs = [];
 BCRHS = {};
 
 if ( ischar(bc) && any(strcmpi(bc, {'periodic', 'trig'})) )
+        
     %% %%%%%%%%%%%%%%%%%%%%%%%%%%% PERIODIC BCS  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    r = cell(sum(DIFFORDER), 1);
-    count = 1;
-    for j = 1:SYSSIZE
-        for k = 0:DIFFORDER(j)-1
-            c = (diff(DOMAIN)/2)^k;
-            A = @(n) [1 zeros(1, n-2) -1]*chebcolloc2.diffmat(n, k)*c;
-            r{count} = @(n) [zeros(1, (j-1)*n) A(n) zeros(1,(SYSSIZE-j)*n)];
-            count = count + 1;
-        end
-    end
-    bc = struct( 'left', [], 'right', []);
-    bc.left.op = r(1:2:end);
-    bc.right.op = r(2:2:end);
-    BCRHS = num2cell(zeros(1, numel(r)));
+    
+    isPeriodic = true;
+    
+    % One can still use a Chebyshev basis and enforce periodic conditions by
+    % enforcing suitable constraints on the derivative. However, using a
+    % periodic basis (for now, trigtech) is much more efficient.
+%     r = cell(sum(DIFFORDER), 1);
+%     count = 1;
+%     for j = 1:SYSSIZE
+%         for k = 0:DIFFORDER(j)-1
+%             c = (diff(DOMAIN)/2)^k;
+%             A = @(n) [1 zeros(1, n-2) -1]*chebcolloc2.diffmat(n, k)*c;
+%             r{count} = @(n) [zeros(1, (j-1)*n) A(n) zeros(1,(SYSSIZE-j)*n)];
+%             count = count + 1;
+%         end
+%     end
+%     bc = struct( 'left', [], 'right', []);
+%     bc.left.op = r(1:2:end);
+%     bc.right.op = r(2:2:end);
+%     BCRHS = num2cell(zeros(1, numel(r)));
     
 else
     %% %%%%%%%%%%%%%%%%%%%%%%%%% NONPERIODIC BCS  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -540,10 +552,9 @@ else
     
 end
 
-if ( ~isfield(bc, 'middle') )
+if ( ~isPeriodic && ~isfield(bc, 'middle') )
     bc.middle.op = [];
 end
-
 
 %% %%%%%%%%%%%%%%%%%%%%%%% SUPPORT FOR COUPLED BVP-PDES! %%%%%%%%%%%%%%%%%%%%%%%
 % Experimental feature for coupled ode/pde systems: (An entry equal to 1 denotes
@@ -557,6 +568,18 @@ if ( numel(pdeFlag) == 1 )
     pdeFlag = repmat(pdeFlag, 1, SYSSIZE);
 end
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% PERIODIC %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+if ( ~isPeriodic )
+    techHandle = @chebtech2;
+    points = @chebpts;
+    mydouble = @chebdouble;
+else
+    techHandle = @trigtech;
+    points = @trigpts;
+    mydouble = @trigdouble;  
+end
+tech = techHandle();
 
 %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% MISC %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -570,7 +593,7 @@ uOut{1} = uCurrent;
 B = []; q = []; rows = []; M = []; P = []; n = [];
 
 % Set the preferences:
-pref = chebtech.techPref();
+pref = tech.techPref();
 pref.eps = tol;
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -589,7 +612,7 @@ DONE = false;
 if ( ~isnan(optN) )
     % Non-adaptive in space:
     tSpan = tt;
-    x = chebpts(optN, DOMAIN);
+    x = points(optN, DOMAIN);
     solvePDE(tSpan); % Do all chunks at once!
 else
     % Adaptive in space
@@ -600,7 +623,7 @@ else
     tSpan = tt;
     while ( tCurrent < tt(end) && ~DONE )
         tSpan(tSpan < tCurrent) = [];
-        x = chebpts(currentLength, DOMAIN);
+        x = points(currentLength, DOMAIN);
         solvePDE(tSpan);
     end
 
@@ -653,9 +676,14 @@ clear global SYSSIZE
 
         % Evaluate the chebfun at discrete points:
         U0 = feval(uCurrent, x);
-        
-        % This depends only on the size of n. If this is the same, reuse!
-        if ( isempty(n) || (n ~= length(x)) )
+
+        if ( isPeriodic )
+            
+            % The discretisation length
+            n = length(x);
+            
+        elseif ( isempty(n) || (n ~= length(x)) )
+            % This depends only on the size of n. If this is the same, reuse!
             
             % The new discretisation length
             n = length(x);
@@ -688,26 +716,28 @@ clear global SYSSIZE
             
         end
         
-        % We have to ensure the starting condition satisfies the boundary
-        % conditions, or else we will get a singularity in time. We do this by
-        % tweaking the BC values to match the reality. Changing the IC itself is
-        % much trickier. Find out what the BC deviance from nominal really is:
-        BCVALOFFSET = 0;            % recover nominal value in next call
-        F = odeFun(tSpan(1),U0(:)); % also assigns to "rows" and "q"
-        
-        % If this is for the initial chunk, check whether the initial
-        % condition nearly satisfies the BCs.
-        % We're quite lax about this, because discretization at low N can
-        % cause derivatives to look fairly bad. 
-        if ( throwBCwarning && (length(uOut) > 1) && (norm(F(rows)) > 0.05*norm(F)) )
-            warning('CHEBFUN:CHEBFUN:pde15s:BadIC',...
-                'Initial state may not satisfy the boundary conditions.')
-            throwBCwarning = false;
-        end
-        if ( adjustBCs )
-            BCVALOFFSET = F(rows) - q;
-        else
-            BCVALOFFSET = 0;
+        if ( ~isPeriodic )
+            % We have to ensure the starting condition satisfies the boundary
+            % conditions, or else we will get a singularity in time. We do this by
+            % tweaking the BC values to match the reality. Changing the IC itself is
+            % much trickier. Find out what the BC deviance from nominal really is:
+            BCVALOFFSET = 0;            % recover nominal value in next call
+            F = odeFun(tSpan(1),U0(:)); % also assigns to "rows" and "q"
+
+            % If this is for the initial chunk, check whether the initial
+            % condition nearly satisfies the BCs.
+            % We're quite lax about this, because discretization at low N can
+            % cause derivatives to look fairly bad. 
+            if ( throwBCwarning && (length(uOut) > 1) && (norm(F(rows)) > 0.05*norm(F)) )
+                warning('CHEBFUN:CHEBFUN:pde15s:BadIC',...
+                    'Initial state may not satisfy the boundary conditions.')
+                throwBCwarning = false;
+            end
+            if ( adjustBCs )
+                BCVALOFFSET = F(rows) - q;
+            else
+                BCVALOFFSET = 0;
+            end
         end
         
         % Solve ODE over time chunk with ode15s:
@@ -732,10 +762,18 @@ clear global SYSSIZE
             U = reshape(U, n, SYSSIZE);
             
             % Evaluate the PDEFUN:
-            Utmp = chebdouble(U, DOMAIN);
+            Utmp = mydouble(U, DOMAIN);
             F = pdeFun(t, x, Utmp);
             F = double(F);
-            F = P*F(:);
+            F = F(:);
+            
+            if ( isPeriodic )
+                return
+            end
+            
+            F = P*F;
+            
+            % Enforce boundary constraints:
             
             % Get the algebraic right-hand sides: (may be time-dependent)
             for l = 1:numel(BCRHS)

--- a/@chebfun/pdeSolve.m
+++ b/@chebfun/pdeSolve.m
@@ -220,6 +220,9 @@ end
             c = (1+sin(1:SYSSIZE)).'; % Arbitrarily linear combination.
             Uk2 = (Uk*c/sum(c));
             uk2 = tech.make(Uk2, pref);
+            
+            % TODO: This is required as trigtech.classicCheck has a different
+            % template to chebtech.classicCheck. We shuold fix this.
             if ( isPeriodic )
                 [ishappy, epslevel, cutoff] = classicCheck(uk2, pref);
             else

--- a/@chebfun/pdeSolve.m
+++ b/@chebfun/pdeSolve.m
@@ -220,14 +220,7 @@ end
             c = (1+sin(1:SYSSIZE)).'; % Arbitrarily linear combination.
             Uk2 = (Uk*c/sum(c));
             uk2 = tech.make(Uk2, pref);
-            
-            % TODO: This is required as trigtech.classicCheck has a different
-            % template to chebtech.classicCheck. We shuold fix this.
-            if ( isPeriodic )
-                [ishappy, epslevel, cutoff] = classicCheck(uk2, pref);
-            else
-                [ishappy, epslevel, cutoff] = classicCheck(uk2, Uk2, pref);
-            end
+            [ishappy, epslevel, cutoff] = classicCheck(uk2, Uk2, pref);
 
             if ( ishappy )  
                 

--- a/@chebtech/classicCheck.m
+++ b/@chebtech/classicCheck.m
@@ -7,9 +7,9 @@ function [ishappy, epslevel, cutoff] = classicCheck(f, values, pref)
 %   below and FALSE otherwise.  If ISHAPPY is FALSE, EPSLEVEL returns an
 %   estimate of the accuracy achieved.
 %
-%   [ISHAPPY, EPSLEVEL, CUTOFF] = CLASSICCHECK(F, PREF) allows additional
-%   preferences to be passed. In particular, one can adjust the target accuracy
-%   with PREF.EPS.
+%   [ISHAPPY, EPSLEVEL, CUTOFF] = CLASSICCHECK(F, VALUES, PREF) allows
+%   additional preferences to be passed. In particular, one can adjust the
+%   target accuracy with PREF.EPS.
 %
 %   CLASSICCHECK first queries HAPPINESSREQUIREMENTS to obtain TESTLENGTH and
 %   EPSLEVEL (see documentation below). If |F.COEFFS(1:TESTLENGTH)|/VSCALE <

--- a/@trigtech/classicCheck.m
+++ b/@trigtech/classicCheck.m
@@ -1,4 +1,4 @@
-function [ishappy, epslevel, cutoff] = classicCheck(f, pref)
+function [ishappy, epslevel, cutoff] = classicCheck(f, values, pref)
 %CLASSICCHECK   Attempt to trim trailing Fourier coefficients in a TRIGTECH.
 %   [ISHAPPY, EPSLEVEL, CUTOFF] = CLASSICCHECK(F, VALUES) returns an estimated
 %   location, the CUTOFF, at which the TRIGTECH F could be truncated to maintain
@@ -6,9 +6,9 @@ function [ishappy, epslevel, cutoff] = classicCheck(f, pref)
 %   if CUTOFF < MIN(LENGTH(VALUES),2) or F.VSCALE = 0, and FALSE otherwise.
 %   If ISHAPPY is false, EPSLEVEL returns an estimate of the accuracy achieved.
 %
-%   [ISHAPPY, EPSLEVEL, CUTOFF] = CLASSICCHECK(F, PREF) allows additional
-%   preferences to be passed. In particular, one can adjust the target accuracy
-%   with PREF.EPS.
+%   [ISHAPPY, EPSLEVEL, CUTOFF] = CLASSICCHECK(F, VALUES, PREF) allows
+%   additional preferences to be passed. In particular, one can adjust the
+%   target accuracy with PREF.EPS.
 %
 %   CLASSICCHECK first queries HAPPINESSREQUIREMENTS to obtain TESTLENGTH and
 %   EPSLEVEL (see documentation below). If |F.COEFFS(1:TESTLENGTH)|/VSCALE <
@@ -121,7 +121,7 @@ ac = bsxfun(@rdivide, abs(f.coeffs), f.vscale);
 
 % Happiness requirements:
 [testLength, epslevel] = ...
-    happinessRequirements(f.values, f.coeffs, f.points(), f.vscale, f.hscale, epslevel);
+    happinessRequirements(values, f.coeffs, f.points(), f.vscale, f.hscale, epslevel);
 
 if ( all(max(ac(1:testLength, :)) < epslevel) ) % We have converged! Chop tail:
     % We must be happy.

--- a/@trigtech/happinessCheck.m
+++ b/@trigtech/happinessCheck.m
@@ -24,11 +24,11 @@ if ( strcmpi(pref.happinessCheck, 'classic') )
     % Use the default happiness check procedure from Chebfun V4.
     
     % Check the coefficients are happy:
-    [ishappy, epslevel, cutoff] = classicCheck(f, pref);
+    [ishappy, epslevel, cutoff] = classicCheck(f, f.values, pref);
     
 elseif ( strcmpi(pref.happinessCheck, 'plateau') )
     % Use the 'plateau' happiness check:
-    [ishappy, epslevel, cutoff] = plateauCheck(f, values, pref);
+    [ishappy, epslevel, cutoff] = plateauCheck(f, f.values, pref);
 
 elseif ( strcmpi(pref.happinessCheck, 'strict') )
     error('CHEBFUN:TRIGTECH:happinessCheck:strictCheck','Strict check not implemented for TRIGTECH.  Please use classic check.');

--- a/@trigtech/plateauCheck.m
+++ b/@trigtech/plateauCheck.m
@@ -32,6 +32,6 @@ function [ishappy, epsLevel, cutoff] = plateauCheck(f, values, pref)
 % [TODO]: implement PLATEAUCHECK for TRIGTECH. For the moment, we just call
 % classicCheck. The reason why the plateauCheck() is needed for TRIGTECH is 
 % that it gets called in CHEBDISCRETIZATION/TESTCONVERGENCE.
-[ishappy, epsLevel, cutoff] = classicCheck(f, pref);
+[ishappy, epsLevel, cutoff] = classicCheck(f, values, pref);
 
 end

--- a/trigdouble.m
+++ b/trigdouble.m
@@ -134,8 +134,7 @@ classdef trigdouble < chebdouble
             n = length(u.values);
             dom = u.domain;
             x = trigpts(n, dom);
-            v = trigpts.barywts(n);
-            out = trigtech.bary(y, u.values, x, v);
+            out = trigBary(y, u.values, x, dom);
 
         end
                 

--- a/trigdouble.m
+++ b/trigdouble.m
@@ -1,0 +1,125 @@
+classdef trigdouble < chebdouble
+%FOURDOUBLE   Fourier double class. 
+%
+%   See the CHEBDOUBLE class for details.
+%
+%   This class in intended solely as a worker-class for PDE15s.
+
+% Copyright 2014 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+    methods
+        
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    %% CLASS CONSTRUCTOR:
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+        function obj = trigdouble(varargin)
+            
+            % Call the CHEBDOUBLE constructor:
+            obj = obj@chebdouble(varargin{:});
+            
+        end
+        
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    %% CLASS METHODS:
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%        
+
+        %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  DIFF  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+        function u = diff(u, k)
+            %DIFF   Compute the k-th derivative of u using Fourier
+            % differentiation matrices defined by diffmat.
+            
+            % Store the diffmat D as a persistent variable to allow speeding up
+            % if we work with the same discretization at multiple time steps.
+            % Note that the matrix D is independent of the domain, since it is
+            % scaled separately below.
+            persistent D
+            
+            % Assume first-order derivative
+            if ( nargin == 1 )
+                k = 1;
+            end
+            
+            N = length(u.values);
+            
+            % Construct D if we don't match a previous discretization.
+            if ( isempty(D) || numel(D) < k || size(D{k}, 1) ~= N )
+                D{k} = trigtech.diffmat(N, k); % Diffmat
+            end
+            
+            % Interval scaling
+            c = 2*pi/diff(u.domain);     
+            
+            % Muliplying by the kth-order differentiation matrix
+            u.values = c^k*(D{k}*u.values);
+            
+            % Update the difforder:
+            u.diffOrder = u.diffOrder + k;
+            
+        end
+        
+        %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  SUM  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+        % The differential operators
+        function I = sum(u, a, b)
+            %SUM  Compute the integral of u.
+            
+            % TODO: Add support.
+            error('CHEBFUN:FOURDOUBLE:sum:noImplemented', 'Not implemented yet.')
+            
+        end
+        
+        function I = integral(varargin)
+            I = sum(varargin{:});
+        end
+        
+        %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  CUMSUM  %%%%%%%%%%%%%%%%%%%%%%%%%%%%
+        % The differential operators
+        function u = cumsum(u)
+            %CUMSUM   Compute the indefinite integral of the Chebyshev
+            %         interpolant to u.
+            
+            % TODO: Add support.
+            error('CHEBFUN:FOURDOUBLE:cumsum:noImplemented', 'Not implemented yet.')
+            
+        end
+        
+        %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  FRED  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+        function u = fred(K, u)
+            %FRED  Fredholm operator with kernel K.
+            %   FRED(K, U) computes the action of the Fredholm operator with
+            %   kernel K on the Chebyshev interpolant to the points in the
+            %   vector U.
+            
+            % TODO: Add support.
+            error('CHEBFUN:FOURDOUBLE:fred:noImplemented', 'Not implemented yet.')
+            
+        end
+        
+        %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  VOLT  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+        function u = volt(K, u)
+            %VOLT  Volterra operator with kernel K.
+            %   VOLT(K, U) computes the action of the Volterra operator with
+            %   kernel K on the Chebyshev interpolant to the points in the
+            %   vector U.
+            
+            % TODO: Add support.
+            error('CHEBFUN:FOURDOUBLE:volt:noImplemented', 'Not implemented yet.')
+            
+        end
+
+        %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  FEVAL  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+        
+        function out = feval(u, y)
+            %FEVAL  Evaluate polynomial interpolant of data {X_four, U} at a
+            % point y using barycentric interpolation.
+            
+            % TODO: Add support.
+            error('CHEBFUN:FOURDOUBLE:feval:noImplemented', 'Not implemented yet.')
+
+        end
+                
+    end
+    
+end
+
+

--- a/trigdouble.m
+++ b/trigdouble.m
@@ -63,8 +63,24 @@ classdef trigdouble < chebdouble
         function I = sum(u, a, b)
             %SUM  Compute the integral of u.
             
-            % TODO: Add support.
-            error('CHEBFUN:FOURDOUBLE:sum:noImplemented', 'Not implemented yet.')
+            persistent W
+            
+            if ( nargin > 1 )
+                % TODO: Add support.
+                error('CHEBFUN:FOURDOUBLE:sum:notImplemented', ...
+                    'Not implemented yet.')
+            end
+            
+            % Retrieve or compute weights::
+            if ( N > 5 && numel(W) >= N && ~isempty(W{N}) )
+                % Weights are already in storage!
+            else
+                c = diff(u.domain)/2; % Interval scaling.
+                W{N} = c*trigtech.quadwts(N);
+            end
+            
+            % Find the sum by muliplying by the weights vector:
+            I = W{N}*u;
             
         end
         
@@ -79,7 +95,8 @@ classdef trigdouble < chebdouble
             %         interpolant to u.
             
             % TODO: Add support.
-            error('CHEBFUN:FOURDOUBLE:cumsum:noImplemented', 'Not implemented yet.')
+            error('CHEBFUN:FOURDOUBLE:cumsum:notImplemented', ...
+                'Not implemented yet.')
             
         end
         
@@ -91,7 +108,8 @@ classdef trigdouble < chebdouble
             %   vector U.
             
             % TODO: Add support.
-            error('CHEBFUN:FOURDOUBLE:fred:noImplemented', 'Not implemented yet.')
+            error('CHEBFUN:FOURDOUBLE:fred:notImplemented', ...
+                'Not implemented yet.')
             
         end
         
@@ -103,7 +121,8 @@ classdef trigdouble < chebdouble
             %   vector U.
             
             % TODO: Add support.
-            error('CHEBFUN:FOURDOUBLE:volt:noImplemented', 'Not implemented yet.')
+            error('CHEBFUN:FOURDOUBLE:volt:notImplemented', ...
+                'Not implemented yet.')
             
         end
 
@@ -114,7 +133,8 @@ classdef trigdouble < chebdouble
             % point y using barycentric interpolation.
             
             % TODO: Add support.
-            error('CHEBFUN:FOURDOUBLE:feval:noImplemented', 'Not implemented yet.')
+            error('CHEBFUN:FOURDOUBLE:feval:notImplemented', ...
+                'Not implemented yet.')
 
         end
                 

--- a/trigdouble.m
+++ b/trigdouble.m
@@ -127,14 +127,15 @@ classdef trigdouble < chebdouble
         end
 
         %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  FEVAL  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-        
         function out = feval(u, y)
             %FEVAL  Evaluate polynomial interpolant of data {X_four, U} at a
             % point y using barycentric interpolation.
             
-            % TODO: Add support.
-            error('CHEBFUN:FOURDOUBLE:feval:notImplemented', ...
-                'Not implemented yet.')
+            n = length(u.values);
+            dom = u.domain;
+            x = trigpts(n, dom);
+            v = trigpts.barywts(n);
+            out = trigtech.bary(y, u.values, x, v);
 
         end
                 


### PR DESCRIPTION
Replacing #1488 with this one. Per @nickhale's original message:

In the past we dealt with periodic problems by enforcing
certain derivative conditions on the solution. A much
better way is to use a periodic basis, thus negating the
need to enforce any boundary conditions at all.

The following, which hangs on development after t = .5,
now works perfectly:

```
dom = [-1 1];
t = 0:.01:1;
pdefun = @(t,x,u) diff(u);
bc = 'periodic';
x = chebfun(@(x) x, dom);
u0 = sin(3*pi*x);
opts = pdeset('Eps', 1e-6, 'Ylim', [-1.2,1.2]);
[t, sol] = pde15s(pdefun, t, u0, bc, opts);
```

Note, this branch is based off of `feature-pde23t` (and based off of an earlier implementation in `feature-fourtech-pde`). I propose we merge this branch with `feature-pde23t` before merging to development.