### PR TITLE
changed chebtech/simplify to use original coefficients

### DIFF
--- a/@chebtech/simplify.m
+++ b/@chebtech/simplify.m
@@ -64,6 +64,6 @@ end
 cutoff = min(cutoff, nold);
 
 % Chop coefficients using CUTOFF.
-f.coeffs = coeffs(1:cutoff,:);
+f.coeffs = f.coeffs(1:cutoff,:);
 
 end


### PR DESCRIPTION
This fixes a bug in `chebtech/simplify` regarding noisy output coefficients.