### PR TITLE
Hot fix for the evaluation of a constant trigtech

### DIFF
--- a/@trigtech/horner.m
+++ b/@trigtech/horner.m
@@ -140,6 +140,7 @@ n = ceil((N+1)/2);
 c = c(n:-1:1,:);
 a = real(c);
 b = imag(c);
+e = ones(nValsX,1);
 
 % Adjust the last coefficient which corresponds to the pure cos(pi*n*x) 
 % mode in the case that N is even.
@@ -150,7 +151,7 @@ end
 
 % Just return the constant term.
 if N == 1
-    q = a;
+    q = e*a;
     return
 end
     

--- a/@trigtech/horner.m
+++ b/@trigtech/horner.m
@@ -140,7 +140,6 @@ n = ceil((N+1)/2);
 c = c(n:-1:1,:);
 a = real(c);
 b = imag(c);
-e = ones( size(x, 1), 1);
 
 % Adjust the last coefficient which corresponds to the pure cos(pi*n*x) 
 % mode in the case that N is even.
@@ -151,7 +150,7 @@ end
 
 % Just return the constant term.
 if N == 1
-    q = e*a;
+    q = ones( size(x, 1), 1)*a;
     return
 end
     

--- a/@trigtech/horner.m
+++ b/@trigtech/horner.m
@@ -140,7 +140,7 @@ n = ceil((N+1)/2);
 c = c(n:-1:1,:);
 a = real(c);
 b = imag(c);
-e = ones(nValsX,1);
+e = ones( size(x, 1), 1);
 
 % Adjust the last coefficient which corresponds to the pure cos(pi*n*x) 
 % mode in the case that N is even.

--- a/tests/trigtech/test_feval.m
+++ b/tests/trigtech/test_feval.m
@@ -18,54 +18,59 @@ testclass = trigtech();
 % accuracy on the order of the truncation level, so we use this as our 
 % criterion.
 
+f = testclass.make(@(x) ones(size(x)), [], pref);
+f_exact = @(x) ones(size(x));
+pass(1) = (norm(feval(f, x) - f_exact(x), inf) < ...
+    10*f.vscale.*f.epslevel);
+
 f = testclass.make(@(x) sin(pi*x), [], pref);
 f_exact = @(x) sin(pi*x);
-pass(1) = (norm(feval(f, x) - f_exact(x), inf) < ...
+pass(2) = (norm(feval(f, x) - f_exact(x), inf) < ...
     10*f.vscale.*f.epslevel);
 
 f = testclass.make(@(x) exp(cos(pi*x)) - 1, [], pref);
 f_exact = @(x) exp(cos(pi*x)) - 1;
-pass(2) = (norm(feval(f, x) - f_exact(x), inf) < ...
+pass(3) = (norm(feval(f, x) - f_exact(x), inf) < ...
     10*f.vscale.*f.epslevel);
 
 f = testclass.make(@(x) cos(100*sin(pi*x)), [], pref);
 f_exact = @(x) cos(100*sin(pi*x));
-pass(3) = (norm(feval(f, x) - f_exact(x), inf) < ...
+pass(4) = (norm(feval(f, x) - f_exact(x), inf) < ...
     1e3*f.vscale.*f.epslevel);
     
 f = testclass.make(@(x) exp(1i*pi*x), [], pref);
 f_exact = @(x) exp(1i*pi*x);
-pass(4) = (norm(feval(f, x) - f_exact(x), inf) < ...
+pass(5) = (norm(feval(f, x) - f_exact(x), inf) < ...
     10*f.vscale.*f.epslevel);
 
 % Check that even expansions are working
 coeffs = [2 0.25*1i 5 -0.25*1i].';
 f_exact = @(x) 2*cos(2*pi*x) + 0.5*sin(pi*x) + 5;
 f = testclass.make({[],coeffs},[],pref);
-pass(5) = (norm(feval(f, x) - f_exact(x), inf) < ...
+pass(6) = (norm(feval(f, x) - f_exact(x), inf) < ...
     10*f.vscale.*f.epslevel);
 
 coeffs = ([2 0.25*1i 5 -0.25*1i] + [2*1i 0.25 5*1i 0.25]).';
 f_exact = @(x) 2*(1+1i)*cos(2*pi*x) + 0.5*(cos(pi*x) + sin(pi*x)) + 5*(1 + 1i);
 f = testclass.make({[],coeffs},[],pref);
-pass(6) = (norm(feval(f, x) - f_exact(x), inf) < ...
+pass(7) = (norm(feval(f, x) - f_exact(x), inf) < ...
     10*f.vscale.*f.epslevel);
 
 %%
 % Check row vector and matrix input.
     
 err = feval(f, x.') - f_exact(x.');
-pass(7) = (all(size(err) == [1 1000])) && (norm(err(:), inf) < ...
+pass(8) = (all(size(err) == [1 1000])) && (norm(err(:), inf) < ...
     10*f.vscale.*f.epslevel);
 
 x_mtx = reshape(x, [100 10]);
 err = feval(f, x_mtx) - f_exact(x_mtx);
-pass(8) = (all(size(err) == [100 10])) && (norm(err(:), inf) < ...
+pass(9) = (all(size(err) == [100 10])) && (norm(err(:), inf) < ...
     10*f.vscale.*f.epslevel);
 
 x_3mtx = reshape(x, [10 10 10]);
 err = feval(f, x_3mtx) - f_exact(x_3mtx);
-pass(9) = (all(size(err) == [10 10 10])) && (norm(err(:), inf) < ...
+pass(10) = (all(size(err) == [10 10 10])) && (norm(err(:), inf) < ...
     10*f.vscale.*f.epslevel);
 
 %%
@@ -74,7 +79,7 @@ pass(9) = (all(size(err) == [10 10 10])) && (norm(err(:), inf) < ...
 f = testclass.make(@(x) [(2+sin(pi*x)).*exp(1i*pi*x), -(2+sin(pi*x)).*exp(1i*pi*x), 2+sin(pi*x)], [], pref);
 f_exact = @(x) [(2+sin(pi*x)).*exp(1i*pi*x), -(2+sin(pi*x)).*exp(1i*pi*x), 2+sin(pi*x)];
 err = feval(f, x) - f_exact(x);
-pass(10) = all(max(abs(err)) < 10*max(f.vscale.*f.epslevel));
+pass(11) = all(max(abs(err)) < 10*max(f.vscale.*f.epslevel));
 
 %%
 % Test for evaluating array-valued trigtech objects at matrix arguments if
@@ -85,6 +90,6 @@ x2 = [-1 0 1 ; .25 .5 .75];
 fx = feval(f, x2);
 f_exact = [0 0 0 -1 1 -1 exp(-1i*pi) 1 exp(1i*pi)
     [1 sqrt(2) 1 1 0 -1]/sqrt(2) exp(1i*pi.*[.25 .5 .75])];
-pass(11) = all(all(abs(fx - f_exact) < 10*max(f.vscale.*f.epslevel)));
+pass(12) = all(all(abs(fx - f_exact) < 10*max(f.vscale.*f.epslevel)));
 
 end


### PR DESCRIPTION
Fixes a bug introduced in #1540 where the evaluation of a constant `trigtech` only returns one value regardless of the number of input evaluation points.  A new test has been included for this case.