### PR TITLE
fix-chebfunpref-techs-determine-defaults

### DIFF
--- a/@chebfun/chebfun.m
+++ b/@chebfun/chebfun.m
@@ -713,7 +713,7 @@ function [op, dom, data, pref, flags] = parseInputs(op, varargin)
             end
         elseif ( strcmpi(args{1}, 'equi') )
             % Enable FUNQUI when dealing with equispaced data.
-            keywordPrefs.tech = 'funqui';
+            keywordPrefs.enableFunqui = true;
             args(1) = [];
         elseif ( strcmpi(args{1}, 'vectorize') || ...
                  strcmpi(args{1}, 'vectorise') )
@@ -889,6 +889,7 @@ function [op, dom, data, pref, flags] = parseInputs(op, varargin)
         % Translate 'periodic' or 'trig'.
         pref.tech = @trigtech;
         pref.splitting = false;
+        pref.enableFunqui = false;
         if ( numel(dom) > 2 )
             error('CHEBFUN:parseInputs:periodic', ...
                 '''periodic'' or ''trig'' option is only supported for smooth domains.');
@@ -915,7 +916,7 @@ function [op, dom, data, pref, flags] = parseInputs(op, varargin)
         if ( isa(op, 'chebfun') )
             op = @(x) feval(op, x);
         end
-        if ( isa(op, 'function_handle') && strcmp(pref.tech, 'funqui') )
+        if ( isa(op, 'function_handle') && pref.enableFunqui )
             if ( isfield(pref.techPrefs, 'fixedLength') && ...
                  ~isnan(pref.techPrefs.fixedLength) )
                 x = linspace(dom(1), dom(end), pref.techPrefs.fixedLength).';

--- a/@chebfunpref/chebfunpref.m
+++ b/@chebfunpref/chebfunpref.m
@@ -109,38 +109,34 @@ classdef chebfunpref < chebpref
 %      preferences:
 %
 %      eps                     - Construction tolerance.
-%       [2^(-52)]
 %
-%        Specifies the relative tolerance to which the representation should be
-%        constructed.
+%        A positive floating-point number specifying the relative tolerance to
+%        which the representation should be constructed.
 %
 %      maxLength               - Maximum representation length.
-%       [65537]
 %
-%        Maximum length of the underlying representation.
+%        A positive integer giving the maximum length of the underlying
+%        representation.
 %
 %      fixedLength             - Exact representation length.
-%       [NaN]
 %
-%        Exact length of the underlying representation to be used.  A NaN value
-%        indicates that the tech is free to choose the length (up to maxLength),
-%        e.g., as the basis of an adaptive construction procedure.
+%        A positive integer specifying the exact length of the underlying
+%        representation to be used.  A NaN value indicates that the tech is
+%        free to choose the length (up to maxLength), e.g., as the basis of an
+%        adaptive construction procedure.
 %
 %      extrapolate             - Extrapolate endpoint values.
-%        true
-%       [false]
 %
-%        If true, the tech should avoid direct evaluation of the function at
-%        the interval endpoints and "extrapolate" the values at those points if
-%        needed.  It should also extrapolate the values of any points for which
-%        the function being sampled returns NaN.
+%        A boolean which, if true, indicates that the tech should avoid direct
+%        evaluation of the function at the interval endpoints and "extrapolate"
+%        the values at those points if needed.  It should also extrapolate the
+%        values of any points for which the function being sampled returns NaN.
 %
 %      sampleTest              - Test accuracy at arbitrary point.
-%       [true]
-%        false
 %
-%        If true, the tech should check an arbitrary point for accuracy to
-%        ensure that behavior hasn't been missed, e.g., due to undersampling.
+%        A boolean which, if true, indicates that the tech should check an
+%        arbitrary point for accuracy to ensure that behavior hasn't been
+%        missed, e.g., due to undersampling.
 %
 % The default values for any of these preferences may be globally overridden
 % using CHEBFUNPREF.SETDEFAULTS(); see the documentation for that function for
@@ -297,6 +293,10 @@ classdef chebfunpref < chebpref
                         'second must be a CHEBFUNPREF or a struct.']);
                 elseif ( isa(varargin{2}, 'chebfunpref') )
                     inPrefList = varargin{2}.prefList;
+                    techObj = feval(inPrefList.tech);
+                    inPrefList.techPrefs = ...
+                        chebpref.mergePrefStructs(techObj.techPref(), ...
+                        inPrefList.techPrefs);
                 else
                     inPrefList = varargin{2};
                 end
@@ -356,26 +356,24 @@ classdef chebfunpref < chebpref
             switch ( ind(1).type )
                 case '.'
                     if ( isfield(pref.prefList, ind(1).subs) )
-                        out = pref.prefList.(ind(1).subs);
+                        if ( strcmp(ind(1).subs, 'techPrefs') )
+                            techObj = feval(pref.prefList.tech);
+                            fullTechPrefs = ...
+                                techObj.techPref(pref.prefList.techPrefs);
+                            ind(1) = [];
+                            if ( isempty(ind) )
+                                out = fullTechPrefs;
+                            else
+                                out = fullTechPrefs.(ind(1).subs);
+                            end
+                        else
+                            out = pref.prefList.(ind(1).subs);
+                        end
                     else
                         techObj = feval(pref.prefList.tech);
                         fullTechPrefs = ...
                             techObj.techPref(pref.prefList.techPrefs);
-                        if ( isfield(fullTechPrefs, ind(1).subs) )
-                            % Try to find the tech preference name after
-                            % merginging with the full list of tech preferences
-                            % obtained via the tech's techPref() function of the
-                            % current tech.
-                            out = fullTechPrefs.(ind(1).subs);
-                        else
-                            % If we couldn't find the tech preference name
-                            % above, it may be because it was an abstractly
-                            % named preference that got mapped to something the
-                            % tech's techPref() deemed more sensible.  So, we
-                            % also try looking in the list of tech preferences
-                            % we have prior to forming the full list.
-                            out = pref.prefList.techPrefs.(ind(1).subs);
-                        end
+                        out = fullTechPrefs.(ind(1).subs);
                     end
 
                     if ( numel(ind) > 1 )
@@ -536,11 +534,15 @@ classdef chebfunpref < chebpref
         %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
             if ( isa(pref1, 'chebfunpref') )
-                pref1 = pref1.prefList.techPrefs;
+                techObj1 = feval(pref1.prefList.tech);
+                pref1 = chebpref.mergePrefStructs(techObj1.techPref(), ...
+                    pref1.prefList.techPrefs);
             end
 
             if ( isa(pref2, 'chebfunpref') )
-                pref2 = pref2.prefList.techPrefs;
+                techObj2 = feval(pref2.prefList.tech);
+                pref2 = chebpref.mergePrefStructs(techObj2.techPref(), ...
+                    pref2.prefList.techPrefs);
             end
 
             pref1 = chebpref.mergePrefStructs(pref1, pref2);
@@ -699,11 +701,6 @@ classdef chebfunpref < chebpref
             factoryPrefs.enableFunqui = false;
             factoryPrefs.tech = @chebtech2;
             factoryPrefs.techPrefs = struct();
-                factoryPrefs.techPrefs.eps = 2^(-52);
-                factoryPrefs.techPrefs.maxLength = 65537;
-                factoryPrefs.techPrefs.fixedLength = NaN;
-                factoryPrefs.techPrefs.extrapolate = false;
-                factoryPrefs.techPrefs.sampleTest = true;
             factoryPrefs.cheb2Prefs = struct(); 
                 factoryPrefs.cheb2Prefs.maxRank = 513;   
                 factoryPrefs.cheb2Prefs.sampleTest = 1;

--- a/@chebfunpref/chebfunpref.m
+++ b/@chebfunpref/chebfunpref.m
@@ -696,6 +696,7 @@ classdef chebfunpref < chebpref
             factoryPrefs.enableDeltaFunctions = true;
                 factoryPrefs.deltaPrefs.deltaTol = 1e-9;
                 factoryPrefs.deltaPrefs.proximityTol = 1e-11;
+            factoryPrefs.enableFunqui = false;
             factoryPrefs.tech = @chebtech2;
             factoryPrefs.techPrefs = struct();
                 factoryPrefs.techPrefs.eps = 2^(-52);

--- a/@smoothfun/smoothfun.m
+++ b/@smoothfun/smoothfun.m
@@ -49,14 +49,8 @@ classdef smoothfun < onefun % (Abstract)
             end
 
             % Deal with FUNQUI:
-            if ( strcmp(pref.tech, 'funqui') )
+            if ( pref.enableFunqui )
                 op = funqui(op);
-                if ( isfield(pref.techPrefs, 'funquiTech') )
-                    pref.tech = pref.techPrefs.funquiTech;
-                    pref.techPrefs = rmfield(pref.techPrefs, 'funquiTech');
-                else
-                    pref.tech = @chebtech2;
-                end
             end
             
             % Call the TECH constructor.

--- a/tests/chebpref/test_chebfunpref.m
+++ b/tests/chebpref/test_chebfunpref.m
@@ -107,6 +107,15 @@ q.techPrefs.testPref = 'testq';
 pass(15) = isequalNaN(chebfunpref.mergeTechPrefs(p, q), ...
     chebfunpref.mergeTechPrefs(p.techPrefs, q.techPrefs));
 
+% Test that chebfunpref().techPrefs returns a complete set of tech prefs.
+p = chebfunpref();
+
+p.tech = @chebtech2;
+pass(16) = isequalNaN(p.techPrefs, chebtech2().techPref());
+
+p.tech = @trigtech;
+pass(17) = isequalNaN(p.techPrefs, trigtech().techPref());
+
 % Test functions for managing default preferences.
 savedPrefs = chebfunpref();
 
@@ -114,14 +123,14 @@ try
     chebfunpref.setDefaults('factory');
     factoryPrefs = chebfunpref.getFactoryDefaults();
     p = chebfunpref();
-    pass(16) = isequalNaN(p, factoryPrefs);
+    pass(18) = isequalNaN(p, factoryPrefs);
 
     chebfunpref.setDefaults('factory');
     p = chebfunpref();
     p.domain = [-2 7];
     p.testPref = 'testq';
     chebfunpref.setDefaults(p);
-    pass(17) = strcmp(chebfunpref().testPref, 'testq') && ...
+    pass(19) = strcmp(chebfunpref().testPref, 'testq') && ...
         isequal(chebfunpref().domain, [-2 7]);
 
     chebfunpref.setDefaults('factory');
@@ -129,18 +138,18 @@ try
     p.domain = [-2 7];
     p.testPref = 'testq';
     chebfunpref.setDefaults(p);
-    pass(18) = strcmp(chebfunpref().testPref, 'testq') && ...
+    pass(20) = strcmp(chebfunpref().testPref, 'testq') && ...
         isequal(chebfunpref().domain, [-2 7]);
 
     chebfunpref.setDefaults('factory');
     chebfunpref.setDefaults('domain', [-2 7], 'testPref', 'testq');
-    pass(19) = strcmp(chebfunpref().testPref, 'testq') && ...
+    pass(21) = strcmp(chebfunpref().testPref, 'testq') && ...
         isequal(chebfunpref().domain, [-2 7]);
 
     % Test getting defaults:
-    pass(20) = isnumeric(chebfunpref().eps);
-    pass(21) = ischar(chebfunpref().blowupPrefs.defaultSingType);
-    pass(22) = ischar(chebfunpref().refinementFunction);
+    pass(22) = isnumeric(chebfunpref().eps);
+    pass(23) = ischar(chebfunpref().blowupPrefs.defaultSingType);
+    pass(24) = ischar(chebfunpref().refinementFunction);
     
 catch ME
     


### PR DESCRIPTION
This set of changes has `chebfunpref` now get the tech preferences "on-demand" whenever they are needed.  As a result, techs can now determine their own default values for the "abstract" preferences that they are required to expose to the upper layers.

I've always felt that this was more or less the right thing to do and only did things the other way for convenience and to avoid the potential performance hit associated with needing to merge tech preferences a little more often.  Crude "profiling" using `chebtest` doesn't show any detectable performance impact on my machine (specifically, `chebtest('chebfun')` takes somewhere between 235s-240s on my machine with and without these changes), so I guess we're OK.

The motivation for making these changes is given in the discussion in #1336, which was recently re-raised in #1514.