### PR TITLE
Eliminate calls to chebfun/subsref in treeVar/tree2infix output.

### DIFF
--- a/@treeVar/toFirstOrder.m
+++ b/@treeVar/toFirstOrder.m
@@ -168,8 +168,10 @@ for wCounter = 1:length(fevalResult)
     maxDerLoc = find(expTree.diffOrder == totalDiffOrders);
     
     % Convert the derivative part to infix form.
+    % Indicate that we are converting a coeffFun
+    isCoeffFun = true;
     [infixDer, varArrayDer] = ...
-        treeVar.tree2infix(derTree, maxDerLoc, indexStartDer);
+        treeVar.tree2infix(derTree, maxDerLoc, indexStartDer, isCoeffFun);
     
     % Convert the infix form of the expression that gives us the coefficient
     % multiplying the highest order derivative appearing in the expression to an
@@ -202,8 +204,9 @@ for wCounter = 1:length(fevalResult)
     newTree = struct('method', 'minus', 'numArgs', 2, ...
         'left', rhs{wCounter}, 'right', newTree);
     % Convert current expression to infix form:
+    isCoeffFun = false;
     [infix, varArray] = ...
-        treeVar.tree2infix(newTree, maxDerLoc, indexStart);
+        treeVar.tree2infix(newTree, maxDerLoc, indexStart, isCoeffFun);
     % Store the infix form and the variables that appeared in the anonymous
     % function.
     systemInfix{maxDerLoc} = infix;

--- a/@treeVar/tree2infix.m
+++ b/@treeVar/tree2infix.m
@@ -1,4 +1,4 @@
-function [infixOut, varArray] = tree2infix(tree, eqno, indexStart)
+function [infixOut, varArray] = tree2infix(tree, eqno, indexStart, isCoeffFun)
 %TREE2INFIX   Convert a syntax tree to infix form.
 %   Calling sequence:
 %      [OUT, VARCOUNTER, VARARRAY] = TREE2INFIX(TREE, EQNO, INDEXSTART)
@@ -34,12 +34,12 @@ varArray = [];
 
 % Start the recursive call for converting a syntax tree to infix form.
 [infixOut, varCounter, varArray] = ...
-    toInfix(tree, eqno, indexStart, varCounter, varArray);
+    toInfix(tree, eqno, indexStart, varCounter, varArray, isCoeffFun);
 end
 
 
 function [out, varCounter, varArray] = ...
-    toInfix(tree, eqno, indexStart, varCounter, varArray)
+    toInfix(tree, eqno, indexStart, varCounter, varArray, isCoeffFun)
 %TOINFIX   Recursively convert syntax tree of infix form.
 
 % Check whether we're converting a syntax tree to infix form, or whether we're
@@ -63,7 +63,7 @@ switch numArgs
         % CHEBFUN. Generate a string so that we can include it as a variable
         % later in the conversion process.
         [out, varArray, varCounter] = ...
-                scalarChebfunInfix(eqno, varCounter, tree, varArray);
+            scalarChebfunInfix(eqno, varCounter, tree, varArray, isCoeffFun);
     case 0
         % We've hit the TREEVAR constructor level. Return a string containing
         % the name of the dependent variable -- u -- and its index.
@@ -71,7 +71,7 @@ switch numArgs
     case 1
         % Unary operator tree, convert it recursively to a infix form string.
         [tempOut, varCounter, varArray] = ...
-            toInfix(tree.center, eqno, indexStart, varCounter, varArray);
+            toInfix(tree.center, eqno, indexStart, varCounter, varArray, isCoeffFun);
         % Generate a string using the information obtained above, and return it.
         out = sprintf('%s(%s)', tree.method, tempOut);
     case 2
@@ -90,23 +90,23 @@ switch numArgs
         if ( isstruct(tree.left) )
             % Left child node is a tree, convert it recursively to infix form.
             [leftInfix, varCounter, varArray] = ...
-                toInfix(tree.left, eqno, indexStart, varCounter, varArray);
+                toInfix(tree.left, eqno, indexStart, varCounter, varArray, isCoeffFun);
         else
             % Left child node is a CHEBFUN/scalar, generate an infix string we
             % can use later in the process.
             [leftInfix, varArray, varCounter] = ...
