### PR TITLE
fix-chebfun2-explain

### DIFF
--- a/@chebfun2/explain.m
+++ b/@chebfun2/explain.m
@@ -22,9 +22,13 @@ function explain(f, varargin)
 % Copyright 2015 by The University of Oxford and The Chebfun Developers.
 % See http://www.maths.ox.ac.uk/chebfun/ for Chebfun information.
 
-%% Tidy up before we start the movie and create a new figure to plot on:
-home
-close all
+%% Explain only supports chebfun2 on the unit domain
+assert(all(f.domain == [-1 1 -1 1]), 'CHEBFUN:CHEBFUN2:explain:domain', ...
+    ['Explain only supports chebfun2 objects that are defined on the ' ...
+    'unit interval [-1 1 -1 1].']);
+
+%% Create a new figure to plot on:
+
 % Create a new figure, and add space to the bottom for a text box
 fig = figure;
 shg
@@ -201,7 +205,8 @@ if ( numCoarsePivots == 2 )
     
     % Make an observation if the function was of numerical rank 2
     if ( length(f) == 2)
-        fprintf('The first step is complete.')
+        str = [str; 'The first step is complete.'];
+        textBox = myTextbox(str, textBox);
         mypause(psectionbreak),
     end
     

--- a/@chebfun2/explain.m
+++ b/@chebfun2/explain.m
@@ -291,7 +291,7 @@ if ( length(f) > 6 )
         'eventually sampled on a %u x %u Chebyshev grid.'], ...
         length(f.rows(:,1)), length(f.rows(:,1)))};
 elseif ( length(f) > 1 )
-    str = {str; 'The first stage is done.'};
+    str = 'The first stage is done.';
 end
 textBox = myTextbox(str, textBox);
 


### PR DESCRIPTION
See commit message for details.

@asgeirbirkis, I've assigned this to you, since you were the one who moved `explain()` (formerly `movie()`) into v5.  While we're at it, can we also remove the call to `home` [here](https://github.com/chebfun/chebfun/blob/a0b092892a7ffee20660115cb33d69ba9033a8c7/%40chebfun2/explain.m#L26) and [these lines](https://github.com/chebfun/chebfun/blob/a0b092892a7ffee20660115cb33d69ba9033a8c7/%40chebfun2/explain.m#L202-L206), since they don't seem to serve any purpose anymore?