### PR TITLE
Fix chebop/feval to vertcat outputs which would otherwise return cell arrays

### DIFF
--- a/@chebop/feval.m
+++ b/@chebop/feval.m
@@ -188,7 +188,7 @@ elseif ( numberOfInputs == 2 )
 
     % Evaluate the operator!
     out = N.op(x, u);
-
+    
 else
     % The operator is specified on the form
     %   N.op = @(x, u, v) = [diff(u,2) + v; u + diff(v)]
@@ -228,6 +228,12 @@ else
         out = doEval(N, args);
     end
     
+end
+
+% If the operator is written in a function file or nested function, then it
+% is natural for it to be returned in cell form. Convert it to a chebmatrix:
+if ( iscell(out) )
+    out = vertcat(out{:}); % TODO: is this correct for multiple RHSs?
 end
 
 end

--- a/tests/chebop/test_cellOperator.m
+++ b/tests/chebop/test_cellOperator.m
@@ -1,0 +1,21 @@
+function pass = test_cellOperator
+% TEST_CELLOPERATOR   Test a chebop whose OP is a function that returns a cell
+
+N = chebop(@(r,u) odefun(r,u), [-1 1]);
+N.lbc = @(u) [u{1} - 1 ; u{2}];
+N.rbc = @(u) [u{1} ; u{2} - 1];
+% Need to specify the number of input variables, as otherwise, we won't know the
+% number of variables involved:
+N.numVars = 2; 
+u = N\0;
+% Did we get the results expected?
+pass = norm(N(u)) < 1e-10 && norm(feval(N.lbc(u), -1)) < 1e-13 && ...
+    norm(feval(N.rbc(u), 1)) < 1e-13;
+
+    function op = odefun(r, u)
+        for n = 1:2
+            op{n} = diff(u{n}, 2) + n*u{n};
+        end
+    end
+
+end


### PR DESCRIPTION
This allows construction of operators such as

```matlab
function foo
N = chebop(@(r,u) odefun(r,u), [-1 1]);
N.lbc = @(u) [u{1} - 1 ; u{2}];
N.rbc = @(u) [u{1} ; u{2} - 1];
N.numVars = 2; % <-- Why is this is required here?
x = chebfun('x');
u = N\0
plot(u), shg

    function op = odefun(r, u)
        for n = 1:2
            op{n} = diff(u{n}, 2) + n*u{n};
        end
    end

end
```