### PR TITLE
Save a lot of overheads when constructing piecewise operators

### DIFF
--- a/@chebcolloc/diff.m
+++ b/@chebcolloc/diff.m
@@ -9,35 +9,37 @@ function D = diff(disc, m)
 %  Copyright 2015 by The University of Oxford and The Chebfun Developers.
 %  See http://www.chebfun.org/ for Chebfun information.
 
-% Store information about domain and dimensions.
-d = disc.domain;
-n = disc.dimension;
-
-if m == 0
+if ( m == 0 )
     % Trivial case:
-    D = eye(sum(n));
-else
-    numIntervals = disc.numIntervals;
+    D = eye(sum(disc.dimension));
     
+else
     % Find the diagonal blocks.
-    blocks = cell(numIntervals);
+    
+    % Store information about domain and dimensions.
+    numIntervals = disc.numIntervals;   
+    n = disc.dimension;
+    d = disc.domain;
+    lengths = diff(d);
     
     % Check how many unique discretization sizes we've got:
     nUnique = unique(n);
     
     % Create a discretization matrix for each unique discretization size:
+    Dn = cell(max(nUnique));
     for nn = nUnique
-        nBlocks{nn} = disc.diffmat(nn, m);
+        Dn{nn} = disc.diffmat(nn, m);
     end
     
     % Scale the blocks appropriately, based on each subinterval length:
-    lengths = diff(d);
+    blocks = cell(numIntervals);
     for k = 1:numIntervals
-        blocks{k} = nBlocks{n(k)} * (2/lengths(k))^m;
+        blocks{k} = Dn{n(k)} * (2/lengths(k))^m;
     end
     
     % Assemble!
     D = blkdiag(blocks{:});
 end
+
 end
 

--- a/@chebcolloc/diff.m
+++ b/@chebcolloc/diff.m
@@ -21,9 +21,19 @@ else
     
     % Find the diagonal blocks.
     blocks = cell(numIntervals);
+    
+    % Check how many unique discretization sizes we've got:
+    nUnique = unique(n);
+    
+    % Create a discretization matrix for each unique discretization size:
+    for nn = nUnique
+        nBlocks{nn} = disc.diffmat(nn, m);
+    end
+    
+    % Scale the blocks appropriately, based on each subinterval length:
+    lengths = diff(d);
     for k = 1:numIntervals
-        len = d(k+1) - d(k);
-        blocks{k} = disc.diffmat(n(k),m) * (2/len)^m; % Scaled diffmats
+        blocks{k} = nBlocks{n(k)} * (2/lengths(k))^m;
     end
     
     % Assemble!

--- a/@linop/deriveContinuity.m
+++ b/@linop/deriveContinuity.m
@@ -46,8 +46,7 @@ else
     % Create periodic conditions, using only endpoints.
     left = dom(end);
     right = dom(1);
-end
-    
+end    
 
 if ( ( max(diffOrd) > 0 ) && ( ~isempty(left) ) )
     
@@ -58,10 +57,10 @@ if ( ( max(diffOrd) > 0 ) && ( ~isempty(left) ) )
     % Each function variable gets a zero functional block; each scalar variable
     % gets a scalar zero.
     z = functionalBlock.zero(dom);
-    Z = {};
+    Z = {}; %#ok<*AGROW>
     for var = 1:length(diffOrd)
         if ( isnan(diffOrd(var)) || diffOrd(var) == 0 )  % scalar variable
-            Z = [Z, 0];
+            Z = [Z, 0]; 
         else   % function variable
             Z = [Z, z];
         end
@@ -87,7 +86,6 @@ L.continuity = cont;
 
 end
 
-
 function C = domainContinuity(dom, maxorder,left, right)
 % Returns expressions of continuity at the breakpoints of the domain of L.
 %   C{m,k} has the (m-1)th-order derivative at breakpoint k