-                scalarChebfunInfix(eqno, varCounter, tree.left, varArray);
+                scalarChebfunInfix(eqno, varCounter, tree.left, varArray, isCoeffFun);
         end
         
         if ( isstruct(tree.right) )
             % Right child node is a tree, convert it recursively to infix form.
             [rightInfix, varCounter, varArray] = ...
-                toInfix(tree.right, eqno, indexStart, varCounter, varArray);
+                toInfix(tree.right, eqno, indexStart, varCounter, varArray, isCoeffFun);
         else
             % Left child node is a CHEBFUN/scalar, generate an infix string we
             % can use later in the process.
             [rightInfix, varArray, varCounter] = ...
-                scalarChebfunInfix(eqno, varCounter, tree.right, varArray);
+                scalarChebfunInfix(eqno, varCounter, tree.right, varArray, isCoeffFun);
         end
         
         % Combine the infix forms of the left and right nodes into one string on
@@ -118,7 +118,7 @@ end
 end
 
 function [infixOut, varArray, varCounter] = ...
-    scalarChebfunInfix(eqno, varCounter, tree, varArray)
+    scalarChebfunInfix(eqno, varCounter, tree, varArray, isCoeffFun)
 %SCALARCHEBFUNINFIX   Convert a scalar/CHEBFUN expression to infix form.
 %   A scalar/CHEBFUN expression is one that only contains a scalar or CHEBFUN.
 
@@ -129,10 +129,17 @@ varName = sprintf('eq%i_var%i', eqno, varCounter);
 if ( isnumeric(tree) )
     % The left tree is a scalar.
     infixOut = varName;
-else
-    % The left tree must be a chebfun -- need to be able to evaluate it on
-    % gridpoints
-    infixOut = [varName, '(t)'];
+    
+% Otherwise, the tree must be a CHEBFUN. However, we need to treat it
+% differently depending on whether it appears in the coeffFun (i.e., if we are
+% obtaining the coefficient multiplying the highest order derivative) or not. In
+% the first case, we want to compose it, so that we get a new CHEBFUN that can
+% be evaluated later at an arbitrary time. In the second case, we'll simply want
+% to evaluate the CHEBFUN at given gridpoints.
+elseif ( isCoeffFun ) 
+    infixOut = ['compose(t,', varName, ')'];
+elseif ( ~isCoeffFun )
+    infixOut = ['feval(', varName, ',t)'];
 end
 
 % Add the name and value of the current variable to the VARARRAY cell.

--- a/@treeVar/treeVar.m
+++ b/@treeVar/treeVar.m
@@ -527,7 +527,8 @@ classdef  (InferiorClasses = {?chebfun}) treeVar
         funOut = toRHS(infix, varArray, coeff, indexStart, totalDiffOrders);
         
         % Convert a syntax tree to infix form
-        [infix, varArray] = tree2infix(tree, diffOrders, varCounter, varArray)
+        [infix, varArray] = ...
+            tree2infix(tree, diffOrders, varCounter, varArray, isCoeffFun)
            
         % Construct syntax trees for univariate methods
         treeOut = univariate(treeIn, method)


### PR DESCRIPTION
Another PR, which like #1341 was inspired by an example by @trefethen . By avoiding calls to `chebfun/subsref` in output from the `treeVar` class, nice speedups can be obtained. Take for example:
```
L = chebop(0,8); L.lbc = 0;
L.op = @(t,y) diff(y) + y;
t = chebfun('t',[0 8]);
% Smooth RHS
g = sin(t.^2); 
tic, 
for i =1:5
    y1 = L\g;
end
time = toc; fprintf('smooth: %4.3fs.\n', time)
% Piecewise RHS
g = sign(sin(t.^2));
tic
for i=1:5
    y2 = L\g;
end
time = toc; fprintf('piecewise: %4.2fs.\n', time)
```

On current release branch, I get the timings on my laptop on Matlab 2014b:
```
smooth: 3.482s.
piecewise: 27.03s.
```
On this branch, I get:
```
smooth: 2.515s.
piecewise: 20.27s.
```

On the 2015b prerelease, the timing results are also pretty nice (notice how much faster 2015b appears to be in general). On current release branch:
```
smooth: 1.404s.
piecewise: 10.03s.
```
On this branch:
```
smooth: 0.815s.
piecewise: 5.90s.
```

Profiling reveals to for this particular example, 639 calls to `chebfun/subsref` are saved for the smooth example, and 4453 for the piecewise one.