### PR TITLE
Simplify trigtech/sum. 

### DIFF
--- a/@trigtech/sum.m
+++ b/@trigtech/sum.m
@@ -37,8 +37,9 @@ if ( isempty(f) )
     % Empty TRIGTECH
     out = []; 
 else
-    % Trapezium rule:
-    out = sum(f.values, 1)*(2/n);
+    % By orthogonality of complex exponentials integral is 2x 
+    % zeroth coefficient: 
+    out = 2*f.coeffs( floor((n+2)/2), :); 
 end
 
 % Return a real result if f is real:


### PR DESCRIPTION
There is no need to use the trapezium rule in `trigtech/sum`, requiring `O(n)` operations, when the zeroth Fourier coefficient is already known.   The algorithm is now `O(1)` operations.  (This speed up can be seen with very high rank periodic `chebfun2` objects.) 