### PR TITLE
Ensure that initial guess for chebop methods is a CHEBMATRIX.

### DIFF
--- a/@chebop/solvebvp.m
+++ b/@chebop/solvebvp.m
@@ -91,7 +91,11 @@ if ( isempty(N.init) )
     u0 = chebmatrix(u0);
 else
     % Get the initial guess.
-    u0 = N.init; 
+    u0 = N.init;
+    % Ensure that initial guess is a CHEBMATRIX (as later code assumes it is):
+    if ( isa(u0, 'chebfun') )
+        u0 = chebmatrix(u0);
+    end 
 end
 
 % Initialise the independent variable:


### PR DESCRIPTION
This was causing an issue found by @trefethen, namely that "Use latest solution as initial guess" option in Chebgui was crashing.