### PR TITLE
Pass dimension to cumsum() in computeDerCoeffs() in chebtech.diff().

### DIFF
--- a/@chebtech/diff.m
+++ b/@chebtech/diff.m
@@ -103,10 +103,10 @@ function cout = computeDerCoeffs(c)
 %   whose columns are the derivatives of those of the original.
 
     [n, m] = size(c);
-    cout = zeros(n-1, m);                       % Initialize vector {c_r}
+    cout = zeros(n-1, m);                        % Initialize vector {c_r}
     w = repmat(2*(1:n-1)', 1, m);
-    v = w.*c(2:end,:);                          % Temporal vector
-    cout(n-1:-2:1,:) = cumsum(v(n-1:-2:1,:));   % Compute c_{n-2}, c_{n-4},...
-    cout(n-2:-2:1,:) = cumsum(v(n-2:-2:1,:));   % Compute c_{n-3}, c_{n-5},...
-    cout(1,:) = .5*cout(1,:);                   % Adjust the value for c_0
+    v = w.*c(2:end,:);                           % Temporal vector
+    cout(n-1:-2:1,:) = cumsum(v(n-1:-2:1,:), 1); % Compute c_{n-2}, c_{n-4}, ...
+    cout(n-2:-2:1,:) = cumsum(v(n-2:-2:1,:), 1); % Compute c_{n-3}, c_{n-5}, ...
+    cout(1,:) = .5*cout(1,:);                    % Adjust the value for c_0
 end

--- a/tests/chebtech/test_diff.m
+++ b/tests/chebtech/test_diff.m
@@ -132,6 +132,13 @@ for n = 1:2
     f = testclass.make(@(x) x.^3);
     dim2df = diff(f, 1, 2);
     pass(n, 15) = (isempty(dim2df.coeffs));
+
+    % Check for #1641.
+    f = testclass.make(@(x) [1 + x + x.^2, 1 - x + 2*x.^2]);
+    df = diff(f);
+    err = norm(df.coeffs - [1 -1 ; 2 4], 'fro');
+    tol = 10*eps;
+    pass(n, 16) = err < tol;
 end
 
 end


### PR DESCRIPTION
This is necessary because if the degree is low (2, 3), we'll end up calling cumsum() on a row vector, and when operating on a vector MATLAB cumsum() goes along the non-singleton dimension.  That's not desirable in this case:  we always want to cumsum down _columns_ here, even if the vector is a row.

A test has been added to check for this issue.

This closes #1641.