### PR TITLE
Warning for f.epslevel and get(f,'epslevel').

### DIFF
--- a/@chebfun/chebfun.m
+++ b/@chebfun/chebfun.m
@@ -286,9 +286,6 @@ classdef chebfun
         % Display a CHEBFUN object.
         display(f);
 
-        % Accuracy estimate of a CHEBFUN object.
-        out = epslevel(f, flag);
-        
         % Evaluate a CHEBFUN.
         y = feval(f, x, varargin)
         
@@ -473,6 +470,9 @@ classdef chebfun
         % Compare domains of two CHEBFUN objects.
         pass = domainCheck(f, g);        
         
+        % Accuracy estimate of a CHEBFUN object.
+        out = epslevel(f, flag);
+
         % Extract columns of an array-valued CHEBFUN object.
         f = extractColumns(f, columnIndex);
         

--- a/@chebfun/get.m
+++ b/@chebfun/get.m
@@ -10,8 +10,6 @@ function out = get(f, prop, simpLevel)
 %       'hscale'         - Horizontal scale of F.
 %       'hscale-local'   - Local horizontal scales of F.
 %       'ishappy'        - Is F happy?
-%       'epslevel'       - Approximate accuracy estimate of F.
-%       'epslevel-local' - Approximate accuracy estimate of F's components.
 %       'lval'           - Value(s) of F at left-hand side of domain.
 %       'rval'           - Value(s) of F at right-hand side of domain.
 %       'lval-local      - Value(s) of F's FUNs at left sides of their domains.
@@ -102,6 +100,9 @@ switch prop
     case 'hscale'
         out = hscale(f);
     case 'epslevel'
+        warning('CHEBFUN:CHEBFUN:get:epslevel', ...
+            ['f.epslevel and get(f,''epslevel'') now always returns machine\n'...
+            'epsilon, and is likely to be removed from Chebfun in the future.'])
         out = epslevel(f);
     case 'ishappy'
         out = ishappy(f);

--- a/chebtest.m
+++ b/chebtest.m
@@ -226,6 +226,7 @@ errorMessages = {'FAILED', 'CRASHED'};
 % We don't want these warning to be displayed in CHEBTEST:
 warnState = warning('off', 'CHEBFUN:CHEBFUN:vertcat:join');
 warning('off', 'CHEBFUN:CHEBOP2:chebop2:experimental')
+warning('off', 'CHEBFUN:CHEBFUN:get:epslevel')
 
 % Attempt to run all of the tests:
 try % Note, we try-catch as we've CD'd and really don't want to end up elsewhere


### PR DESCRIPTION
After adding a warning in `chebfun.get`, when I then run chebtest, I get a lot of warnings! This is because in a lot of places, the chebtests still include lines such as
```
tol = 10*get(f, 'epslevel')*get(f, 'hscale');
```
and
```
pass(im+1,k) = norm(feval(f,xx) - F(xx), inf) < 1e2*max(f.epslevel.*f.vscale);
```
which were kept because we wanted to keep the option open to easily reintroduce epslevels.

Since removing those lines would make the reintroduction of epslevels a lot trickier (even though it's unlikely we want to do so), I didn't want to change the tests, instead, I turned off the warning inside chebtest.

Closes #1513.