### PR TITLE
Ensure projection matrix has correct dimension when matrices are factored in parametrised problems.

### DIFF
--- a/@linop/linsolve.m
+++ b/@linop/linsolve.m
@@ -109,7 +109,7 @@ for dim = [dimVals inf]
     % currently valid factorization at hand.
     if ( isFactored(disc) )
         A = [];
-        P = speye(disc.dimension*size(L,2));
+        P = speye(disc.dimension*sum(isFun)+sum(~isFun));
     else
         [A, P] = matrix(disc);
         if ( size(A, 1) ~= size(A, 2) )


### PR DESCRIPTION
I don't have a minimal example for this, but the following was sent to me by a user and it works with the fix. All test pass with the change.

```
% Define the parameters
dom = [0 1];                % interval of the space domain.
Nr = 200; Nb = 100;         % number of particles
epr = 0.01; epb = 0.01;     % diameter of the particles
epbr = (epr+epb)/2; 
Dr = 1; Db = 2;             % diffusivities
d = 2;                      % problem dimension (d = 2 or 3)
Vr = @(x) x; Vb = @(x) 2*x; % take potentials that depend on x only
tVr = @(x) Vr(x)/Dr; tVb = @(x) Vb(x)/Db; % rescaled forces with the diffusion
alpha = 2*(d-1)*pi/d;

% Discretise in space:
x = chebfun('x', dom);

% Initial guess
ct = Nr/sum(exp(-tVr(x))); cr0 = log(ct); r0 = ct*exp(-tVr(x));
ct = Nb/sum(exp(-tVb(x))); cb0 = log(ct); b0 = ct*exp(-tVb(x));
X0 = [r0 ; b0; cr0; cb0];

% Construct the operator
op = @(x, r,b,cr,cb) ...
    [log(r) + tVr(x) + alpha*(epr^d * r + epbr^d * b) - cr ; 
     log(b) + tVb(x) + alpha*(epb^d * b + epbr^d * r) - cb ; 
     sum(r)-Nr ;
     sum(b)-Nb];
op2 = @(X) op(X(1:N), X(N+(1:N)), X(2*N+1), X(2*N+2)); % Single variable.

% Solve
N = chebop(op, dom);
N.init = X0;
[r, b, cr, cb] = N\0;

% Plot:
figure(1)
plot(chebfun([r b], dom), 'LineWidth', 3), grid on
```