### PR TITLE
Allowing the use of both 'exps' and 'exponents' 

### DIFF
--- a/@chebfun/chebfun.m
+++ b/@chebfun/chebfun.m
@@ -794,7 +794,7 @@ function [op, dom, data, pref, flags] = parseInputs(op, varargin)
             % Store singularity types.
             data.singType = args{2};
             args(1:2) = [];            
-        elseif ( strcmpi(args{1}, 'exps') )
+        elseif ( strcmpi(args{1}, 'exps') || strcmpi(args{1}, 'exponents') )
             % Store exponents.
             data.exponents = args{2};
             args(1:2) = [];


### PR DESCRIPTION
Allowing the use of both 'exps' and 'exponents' when constructing a singular function in chebfun level. This is to resolve #1469.