### PR TITLE
Treat addition of zero functions as a special case to avoid warnings in singfun/plus.

### DIFF
--- a/@singfun/plus.m
+++ b/@singfun/plus.m
@@ -137,16 +137,9 @@ else
         ['Non-integer difference in the exponents of the two SINGFUN ' ...
         'objects: The result may not be accurate.']);
     
-    % Define a function handle for the sum:
-    op = @(x) feval(f, x) + feval(g, x);
-        
-    % Take the smallest exponents to be those for the summation:
-    exps = [get(f, 'exponents'); get(g, 'exponents')];
-    exps = min(exps);
-    
     % Construct a new SINGFUN for the sum:
-    data.exponents = exps;
-    s = singfun(op, data, []);
+    op = @(x) feval(f, x) + feval(g, x);
+    s = singfun(op, [], []);
 end
 
 %%

--- a/@singfun/plus.m
+++ b/@singfun/plus.m
@@ -137,9 +137,16 @@ else
         ['Non-integer difference in the exponents of the two SINGFUN ' ...
         'objects: The result may not be accurate.']);
     
-    % Construct a new SINGFUN for the sum:
+    % Define a function handle for the sum:
     op = @(x) feval(f, x) + feval(g, x);
-    s = singfun(op, [], []);
+        
+    % Take the smallest exponents to be those for the summation:
+    exps = [get(f, 'exponents'); get(g, 'exponents')];
+    exps = min(exps);
+    
+    % Construct a new SINGFUN for the sum:
+    data.exponents = exps;
+    s = singfun(op, data, []);
 end
 
 %%

--- a/@singfun/plus.m
+++ b/@singfun/plus.m
@@ -122,6 +122,16 @@ elseif ( all(abs(round(fExps - gExps) - (fExps - gExps)) < tolExps) )
 else
     % Case 3: Nontrivial difference in the exponents of F and G. Form a new
     % function handle for the sum from F and G.
+
+    % It's worth looking for the special case when one of f or g is actually a
+    % zero funtion here. See #1423.
+    if ( iszero(f) )
+        s = g;
+        return
+    elseif ( iszero(g) )
+        s = f;
+        return
+    end
     
     warning('CHEBFUN:SINGFUN:plus:exponentDiff', ...
         ['Non-integer difference in the exponents of the two SINGFUN ' ...
@@ -129,17 +139,13 @@ else
     
     % Define a function handle for the sum:
     op = @(x) feval(f, x) + feval(g, x);
-    
-    % The new scales for the sum:
-    vScale = get(f, 'vscale') + get(g, 'vscale');
-    
+        
     % Take the smallest exponents to be those for the summation:
     exps = [get(f, 'exponents'); get(g, 'exponents')];
     exps = min(exps);
     
     % Construct a new SINGFUN for the sum:
     data.exponents = exps;
-    data.vscale = vScale;
     s = singfun(op, data, []);
 end
 


### PR DESCRIPTION
Closes #1423.

We now get:
```
>> cheb.x;
>> sqrt(x) + 0*x
ans =
   chebfun column (2 smooth pieces)
       interval       length     endpoint values   endpoint exponents
[      -1,       0]        1    complex values         [0      0.5]  
[       0,       1]        1         0        1         [0.5      0]  
vertical scale =   1    Total length = 2
```