### PR TITLE
Fix simplification of an even length trigtech

### DIFF
--- a/@trigtech/simplify.m
+++ b/@trigtech/simplify.m
@@ -82,7 +82,7 @@ end
 % Now put the coefficients vector back together.
 coeffs = f.coeffs;
 if ( isEven )
-    coeffs = [.5*coeffs(n,:) ; coeffs(1:n-1,:) ; .5*coeffs(n,:)];
+    coeffs = [.5*coeffs(1,:) ; coeffs(2:n,:) ; .5*coeffs(1,:)];
     n = n + 1;
 end
 

--- a/tests/trigtech/test_simplify.m
+++ b/tests/trigtech/test_simplify.m
@@ -72,4 +72,10 @@ f = testclass.make(@(x) 0*x, [], struct('fixedLength', 8));
 g = simplify(f);
 pass(12) = iszero(g) && (length(g) == 1);
 
+%%
+% Check simplification of even trigtech
+f = testclass.make(ones(8,1));
+g = simplify(f);
+pass(13) = g.values == 1;
+
 end


### PR DESCRIPTION
Even length `trigtechs` are not being simplified correctly.  For example:
```
>>f = trigtech(ones(8,1));
>> simplify(f)
ans = 
  trigtech with properties:
      values: 0
      coeffs: 0
      vscale: 1
      hscale: 1
     ishappy: 1
    epslevel: 2.2204e-16
      isReal: 1
```
This pull request fixes the issue, which turned out to be a mistake in the index for the non-symmetric mode.  This is a pretty trivial pull request (only one line and a new test).
