### PR TITLE
Fix a failure in the ode-linear/ContourExpm example, and minor modifications in solvebvp

### DIFF
--- a/@chebop/determineDiscretization.m
+++ b/@chebop/determineDiscretization.m
@@ -1,9 +1,9 @@
-function pref = determineDiscretization(N, L, pref)
+function pref = determineDiscretization(N, lengthDom, pref)
 %DETERMINEDISCRETIZATION    Determine discretization for a CHEBOP object.
 %
-%   PREFOUT = DETERMINEDISCRETIZATION(N, L, ISPREFGIVEN, PREFIN) choses the
+%   PREFOUT = DETERMINEDISCRETIZATION(N, LENGTHDOM, PREFIN) choses the
 %   correct discretization PREFOUT.DISCRETIZATION to be used when solving
-%   problems (BVP/EIGS/EXPM), modeled by a CHEBOP N and a LINOP L.
+%   problems (BVP/EIGS/EXPM), modeled by a CHEBOP N.
 %
 % See also CHEBOP/CLEARPERIODICBC, CHEBOP/SOLVEBVP, CHEBOP/EIGS.
 
@@ -18,12 +18,8 @@ if ( isa(pref.discretization, 'char') )
     if ( strcmpi(pref.discretization, 'values') )
         % The default for the periodic case if TRIGCOLLOC. But, since TRIGCOLLOC
         % does not support breakpoints, it will be used only if there are no
-        % breakpoints. Note that here and below, we look at L.domain rather
-        % than N.domain, as the domain of the LINOP L will also include any
-        % breakpoints arising from discontinuous coefficients of N (which we 
-        % only become aware of when we do the linearization):
-        if ( isa(N.bc, 'char') && strcmpi(N.bc, 'periodic') && ...
-                length(L.domain) < 3 )
+        % breakpoints.
+        if ( isa(N.bc, 'char') && strcmpi(N.bc, 'periodic') && lengthDom < 3 )
             pref.discretization = @trigcolloc;
         % Otherwise (i.e. periodic + breakpoints or other boundary 
         % conditions), use CHEBCOLLOC2:
@@ -35,8 +31,7 @@ if ( isa(pref.discretization, 'char') )
     % using coefficients:
     elseif ( strcmpi(pref.discretization, 'coeffs') )
         % Same here with TRIGSPEC and breakpoints:
-        if ( isa(N.bc, 'char') && strcmpi(N.bc, 'periodic') && ...
-                length(L.domain) < 3 )
+        if ( isa(N.bc, 'char') && strcmpi(N.bc, 'periodic') && lengthDom < 3 )
             pref.discretization = @trigspec;
         else
             pref.discretization = @ultraS;
