### PR TITLE
Set x and y lims in chebop/quiver, make plots much nicer.

### DIFF
--- a/@chebop/quiver.m
+++ b/@chebop/quiver.m
@@ -149,6 +149,9 @@ end
 
 h = quiver(x, y, u, v, scale,linespec{:});
 
+% Set x and y limits
+xlim(xl);
+ylim(yl);
 if ( nargout > 0 )
     varargout{1} = h;
 else

--- a/@chebop/quiver.m
+++ b/@chebop/quiver.m
@@ -149,7 +149,7 @@ end
 
 h = quiver(x, y, u, v, scale,linespec{:});
 
-% Set x and y limits
+% Set x and y limits:
 xlim(xl);
 ylim(yl);
 if ( nargout > 0 )


### PR DESCRIPTION
While working on an example for `chebop/quiver`, I realised this would make the plots look much nicer, would be great if someone could quickly merge this minor fix (two lines of code).