### PR TITLE
Implement trigonometric version of barycentric interpolation formula.

### DIFF
--- a/@trigtech/bary.m
+++ b/@trigtech/bary.m
@@ -1,0 +1,67 @@
+function fx = bary(x, fvals, xk, wk)
+%BARY   Trigonometric barycentric interpolation formula.
+%   TRIGTECH.BARY(X, FVALS, XK, VK) uses the 2nd form trigonometric barycentric
+%   formula with weights VK to evaluate an interpolant of the data {XK,
+%   FVALS(:,k)} at the points X. Note that XK must be equally-spaced.
+%   Furthermore, XK and VK should be column vectors, and FVALS, XK, and VK
+%   should have the same length.
+%
+%   BARY(X, FVALS) assumes XK are equispaced in [-1, 1) (i.e., as return by
+%   TRIGTECH.TRIGPTS()) and that VK are the corresponding barycentric weights
+%   for trigonomentric-polynomial interpolation (i.e, as returned by
+%   TRIGTECH.BARYWTS().).
+
+% See also TRIG.TRIGPTS and TRIG.BARYWTS.
+
+% Copyright 2014 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+% Length of interpolant:
+n = length(fvals);
+
+% Store dimension of input and reshape to column vector:
+sizex = size(x);
+x = x(:);
+
+% Default to equigrid:
+if ( nargin < 3 )
+    xk = trigtech.trigpts(n);
+end
+% Default weights to trig-poly on equigrid:
+if ( nargin < 4 )
+    wk = trigtech.barywts(n);
+end
+
+% Scale to an interval of length 2*pi:
+dom = xk(end) + xk(2) - 2*xk(1);
+scl = 2*pi/dom;
+
+% Deal with odd / even points (and include sclaing):
+if ( mod(n, 2) )
+    F = @(x) sin(scl*x); % Odd number of points
+else
+    F = @(x) tan(scl*x); % Even number of points 
+end   
+
+% Intialise:
+numer = 0; denom = 0;
+% Loop over the interpolation nodes:
+for k = 1:n
+    temp = wk(k) ./ F((x-xk(k))/2);
+    numer = numer + temp*fvals(k);
+    denom = denom + temp;
+end
+fx = numer./denom;
+
+% Try to clean up NaNs:
+for k = find(isnan(fx(:,1)))'       % (Transpose as Matlab loops over columns)
+    index = find(x(k) == xk, 1);    % Find the corresponding node
+    if ( ~isempty(index) )
+        fx(k,:) = fvals(index,:);   % Set entry/entries to the correct value
+    end
+end
+
+% Reshape output:
+fx = reshape(fx, sizex);
+
+end

--- a/@trigtech/bary.m
+++ b/@trigtech/bary.m
@@ -4,14 +4,18 @@ function fx = bary(x, fvals, xk, wk)
 %   formula with weights VK to evaluate an interpolant of the data {XK,
 %   FVALS(:,k)} at the points X. Note that XK must be equally-spaced.
 %   Furthermore, XK and VK should be column vectors, and FVALS, XK, and VK
-%   should have the same length.
+%   should have the same length. See [1] for details.
 %
 %   BARY(X, FVALS) assumes XK are equispaced in [-1, 1) (i.e., as return by
 %   TRIGTECH.TRIGPTS()) and that VK are the corresponding barycentric weights
 %   for trigonomentric-polynomial interpolation (i.e, as returned by
 %   TRIGTECH.BARYWTS().).
-
+%
 % See also TRIG.TRIGPTS and TRIG.BARYWTS.
+
+% Reference:
+%  [1] P. Henrici, Barycentric formulas for interpolating trigonometric
+%  polynomials and their conjugates, Numer. Math., 33 (1979), pp. 225–234.
 
 % Copyright 2014 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.

--- a/@trigtech/barywts.m
+++ b/@trigtech/barywts.m
@@ -1,0 +1,25 @@
+function v = barywts(n)
+%BARYWTS  Barycentric weights for trigpts.
+%   BARYWTS(N) returns the N barycentric weights for trigonometric-polynomial
+%   interpolation on an equispaced grid [1].
+%
+% See also TRIGTECH.BARY, TRIGPTS. 
+
+% Reference:
+%
+% [1] P. Henrici, Barycentric formulas for interpolating trigonometric
+% polynomials and their conjugates, Numer. Math., 33 (1979), pp. 225–234.
+
+% Copyright 2014 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+if ( n == 0 )                      % Special case (no points)
+    v = [];
+elseif ( n == 1 )                  % Special case (single point)
+    v = 1;
+else                               % General case.
+    v = ones(n, 1);
+    v(2:2:end) = -1;
+end
+
+end