@@ -52,8 +47,7 @@ else
     % If TRIGCOLLOC or TRIGSPEC were chosen and there are breakpoints, we need
     % to throw an error:
     if ( ( isequal(pref.discretization, @trigcolloc) || ...
-            isequal(pref.discretization, @trigspec) ) && ...
-            length(L.domain) > 2 )
+            isequal(pref.discretization, @trigspec) ) && lengthDom > 2 )
         error('CHEBFUN:CHEBOP:solvebvp:breakpointsInDomain', ...
         ['Problems with periodic boundary conditions where breakpoints \n', ...
         'are present cannot be solved with the TRIGCOLLOC/TRIGSPEC class.\n' ...

--- a/@chebop/eigs.m
+++ b/@chebop/eigs.m
@@ -81,7 +81,7 @@ if ( nargin > 1 && isa(varargin{1}, 'chebop') )
 end
 
 % Determine the discretization.
-prefs = determineDiscretization(N, L, prefs);
+prefs = determineDiscretization(N, length(L.domain), prefs);
 
 % Clear boundary conditions if the dicretization uses periodic functions (since
 % if we're using periodic basis functions, the boundary conditions will be

--- a/@chebop/expm.m
+++ b/@chebop/expm.m
@@ -52,7 +52,7 @@ if ( fail )
 end
 
 % Determine the discretization:
-prefs = determineDiscretization(N, L, prefs);
+prefs = determineDiscretization(N, length(L.domain), prefs);
 
 % Clear boundary conditions if the dicretization uses periodic functions (since
 % if we're using periodic basis functions, the boundary conditions will be

--- a/@chebop/solvebvp.m
+++ b/@chebop/solvebvp.m
@@ -128,11 +128,13 @@ if ( isnumeric(rhs) )
     if ( ~(all(size(rhs) == [numRow, numCol])) &&  (max(size(rhs)) > 1) )
         if ( all(size(rhs) == [numCol, numRow]) )
             warning('CHEBFUN:CHEBOP:solvebvp:vertcat1', ...
-                'Please concatenate the right-hand side of the BVP vertically. Transposing.')
+                ['Please concatenate the right-hand side of the BVP ' ...
+                'vertically. Transposing.'])
             rhs = rhs.';
         else
             error('CHEBFUN:CHEBOP:solvebvp:rhs', ...
-                'The right-hand side does not match the output dimensions of the operator.');
+                ['The right-hand side does not match the output dimensions ' ...
+                'of the operator.'])
         end
     end
     
@@ -164,8 +166,12 @@ if ( isnumeric(u0) )
     u0 = u0 + 0*residual;
 end
 
-% Determine the discretization.
-pref = determineDiscretization(N, L, pref);
+% Determine the discretization. We look at the max of L.domain and rhs.domain.
+% Note that we look at L.domain rather than N.domain, as the domain of the LINOP
+% L will also include any breakpoints arising from discontinuous coefficients of 
+% N (which we only become aware of when we do the linearization):
+lengthDom = max(max(length(L.domain), length(rhs.domain)), length(u0.domain));
+pref = determineDiscretization(N, lengthDom, pref);
 disc = pref.discretization();
 
 % Determine the TECH used by the discretization.
@@ -175,28 +181,23 @@ techUsed = tech();
 % If the dicretization uses periodic functions, then clear the boundary
 % conditions (if we're using periodic basis functions, the boundary conditions
 % will be satisfied by construction). Also, ensure that u0 is of correct
-% discretization, and convert it to a CHEBMATRIX if necessary.
+% discretization:
 if ( isPeriodicTech(techUsed) )
     % Clear the boundary conditions.
     [N, L] = clearPeriodicBCs(N, L);
-    % Do the conversion.
-    if ( isa(u0, 'chebfun') )
-        u0 = chebmatrix(changeTech(u0, tech));
-    elseif ( isa(u0, 'chebmatrix') )
-        u0 = changeTech(u0, tech);
-    end
+    
+    % ENsure that u0 is of correct discretization:
+    u0 = changeTech(u0, tech);
 end
 
 % Solve:
 if ( all(isLinear) )
-    % Ensure that rhs-residual is of correct discretization, and convert it to a 
-    % CHEBMATRIX if necessary.
+    % This step also ensures that RHS is a CHEBMATRIX:
     rhs = rhs - residual;
-    if ( isa(rhs, 'chebfun') )
-        rhs = chebmatrix(chebfun(rhs, dom, 'tech', tech));
-    elseif ( isa(rhs, 'chebmatrix') )
-        constr = @(f) chebfun(f, dom, 'tech', tech);
-        rhs.blocks = cellfun(constr, rhs.blocks, 'uniformOutput', false);
+    
+    % Ensure that rhs-residual is of correct discretization:
+    if ( isPeriodicTech(techUsed) )
+        rhs = changeTech(rhs, tech);
     end
     
     % Call solver method for linear problems.

--- a/@chebop/solvebvp.m
+++ b/@chebop/solvebvp.m
@@ -186,7 +186,7 @@ if ( isPeriodicTech(techUsed) )
     % Clear the boundary conditions.
     [N, L] = clearPeriodicBCs(N, L);
     
-    % ENsure that u0 is of correct discretization:
+    % Ensure that u0 is of correct discretization:
     u0 = changeTech(u0, tech);
 end
 

--- a/tests/chebop/test_determineDiscretization.m
+++ b/tests/chebop/test_determineDiscretization.m
@@ -16,12 +16,12 @@ L = linearize(N, u0, x);
 N.bc = 'periodic';
 options = cheboppref();
 options.discretization = 'values';
-out = determineDiscretization(N, L, options);
+out = determineDiscretization(N, length(L.domain), options);
 pass(1) = isequal(out.discretization, @trigcolloc);
 
 % Test when coeffs is passed with periodic boundary conditions:
 options.discretization = 'coeffs';
-out = determineDiscretization(N, L, options);
+out = determineDiscretization(N, length(L.domain), options);
 pass(2) = isequal(out.discretization, @trigspec);
 
 % Test when values is passed with periodic boundary conditions and breakpoints:
@@ -31,12 +31,12 @@ u0 = chebfun('0',dom);
 x = chebfun('x',dom);
 L = linearize(N, u0, x);
 options.discretization = 'values';
-out = determineDiscretization(N, L, options);
+out = determineDiscretization(N, length(L.domain), options);
 pass(3) = isequal(out.discretization, @chebcolloc2);
 
 % Test when coeffs is passed with periodic boundary conditions and breakpoints:
 options.discretization = 'coeffs';
-out = determineDiscretization(N, L, options);
+out = determineDiscretization(N, length(L.domain), options);
 pass(4) = isequal(out.discretization, @ultraS);
 
 % Test when values is passed with dirichlet boundary conditions:
@@ -47,12 +47,12 @@ x = chebfun('x',dom);
 L = linearize(N, u0, x);
 N.bc = 'dirichlet';
 options.discretization = 'values';
-out = determineDiscretization(N, L, options);
+out = determineDiscretization(N, length(L.domain), options);
 pass(5) = isequal(out.discretization, @chebcolloc2);
 
 % Test when coeffs is passed with dirichlet boundary conditions:
 options.discretization = 'coeffs';
-out = determineDiscretization(N, L, options);
+out = determineDiscretization(N, length(L.domain), options);
 pass(6) = isequal(out.discretization, @ultraS);
 
 %% Test default:
@@ -64,23 +64,40 @@ u0 = chebfun('0',dom);
 x = chebfun('x',dom);
 L = linearize(N, u0, x);
 N.bc = 'dirichlet';
-out = determineDiscretization(N, L, pref); % use pref
+out = determineDiscretization(N, length(L.domain), pref); % use pref
 pass(7) = isequal(out.discretization, @chebcolloc2);
 
 % Default with periodic:
 N.bc = 'periodic';
-out = determineDiscretization(N, L, pref); % use pref
+out = determineDiscretization(N, length(L.domain), pref); % use pref
 pass(8) = isequal(out.discretization, @trigcolloc);
 
 %% Test CHEBCOLLOC1/ULTRAS:
 
 options.discretization = @chebcolloc1;
-out = determineDiscretization(N, L, options);
+out = determineDiscretization(N, length(L.domain), options);
 pass(9) = isequal(out.discretization, @chebcolloc1);
 
 options.discretization = @ultraS;
-out = determineDiscretization(N, L, options);
+out = determineDiscretization(N, length(L.domain), options);
 pass(10) = isequal(out.discretization, @ultraS);
 
+%% Test a discontinuous RHS:
+
+% Zero boundary condtion at the left:
+dom = [-1 1];
+L = chebop(dom);
+L.op = @(x,u) diff(u) + 2*u;
+L.lbc = @(u) u - 0;
+rhs = chebfun(@(x) abs(x), 'splitting', 'on');
+lengthDom = max(length(L.domain),length(rhs.domain));
+out = determineDiscretization(L, lengthDom, pref);
+pass(11) = isequal(out.discretization, @chebcolloc2);
+
+% Periodic boundary condition. The rhs is discontinuous so it should use 
+% CHEBCOLLOC2:
+L.bc = 'periodic';
+out = determineDiscretization(L, lengthDom, pref);
+pass(12) = isequal(out.discretization, @chebcolloc2); 
 
 end

--- a/tests/chebop/test_determineDiscretization.m
+++ b/tests/chebop/test_determineDiscretization.m
@@ -84,7 +84,7 @@ pass(10) = isequal(out.discretization, @ultraS);
 
 %% Test a discontinuous RHS:
 
-% Zero boundary condtion at the left:
+% Zero boundary condition at the left:
 dom = [-1 1];
 L = chebop(dom);
 L.op = @(x,u) diff(u) + 2*u;


### PR DESCRIPTION
Thank you @aaustin141. 

1. Minor modifications in `solvebvp`.

3. `determineDiscretization` now also checks if the rhs of the ODE is discontinuous. If that's the case, `solvebvp` uses Chebyshev-based discretizations, as opposed to Fourier-based ones. 

3. Add tests in `test_determineDiscretization`.

4. Modify `eigs`, `expm` and `solvebvp` to use the new syntax of `determineDiscretization`. 

