### PR TITLE
Fix trivial bug in chebfun2.isequal().

### DIFF
--- a/@chebfun2/isequal.m
+++ b/@chebfun2/isequal.m
@@ -23,9 +23,9 @@ frows = f.rows;
 fpiv = f.pivotValues;
 
 % Get the low rank representation for g. 
-gcols = f.cols; 
-grows = f.rows; 
-gpiv = f.pivotValues;
+gcols = g.cols; 
+grows = g.rows; 
+gpiv = g.pivotValues;
 
 % Test every part: 
 out = ( isequal(fcols, gcols) & isequal(frows, grows) & isequal(fpiv, gpiv) );

--- a/tests/chebfun2/test_isequal.m
+++ b/tests/chebfun2/test_isequal.m
@@ -1,0 +1,15 @@
+% Test file for @chebfun2/isequal.m
+
+function pass = test_isequal(pref)
+
+if ( nargin < 1 )
+    pref = chebfunpref;
+end
+
+f = chebfun2(@(x, y) cos(x.*y));
+g = chebfun2(@(x, y) sin(x + y.^2));
+
+pass(1) = isequal(f, f);
+pass(2) = ~isequal(f, g);
+
+end


### PR DESCRIPTION
We need to get the data from g here, not f, whose data we've already extracted.  Also added a test for this method.

This closes #1276.