### PR TITLE
Fix reversed arguments to eig() call in chebT1rtsmatgep() in chebfun2v.roots().

### DIFF
--- a/@chebfun2v/roots.m
+++ b/@chebfun2v/roots.m
@@ -384,7 +384,7 @@ else
     % cutoff negligible B
     nrmB = norm(B(:,:,end),'fro');
     for ii=1:size(B,3)
-        if norm(B(:,:,ii),'fro')/nrmB > eps/2,    break;    end
+        if norm(B(:,:,ii),'fro')/nrmB > 10*eps,    break;    end
     end
     B = B(:,:,ii:end);
     ns = size(B);
@@ -636,7 +636,7 @@ function [r,A,B] = chebT1rtsmatgep(c)
 k=length(c(1,1,:)); n=length(c(:,:,1));
 
 if size(c,3) ==2,  % linear case
-    r = eig(c(:,:,1),-c(:,:,2));
+    r = eig(c(:,:,2),-c(:,:,1));
     return
 end
 

--- a/tests/chebfun2v/test_roots01.m
+++ b/tests/chebfun2v/test_roots01.m
@@ -38,5 +38,10 @@ p = chebfun2(@(x,y) x - y + .5);
 q = chebfun2(@(x,y) x + y );
 r = roots([p; q]); 
 pass(j) = norm( r - [-.25 .25] ) < tol; j = j + 1; 
-end
 
+p = chebfun2(@(x, y) y + x/2 + 1/10);
+q = chebfun2(@(x, y) y - 2.1*x + 2);
+r = roots([p ;  q], 'resultant');
+pass(j) = norm(r - [0.730769230769231, -0.465384615384615]) < tol; j = j + 1;
+
+end


### PR DESCRIPTION
These should be the other way around:  the leading-order coefficient should be the "B" argument, while the constant term should stand in for "A".  This closes #1505 and is the right resolution for #1232.  `chebfun2v.roots` now handles bivariate linear problems correctly.

This commit also reverts the changes made in 8bcf6c4d and 6bb4be81 to address #1232, as the cutoff tolerance is not the issue here.  The reason that making that tolerance smaller appeared to fix things is that it sometimes caused a small leading-order coefficient that in principle _should_ be stripped to not be stripped, so that when the coefficients were passed to `chebT1rtsmatgep` later, the input would have size at least 3 in the third dimension.  This caused the handler for the general case, which does things correctly, to get called instead of the handler for the linear case, which was faulty prior to the changes in this commit.

A test has been added to hopefully prevent this behavior from recurring in the future.