### PR TITLE
Simplification of code in chebfun/feval

### DIFF
--- a/@chebfun/feval.m
+++ b/@chebfun/feval.m
@@ -88,7 +88,6 @@ x = x(:);
 numCols = numColumns(f);
 numFuns = numel(f.funs);
 
-out = zeros(size(x, 1), numCols);
 funs = f.funs;
 dom = f.domain;
 
@@ -110,26 +109,40 @@ end
 
 %% VALUES FROM FUNS:
 
-% Points to the left of the domain:
-xReal = real(x);
-I = xReal < dom(1);
-if ( any(I(:)) )
-    out(I,:) = feval(funs{1}, x(I), varargin{:});
-end
-
-% Points within the domain:
-for k = 1:numFuns
-    I = ( xReal >= dom(k) ) & ( xReal < dom(k+1) );
+if ( numFuns == 1 )
+    
+    % Things are simple when there is only a single fun:
+    out = feval(funs{1}, x(:), varargin{:});
+    
+else
+    
+    % For multiple funs we must detrmine which fun corresponds to each x.
+    
+    % Initialise output matrix:
+    out = zeros(numel(x), numCols);
+    
+    % Points to the left of the domain:
+    xReal = real(x);
+    I = xReal < dom(1);
     if ( any(I(:)) )
-        % Evaluate the appropriate fun:
-        out(I,:) = feval(funs{k}, x(I), varargin{:});
+        out(I,:) = feval(funs{1}, x(I), varargin{:});
     end
-end
 
-% Points to the right of the domain:
-I = ( xReal >= dom(end) );
-if ( any(I(:)) )
-    out(I,:) =  feval(funs{end}, x(I), varargin{:});
+    % Points within the domain:
+    for k = 1:numFuns
+        I = ( xReal >= dom(k) ) & ( xReal < dom(k+1) );
+        if ( any(I(:)) )
+            % Evaluate the appropriate fun:
+            out(I,:) = feval(funs{k}, x(I), varargin{:});
+        end
+    end
+
+    % Points to the right of the domain:
+    I = ( xReal >= dom(end) );
+    if ( any(I(:)) )
+        out(I,:) =  feval(funs{end}, x(I), varargin{:});
+    end
+    
 end
 
 %% POINTVALUES:
@@ -137,7 +150,7 @@ end
 % pointValues. 
 
 % Loop over the FUNs:
-for k = 1:numFuns + 1
+for k = 1:(numFuns + 1)
     index = x == dom(k);
     if ( any(index) )
         % If a left or right flag has been passed, we reassign pointValues 

--- a/@chebfun/feval.m
+++ b/@chebfun/feval.m
@@ -34,32 +34,42 @@ elseif ( isempty(x) )
     return
 end
 
+% Deal with FEVAL(FUNCTION_HANDLE, CHEBFUN) type calls.
 if ( isa(F, 'function_handle') )
     out = F(x, varargin{:});
     return
 end
 
-%% LEFT / RIGHT VALUES:
+%% LEFT / RIGHT / END VALUES:
 % Support for feval(f, 'left') and feval(f, 'end'), etc.
 if ( ischar(x) )
-    dom = F.domain;
     if ( any(strcmpi(x, {'left', 'start' ,'-'})) )
-        out = feval(F, dom(1));
+        out = F.pointValues(1,:);
     elseif ( any(strcmpi(x, {'right', 'end', '+'})) )
-        out = feval(F, dom(end));
+        out = F.pointValues(end,:);
     else
         error('CHEBFUN:CHEBFUN:feval:strInput', ...
             'Unknown input argument "%s".', x);
     end
+    if ( F(1).isTransposed )
+        out = out.';
+    end
     return
 end
 
-%% DEAL WITH QUASIMATRICES:
-out = cell(1, numel(F));
-for k = 1:numel(F)
-    out{k} = columnFeval(F(k), x, varargin{:});
+%% EVALUATE EACH COLUMN:
+if ( numel(F) == 1 )
+    out = columnFeval(F, x, varargin{:});
+else
+    % Deal with quasimatrices:
+    out = cell(1, numel(F));
+    for k = 1:numel(F)
+        out{k} = columnFeval(F(k), x, varargin{:});
+    end
+    out = cell2mat(out);
 end