@@ -100,14 +98,14 @@ C = cell(maxorder+1, numIntervals);
 % the output cell, C.
 for k = 1:numIntervals
     C{1, k} = functionalBlock.feval(left(k), dom, -1) - ...
-        functionalBlock.feval(right(k), dom, +1);
+              functionalBlock.feval(right(k), dom, +1);
 end
 
-% Now, multiply the top row of C by increasingly high differentation operators:
+% Now multiply the top row of C by increasingly high differentation operators:
 for m = 1:maxorder
     Dm = operatorBlock.diff(dom, m);
-    C(m+1, :) = cellfun(@mtimes, C(1,:), repmat({Dm}, 1, numIntervals), ...
-        'uniformOutput',false);
+    Dm_rep = repmat({Dm}, 1, numIntervals);
+    C(m+1, :) = cellfun(@mtimes, C(1,:), Dm_rep, 'uniformOutput', false);
 end 
 
 end

--- a/@linop/deriveContinuity.m
+++ b/@linop/deriveContinuity.m
@@ -92,16 +92,22 @@ function C = domainContinuity(dom, maxorder,left, right)
 % Returns expressions of continuity at the breakpoints of the domain of L.
 %   C{m,k} has the (m-1)th-order derivative at breakpoint k
 
-A = operatorBlock.eye(dom);
-D = operatorBlock.diff(dom,1);
-C = cell(maxorder+1,length(left));
-for m = 0:maxorder
-    for k = 1:length(left)
-        El = functionalBlock.feval(left(k),dom,-1);
-        Er = functionalBlock.feval(right(k),dom,+1);
-        C{m+1,k} = (El-Er)*A;
-    end
-    A = D*A;
+% Initialize output cell array
+numIntervals = length(left);
+C = cell(maxorder+1, numIntervals);
+
+% Construct all evaluation difference functionals, and start by storing those in
+% the output cell, C.
+for k = 1:numIntervals
+    C{1, k} = functionalBlock.feval(left(k), dom, -1) - ...
+        functionalBlock.feval(right(k), dom, +1);
 end
+
+% Now, multiply the top row of C by increasingly high differentation operators:
+for m = 1:maxorder
+    Dm = operatorBlock.diff(dom, m);
+    C(m+1, :) = cellfun(@mtimes, C(1,:), repmat({Dm}, 1, numIntervals), ...
+        'uniformOutput',false);
+end 
 
 end


### PR DESCRIPTION
These are the next steps to addressing the slow piecewise BVP first encountered in #1485:

```
tic
dom = [0 16];
x = chebfun('x',dom);
f = (x-floor(x))<sqrt(2)/7;
L = chebop(dom);
L.lbc = 0; L.rbc = 1;
L.op = @(x,u) diff(u,2);
tic, u = L\f;
toc
```

Before #1485 got merged, this took 12.93 seconds on my computer on development, and the merge brought it down to 4.5 seconds.

The code now takes at around 3.8 seconds on my laptop on development, but on this branch, it's down to 1.3 seconds. This is achieved by constructing the pieces of piecewise operators in a way that saves a lot of Matlab overhead, as can be seen by comparing the two profiler results before and after.

On development:
<img width="680" alt="screen shot 2015-10-28 at 16 11 36" src="https://cloud.githubusercontent.com/assets/3543429/10794839/c35a696c-7d8e-11e5-827d-d6e87d722b01.png">

On branch
<img width="686" alt="screen shot 2015-10-28 at 16 12 25" src="https://cloud.githubusercontent.com/assets/3543429/10794842/c7ade7a0-7d8e-11e5-973a-17d8d50158ca.png">


The most expensive operation now is blkdiag, which indicates that further improvements might be achieved by making more use of sparse matrices -- spying the operator that results from the blkdiag call in `chebcolloc/diff` certainly supports that idea. However, making more efficient use of sparse matrices for ODEs is a matter for another PR.
![dspy](https://cloud.githubusercontent.com/assets/3543429/10794885/fd145be0-7d8e-11e5-9d19-8c082c8acf53.png)

