### PR TITLE
Feature chebfun deriv

### DIFF
--- a/@chebfun/deriv.m
+++ b/@chebfun/deriv.m
@@ -11,9 +11,9 @@ function out = deriv(f, xx, m)
 %
 %   Example:
 %     u = chebfun(@sin);
-%     deval(u, 1) % u'(1)
-%     deval(u, .5, 2) % u''(.5)
-%     deval(u, 0.1:0.01:0.2) % u'(0.1:0.01:0.2)
+%     deriv(u, 1) % u'(1)
+%     deriv(u, .5, 2) % u''(.5)
+%     deriv(u, 0.1:0.01:0.2) % u'(0.1:0.01:0.2)
 %
 % See also chebfun/diff, chebfun/feval.
 

--- a/@chebfun/deriv.m
+++ b/@chebfun/deriv.m
@@ -1,0 +1,39 @@
+function out = deriv(f, xx, m)
+%DERIV   Evaluate a derivative of a CHEBFUN.
+%
+%   OUT = DERIV(F, X) evaluates the first derivative of the CHEBFUN F at the
+%   points in X. If F is a quasimatrix with columns F1, ..., FN, then the result
+%   will be [F1(X), ..., FN(X)], the horizontal concatenation of the results of
+%   evaluating each column at the points in X.
+%
+%   OUT = DERIV(F, X, M) is the same as above, but returns the values of the Mth
+%   derivative of F.
+%
+%   Example:
+%     u = chebfun(@sin);
+%     deval(u, 1) % u'(1)
+%     deval(u, .5, 2) % u''(.5)
+%     deval(u, 0.1:0.01:0.2) % u'(0.1:0.01:0.2)
+%
+% See also chebfun/diff, chebfun/feval.
+
+% Copyright 2015 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+% The most trivial case:
+if ( isempty(f) )
+    return
+end
+
+if ( nargin < 3 )
+    m = 1; % By default, compute first derivative
+end
+
+if ( m == 0 )
+    % Trivial case
+    out = feval(f, xx);
+else
+    out = feval(diff(f, m), xx);
+end
+
+end

--- a/tests/chebfun/test_deriv.m
+++ b/tests/chebfun/test_deriv.m
@@ -1,0 +1,27 @@
+function pass = test_deriv(~)
+% TEST_DERIV   Test the chebfun/deriv method
+
+% This test creates some chebfun, evaluates the derivative and compares with the
+% results of feval(diff(...)).
+
+% Our CHEBFUN
+u = chebfun(@(x) sin(exp(x)), [0 2]);
+
+%% Evaluation at one point, default value of derivative
+pass(1) = norm(deriv(u, 1) - feval(diff(u), 1)) == 0;
+
+%% Higher order derivative
+pass(2) = norm(deriv(u, .5, 3) - feval(diff(u, 3), .5)) == 0;
+
+%% Default derivative at a vector of points
+xx = linspace(0.1, 0.5, 11);
+pass(3) = norm(deriv(u, xx) - feval(diff(u), xx)) == 0;
+
+%% Higher derivative, vector of points
+pass(4) = norm(deriv(u, xx, 4) - feval(diff(u, 4), xx)) == 0;
+
+%% Array valued CHEBFUN at a vector of points
+pass(5) = norm(deriv([u cos(u)], xx) - feval(diff([u cos(u)]), xx)) == 0;
+pass(6) = norm(deriv([u cos(u)], xx, 2) - feval(diff([u cos(u)], 2), xx)) == 0;
+
+end


### PR DESCRIPTION
Better syntax for evaluating derivatives of chebfuns. Examples:
```
   Example:
    u = chebfun(@sin);
    deriv(u, 1) % u'(1)
    deriv(u, .5, 2) % u''(.5)
    deriv(u, 0.1:0.01:0.2) % u'(0.1:0.01:0.2)
```

Closes #1624. See also #1626 for a related issue.