### PR TITLE
Turn off default plotting if pde15s is called with outputs.

### DIFF
--- a/@chebfun/pde15s.m
+++ b/@chebfun/pde15s.m
@@ -16,6 +16,12 @@ function varargout = pde15s(varargin)
 %   definite integral operator (i.e., 'sum'), and C the indefinite integral
 %   operator (i.e., 'cumsum') is also supported.
 %
+%   By default, the solutions at intermediate time steps are not plotted when
+%   PDE15s is called with output arguments. See documentation below on how
+%   options can be specified and passed so that intermediate solutions get
+%   plotted. If PDE15s is called without any output arguments, the solutions at
+%   intermediate time steps are plotted by default.
+%
 %   For equations of one variable, UU is output as an array-valued CHEBFUN,
 %   where UU(:, k) is the solution at T(k). For systems, the solution UU is
 %   returned as a CHEBMATRIX with the different variables along the rows, and

--- a/@chebfun/pdeSolve.m
+++ b/@chebfun/pdeSolve.m
@@ -15,8 +15,10 @@ SYSSIZE = 0;
 
 % Default options:
 tol = 1e-6;             % 'eps' in Chebfun terminology
-doPlot = 1;             % Plot after every time chunk?
-doHold = 0;             % Hold plot?
+% The default behaviour with no outputs is to plot. If the method is called with
+% outputs, by default, we don't plot.
+doPlot = ( nargout == 0 );
+doHold = false;         % Hold plot?
 plotOpts = {'-'};       % Plotting style
 adjustBCs = true;       % Adjust inconsistent BCs
 throwBCwarning = true;  % Throw a warning for inconsistent BCs

--- a/pdeset.m
+++ b/pdeset.m
@@ -15,8 +15,10 @@ function varargout = pdeset(varargin)
 %           Use a fixed spacial grid of size N. If N is NaN, then the automatic
 %           procedure is used.
 %
-%       Plot - Plot the solution at the end of every time chunk. [ {on} | off ]
-%              Turning this off can improve speed considerably.
+%       Plot - Plot the solution at the end of every time chunk. [ on | {off} ]
+%              Turning this off can improve speed considerably. Note that if the
+%              PDE methods are called with no output arguments, the default
+%              behaviour is to plot the solution at the end of every time chunk.
 %
 %       HoldPlot - Hold the plots after each chunk. [ on | {off} ]
 %
@@ -69,7 +71,7 @@ if ( nargin == 0 )
         odeset;
         fprintf('             Eps: [ positive scalar {1e-6} ]\n')
         fprintf('               N: [ {NaN} | positive integer  ]\n')        
-        fprintf('            Plot: [ {on} | off ]\n')
+        fprintf('            Plot: [ on | {off} ]\n')
         fprintf('        HoldPlot: [ on | {off} ]\n')
         fprintf('            YLim: [ 2x1 vector | {NaN} ]\n')
         fprintf('       PlotStyle: [ string | ''-'']\n')


### PR DESCRIPTION
If pde15s is called without any outputs, intermediate solutions still
get plotted by default. This is similar to the default behaviour of the
MATLAB ODE solvers, which plot the marching through time if they're called
without outputs. This change is inspired by a discussion with @trefethen
and the use of pde15s in the upcoming book.