### PR TITLE
Set default MarkerSize to 20 in separableApprox.waterfall().

### DIFF
--- a/@separableApprox/waterfall.m
+++ b/@separableApprox/waterfall.m
@@ -116,7 +116,7 @@ else
         % Evaluate on a grid.
         P = f.pivotLocations;
         
-        defaultopts = {'markersize',7, 'marker', '.'};
+        defaultopts = {'markersize', 20, 'marker', '.'};
         lineopts = {'linewidth', 2, 'linestyle', ll{:}};
         if ( ~plotline )
             % Just plot the pivots at height f(x,y)


### PR DESCRIPTION
With a default `LineWidth` of 2, a default `MarkerSize` of 7 makes the markers too small to be visible on my machine.

A change of this sort was originally effected in 33854a3e, but this change was probably undone when `separableApprox` got merged into development and replaced `chebfun2.waterfall()` with
`separableApprox.waterfall()`.