--- a/@trigtech/feval.m
+++ b/@trigtech/feval.m
@@ -1,7 +1,7 @@
 function y = feval(f, x)
 %FEVAL   Evaluate a TRIGTECH.
-%   Y = FEVAL(F, X) Evaluation of the TRIGTECH F at points X via
-%   Horner's scheme.
+%   Y = FEVAL(F, X) Evaluation of the TRIGTECH F at points X via Horner's
+%   scheme.
 %
 %   If size(F, 2) > 1 then FEVAL returns values in the form [F_1(X), F_2(X),
 %   ...], where size(F_k(X)) = size(X).
@@ -62,15 +62,15 @@ elseif ( (m > 1) && ( (ndimsx == 2) || (sizex(2) > 1) ) )
     y = reshape(y, sizex(1), m*numel(x)/sizex(1));
 end
 
-% Vectorized version of Horner's scheme for evaluating multiple
-% polynomials of the same degree at the same locations.
+end
+
 function q = polyvalv(c, x)
+% Vectorized version of Horner's scheme for evaluating multiple polynomials of
+% the same degree at the same locations.
 nValsX = size(x, 1);
 degreePoly = size(c, 1);
 q = ones(nValsX, 1)*c(1,:);
 for j = 2:degreePoly
     q = bsxfun(@plus, bsxfun(@times, x, q), c(j,:));
 end
-end
-
 end

--- a/@trigtech/trigpts.m
+++ b/@trigtech/trigpts.m
@@ -1,9 +1,10 @@
-function [x, w] = trigpts(n)
+function [x, w, v] = trigpts(n)
 %TRIGPTS   Equispaced points in [-1, 1).
 %   TRIGPTS(N) returns N equispaced points in [-1, 1).
 %
 %   [X, W] = TRIGPTS(N) returns also a row vector of the weights for
-%   the trapezoidal rule.
+%   the trapezoidal rule and [X, W, V] = TRIGPTS(N) returns a column vector of
+%   the barycentric weights for trigonometric-polynomial interpolation.
 %
 % See also CHEBPTS, LEGPTS, JACPTS, LAGPTS, and HERMPTS.
 
@@ -24,6 +25,11 @@ x(end) = [];
 % Quadrature weights:
 if ( nargout > 1 )
     w = trigtech.quadwts(n);
+end
+
+% BArycentric weights:
+if ( nargout > 2 )
+    v = trigtech.barywts(n);
 end
     
 end

--- a/@trigtech/trigtech.m
+++ b/@trigtech/trigtech.m
@@ -426,12 +426,18 @@ classdef trigtech < smoothfun % (Abstract)
         % Aliasing:
         coeffs = alias(coeffs, m)
         
+        % Trigonometric-polynomial barycentric interpolation
+        [fx, x]= bary(x, fvals, xk, wk)
+        
+        % Compute barycentric weights for trigonometric-polynomial interpolation.
+        v = barywts(n)
+        
         % Differentiation matrix in Fourier basis.
         D = diffmat(n, p)
         
         % Compute trigonometric points (x) and optionally quadrature (w)
         % and barycentric (v) weights:
-        [x, w] = trigpts(n);
+        [x, w, v] = trigpts(n);
         
         % Convert coefficients to values:
         values = coeffs2vals(coeffs);

--- a/trigpts.m
+++ b/trigpts.m
@@ -1,4 +1,4 @@
-function [x, w] = trigpts(n, dom)
+function [x, w, v] = trigpts(n, dom)
 %TRIGPTS    Equally spaced points.
 %   TRIGPTS(N) returns N equispaced points in [-1, 1).
 %
@@ -7,6 +7,9 @@ function [x, w] = trigpts(n, dom)
 %
 %   [X, W] = TRIGPTS(N) or [X, W] = TRIGPTS(N, D) returns also a row vector 
 %   of the weights for the trapezoidal rule.
+%
+%   [X, W, V] = TRIGPTS(N) returns the barycentric weights for trigonometric-
+%   polynomial interpolation on an equispaced grid.
 %
 % See also CHEBPTS, LEGPTS, JACPTS, LAGPTS, and HERMPTS.
 
@@ -27,6 +30,10 @@ x(end) = [];
 
 if ( nargout > 1 )
     w = trigtech.quadwts(n);
+end
+
+if ( nargout > 2 )
+    v = trigtech.barywts(n);
 end
 
 if ( nargin > 1 )


### PR DESCRIPTION
This isn't being used anywhere yet, but I'll need it for the periodic version of `pde***()`.

(Also, I think it's nice to have.)

As a side note, it might be nice if the Horner scheme was factored out of `trigtech/feval()` in the same was as `clenshaw` is separate from `chebtech/feval()`, but I haven't done this here.