### PR TITLE
Fix caching in chebtech/qr().

### DIFF
--- a/@chebtech/qr.m
+++ b/@chebtech/qr.m
@@ -185,7 +185,6 @@ else
     S = spdiags(s, 0, m, m);       % }
     Q = Winv*Q*S;                  % Fix Q. (Note, Q is still on Legendre grid.)
     Q_coeffs = leg2cheb( chebfun.idlt( Q ) ); % Chebyshev coefficients.
-    Q = f.coeffs2vals( Q_coeffs ); % Values on Chebyshev grid.
     R = S*R;                       % Fix R.
     
 end

--- a/@chebtech/qr.m
+++ b/@chebtech/qr.m
@@ -114,7 +114,7 @@ if ( n <= 4000 )
     
     % Project the values onto a Legendre grid: (where integrals of polynomials
     % p_n*q_n will be computed exactly and on an n-point grid)
-    if ( (length(WP) ~= n) || (~isempty(type) && isa(f, type)) )
+    if ( (length(WP) ~= n) || (~isempty(type) && ~isa(f, type)) )
         % The matrices WP and inv(WP) depends only on the length of the
         % discretization and the cheb-type of f (i.e., not the function values
         % themselves.) We therefore store these persistently which save a lot of


### PR DESCRIPTION
Looking at #1542 made me notice this.

Before this fix:
```
>> tic, for k = 1:100, qr(chebtech2(rand(1000,20))); end, toc
Elapsed time is 2.551894 seconds.
```
After:
```
>> tic, for k = 1:100, qr(chebtech2(rand(1000,20))); end, toc
Elapsed time is 0.868198 seconds.
```

Explanation: We cache the matrix which converts Chebyshev values to Legendre values. This is useful if we are doing many transforms of the same length (which is typical in many `chebfun2` commands).

We could remove the problem of checking for type if we _always_ used cheb1 or cheb2 points locally in `qr`. However, this pull request doesn't address this (and it's actually closely related to #1542)