### PR TITLE
Use standardCheck() in PDE15S() and PDE23T().

### DIFF
--- a/@chebfun/pdeSolve.m
+++ b/@chebfun/pdeSolve.m
@@ -160,7 +160,7 @@ end
             c = (1+sin(1:SYSSIZE)).'; % Arbitrarily linear combination.
             Uk2 = (Uk*c/sum(c));
             uk2 = tech.make(Uk2, pref);
-            [ishappy, epslevel, cutoff] = classicCheck(uk2, Uk2, [], pref);
+            [ishappy, epslevel, cutoff] = standardCheck(uk2, Uk2, [], pref);
 
             if ( ishappy )  
 

--- a/@chebmatrix/pde23t.m
+++ b/@chebmatrix/pde23t.m
@@ -1,0 +1,23 @@
+function varargout = pde23t(varargin)
+%PDE23TS   Solve PDEs using Chebfun.
+%
+%   UU = PDE23T(PDEFUN, TT, U0, BC) where PDEFUN is a handle to a function with
+%   arguments u, t, x, and D, TT is a vector, U0 is a CHEBMATRIX, and BC is a
+%   chebop boundary condition structure will solve the PDE dUdt = PDEFUN(UU, t,
+%   x) with the initial condition U0 and boundary conditions BC over the time
+%   interval TT.
+%
+%   This method is basically, a wrapper for @CHEBFUN/PDE23T(). See that file for
+%   further details.
+%
+% See also CHEBFUN/PDE15S, PDESET.
+
+% Copyright 2015 by The University of Oxford and The Chebfun Developers. See
+% http://www.chebfun.org/ for Chebfun information.
+
+% Convert a CHEBMATRIX input to a CHEBFUN:
+varargin{3} = chebfun(varargin{3}); % Third input should be the only CHEBMATRIX.
+
+[varargout{1:nargout}] = pde23t(varargin{:});
+
+end

--- a/tests/misc/test_pde15s.m
+++ b/tests/misc/test_pde15s.m
@@ -228,7 +228,7 @@ u = exp(-20*x.^2) .* sin(14*x);  u = [u ; -u];
 f = @(u, v) [diff(v) ; diff(u)];
 bc.left = @(u, v) u; bc.right = @(u, v) v;        % New way
 opt = pdeset('eps', 1e-6, 'Ylim', pi/2*[-1 1], 'AbsTol', 1e-6, 'RelTol', 1e-6);
-uu = pde23t(f, 0:.05:.5, u, bc, opt);
+uu = pde23t(f, 0:.05:2, u, bc, opt);
 
 %% 
 %chebop-style synatx
@@ -244,8 +244,6 @@ uu = pde15s(f, 0:.025:.5, u, bcc, opts);
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% V4 syntax
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-% TODO: These seem to have stopped working..
 
 %% Example 1: Nonuniform advection
     close all


### PR DESCRIPTION
Also add systems (i.e., `chebmatrix`) support for `pde23t()`.

All demos work, as does the extended `test/misc/test_pde15s()`.

PS. `pdeSolve()` wastes a lot of time building a `chebfun` after each successful time chunk. It might speed things up to simply store values/coefficients as we go a long, and do the `chebfun` construction at the end.