### PR TITLE
Pass hscale information to tech constructors in chebfun2 constructor.

### DIFF
--- a/@chebfun2/constructor.m
+++ b/@chebfun2/constructor.m
@@ -312,11 +312,11 @@ while ( ~isHappy && ~failure )
     end
     
     % Check if the column and row slices are resolved.
-    colData.vscale = dom(3:4);
+    colData.hscale = norm(dom(3:4), inf);
     tech = pref.tech();
     colChebtech = tech.make(sum(colValues,2), colData);
     resolvedCols = happinessCheck(colChebtech,[],sum(colValues,2));
-    rowData.vscale = dom(1:2);
+    rowData.hscale = norm(dom(1:2), inf);
     rowChebtech = tech.make(sum(rowValues.',2), rowData);
     resolvedRows = happinessCheck(rowChebtech,[],sum(rowValues.',2));
     isHappy = resolvedRows & resolvedCols;


### PR DESCRIPTION
These lines in the `chebfun2` constructor seemed odd:
```
    colData.vscale = dom(3:4);
    tech = pref.tech();
    colChebtech = tech.make(sum(colValues,2), colData);
```
I think they're trying to accound for scale invariance in the domain. I changed it to 
```
    colData.hscale = norm(dom(3:4), inf);
```
which I think is right. 

All the tests pass either way.
