### PR TITLE
Allow scaled jumps.

### DIFF
--- a/tests/chebop/test_jump_scaled.m
+++ b/tests/chebop/test_jump_scaled.m
@@ -1,0 +1,12 @@
+function pass = test_jump_scaled
+% TEST_JUMP_SCALED   Test a scaled jump. See #1694
+
+A = chebop(@(x,u) diff(u,2) - u+x, [-1,1]);
+A.lbc = .2;
+A.rbc = 0;
+A.bc = @(x,u) [ u(.1, 'left') - 4*u(.1, 'right') - 2.2; % Scaled jump in sol
+    jump(diff(u),.1,1)];    % Continuous first derivative
+u = A\0;
+pass = abs(u(.1,'left') - 4*u(.1,'right') - 2.2 ) < 1e-10;
+
+end


### PR DESCRIPTION
The code was mostly there, the only thing that needed fixing was to allow passing varargin to `adchebfun/feval` (like we have been able to do for a long time for the standard `chebfun/feval`), so that the correct `functionalBlocks` would be constructed.

Closes #1694.