-out = cell2mat(out);
+
+%% DEAL WITH ROW CHEBFUNS:
 if ( F(1).isTransposed )
     % We got a passed a row CHEBFUN. If X had more than two dimensions, we can't
     % simply transpose the output from above, instead, we need to use permute.
@@ -76,6 +86,7 @@ end
 end
 
 function out = columnFeval(f, x, varargin)
+% Act on each column. Note that columnFeval ignores the transpose state of F.
 
 %% INITIALISE:
 
@@ -92,11 +103,12 @@ dom = f.domain;
 
 %% LEFT AND RIGHT LIMITS:
 % Deal with feval(f, x, 'left') and feval(f, x, 'right'):
-lrFlag = zeros(1, 4);
+leftFlag = 0; rightFlag = 0;
 if ( nargin > 2 )
     lr = varargin{1};
-    lrFlag = strcmpi(lr, {'left', 'right', '-', '+'});
-    if ( ~any(lrFlag) )
+    leftFlag = any(strcmpi(lr, {'left', '-'}));
+    rightFlag = any(strcmpi(lr, {'right', '+'}));
+    if ( ~(leftFlag || rightFlag) )
         if ( ischar(lr) )
             error('CHEBFUN:CHEBFUN:feval:leftRightChar',...
                 'Unknown input argument "%s".', lr);
@@ -113,6 +125,7 @@ if ( numFuns == 1 )
     % Things are simple when there is only a single FUN:
     out = feval(funs{1}, x(:), varargin{:});
     numCols = size(out, 2);
+    
 else
     
     % For multiple FUNs we must determine which FUN corresponds to each x.
@@ -125,7 +138,7 @@ else
     % use FUN{1} if real(x) < dom(1) and FUN{end} if real(x) > dom(end)).
     domInf = [-inf, dom(2:end-1), inf];
     
-    % Loop over each fun. If  real(x) is in [dom(k) dom(k+1)] then use FUN{k}.
+    % Loop over each FUN. If real(x) is in [dom(k) dom(k+1)] then use FUN{k}.
     xReal = real(x);
     for k = 1:numFuns
         I = ( xReal >= domInf(k) ) & ( xReal < domInf(k+1) );
@@ -139,26 +152,25 @@ end
 
 %% POINTVALUES:
 % If the evaluation point corresponds to a breakpoint, we get the value from
-% pointValues. 
 
-% Loop over the FUNs:
-for k = 1:(numFuns + 1)
-    index = ( x == dom(k) );
-    if ( any(index) )
-        % If a left or right flag has been passed, we reassign pointValues 
-        % to be left/right values.
-        if ( lrFlag(1) || lrFlag(3) ) % left
-            for j = 1:numFuns
-                f.pointValues(j+1,:) = get(funs{j}, 'rval');
-            end
-        elseif ( lrFlag(2) || lrFlag(4) ) % right
-            for j = 1:numFuns
-                f.pointValues(j,:) = get(funs{j}, 'lval');
-            end
-        end
-        pointValues = repmat(f.pointValues(k,:), sum(index), 1);
-        out(index,:) = pointValues;
+% f.pointValues. However, if the 'left' or 'right' flag is given, we first 
+% modify the entry in point values to take either the left- or right-sided
+% limit, respectively.
+
+[xAtBreaks, domIndices] = ismember(x, dom);
+if ( any(xAtBreaks) )
+    if ( leftFlag )
+        % Note that for leftFlag we use 'rval-local', which corresponds to the
+        % function value at the right part of the subdomain.
+        pointValues = [f.pointValues(1,:); get(f, 'rval-local')];
+    elseif ( rightFlag )
+        % Similarly rightFlag uses lval-local.
+        pointValues = [get(f, 'lval-local'); f.pointValues(end,:)];
+    else
+        pointValues = f.pointValues;
     end
+    % Set the output values for any values of x at the breakpoints.
+    out(xAtBreaks,:) = pointValues(domIndices(xAtBreaks),:);
 end
 
 %% RESHAPE FOR OUTPUT:

--- a/@chebfun/feval.m
+++ b/@chebfun/feval.m
@@ -111,36 +111,28 @@ end
 
 if ( numFuns == 1 )
     
