### PR TITLE
Fix dimension mismatch bug in plotcoeffs(f, 'loglog') for trigtech.

### DIFF
--- a/@trigtech/plotcoeffs.m
+++ b/@trigtech/plotcoeffs.m
@@ -94,7 +94,7 @@ else
 
     % Plot the coefficients for the positive and negative fourier modes
     % separately.
-    h = loglog([coeffIndexPos;nan(1,m);coeffIndexNeg], [cPos;nan(1,m);cNeg], args{:});
+    h = loglog([coeffIndexPos nan coeffIndexNeg], [cPos ; nan(1, m) ; cNeg], args{:});
 
     % Set the string for the x-axis label.  In this case we will be
     % plotting the absolute value of the wave number + 1 (since we can't

--- a/tests/chebfun/test_plotcoeffs.m
+++ b/tests/chebfun/test_plotcoeffs.m
@@ -28,6 +28,14 @@ pass(5) = doesNotCrash(@() plotcoeffs(Q));
 pass(6) = doesNotCrash(@() plotcoeffs(g, 'loglog'));
 pass(7) = doesNotCrash(@() plotcoeffs(g, '.--'));
 
+% Check behavior with trigtech.
+f = chebfun(@(x) sin(pi*x), pref, 'trig');
+F = chebfun(@(x) [sin(pi*x) cos(pi*x)], pref, 'trig');
+pass(8) = doesNotCrash(@() plotcoeffs(f));
+pass(9) = doesNotCrash(@() plotcoeffs(F));
+pass(10) = doesNotCrash(@() plotcoeffs(f, 'loglog'));
+pass(11) = doesNotCrash(@() plotcoeffs(f, '.--'));
+
 close(hfig);
 
 end
@@ -39,7 +47,6 @@ try
     pass = true;
 catch ME;
     pass = false;
-    rethrow(ME)
 end
 
 end


### PR DESCRIPTION
This is needed to fix crashes in Ch. 11 of the Guide and the example fourier/FourierCoefficients.m which appeared following the merge of #1584.