-    % Things are simple when there is only a single fun:
+    % Things are simple when there is only a single FUN:
     out = feval(funs{1}, x(:), varargin{:});
     
 else
     
-    % For multiple funs we must detrmine which fun corresponds to each x.
+    % For multiple FUNs we must determine which FUN corresponds to each x.
     
     % Initialise output matrix:
     out = zeros(numel(x), numCols);
     
-    % Points to the left of the domain:
+    % Replace the first and last domain entries with +/-inf. (Since we want to
+    % use FUN{1} if real(x) < dom(1) and FUN{end} if real(x) > dom(end)).
+    domInf = [-inf, dom(2:end-1), inf];
+    
+    % Loop over each fun. If  real(x) is in [dom(k) dom(k+1)] then use FUN{k}.
     xReal = real(x);
-    I = xReal < dom(1);
-    if ( any(I(:)) )
-        out(I,:) = feval(funs{1}, x(I), varargin{:});
-    end
-
-    % Points within the domain:
     for k = 1:numFuns
-        I = ( xReal >= dom(k) ) & ( xReal < dom(k+1) );
+        I = ( xReal >= domInf(k) ) & ( xReal < domInf(k+1) );
         if ( any(I(:)) )
             % Evaluate the appropriate fun:
             out(I,:) = feval(funs{k}, x(I), varargin{:});
         end
-    end
-
-    % Points to the right of the domain:
-    I = ( xReal >= dom(end) );
-    if ( any(I(:)) )
-        out(I,:) =  feval(funs{end}, x(I), varargin{:});
     end
     
 end
@@ -151,7 +143,7 @@ end
 
 % Loop over the FUNs:
 for k = 1:(numFuns + 1)
-    index = x == dom(k);
+    index = ( x == dom(k) );
     if ( any(index) )
         % If a left or right flag has been passed, we reassign pointValues 
         % to be left/right values.

--- a/@chebfun/feval.m
+++ b/@chebfun/feval.m
@@ -85,7 +85,6 @@ ndimsx = ndims(x);
 x = x(:);
 
 % Initialise output:
-numCols = numColumns(f);
 numFuns = numel(f.funs);
 
 funs = f.funs;
@@ -113,12 +112,13 @@ if ( numFuns == 1 )
     
     % Things are simple when there is only a single FUN:
     out = feval(funs{1}, x(:), varargin{:});
-    
+    numCols = size(out, 2);
 else
     
     % For multiple FUNs we must determine which FUN corresponds to each x.
     
     % Initialise output matrix:
+    numCols = numColumns(f);
     out = zeros(numel(x), numCols);
     
     % Replace the first and last domain entries with +/-inf. (Since we want to

--- a/@chebfun/idlt.m
+++ b/@chebfun/idlt.m
@@ -30,7 +30,7 @@ else
     n = size(f, 1);
     [~, w] = legpts(n);                           % Legendre weights
     wf = bsxfun(@times, w.', f);                  % Scale by weights
-    c = ndct_tranpose(wf);                        % NDCT transpose
+    c = ndct_transpose(wf);                       % NDCT transpose
     
     % Stage II:
     c = leg2cheb(c, 'transpose');                 % LEG2CHEB transpose
@@ -67,7 +67,7 @@ v = bsxfun(@times, (0:N-1).' + .5, v);        % Scaling
 
 end
 
-function c = ndct_tranpose(f)
+function c = ndct_transpose(f)
 %NDCT_TRANSPOSE  Evalute transpose of the NDCT operator.
 %   See NDCT in DLT.M.
 


### PR DESCRIPTION
(This PR replaces #1603 )

* Call numColumns instead of size in columnFeval.

* Deal with row chebfuns in feval, rather than columnFeval.

This closes #1600. I didn't do a profiling on the whole of chebtest, but for and chebtest('chebfun'), it turns out that it saved more than 13000 calls to chebfun/size.

Also, for the example listed in #1599, these are the times I get on 2015b prerelease before and after these changes.

Before:

smooth: 0.820s.
piecewise: 5.62s.
After:

smooth: 0.716s.
piecewise: 4.93s. 