### PR TITLE
fix-deriv-sided

### DIFF
--- a/@chebfun/deriv.m
+++ b/@chebfun/deriv.m
@@ -1,13 +1,17 @@
-function out = deriv(f, xx, m)
+function out = deriv(f, xx, varargin)
 %DERIV   Evaluate a derivative of a CHEBFUN.
 %
-%   OUT = DERIV(F, X) evaluates the first derivative of the CHEBFUN F at the
-%   points in X. If F is a quasimatrix with columns F1, ..., FN, then the result
-%   will be [F1(X), ..., FN(X)], the horizontal concatenation of the results of
+%   DERIV(F, X) evaluates the first derivative of the CHEBFUN F at the points in
+%   X. If F is a quasimatrix with columns F1, ..., FN, then the result will be
+%   [F1(X), ..., FN(X)], the horizontal concatenation of the results of
 %   evaluating each column at the points in X.
 %
-%   OUT = DERIV(F, X, M) is the same as above, but returns the values of the Mth
+%   DERIV(F, X, M) is the same as above, but returns the values of the Mth
 %   derivative of F.
+%
+%   DERIV(F, X, S) or DERIV(F, X, S) where S is one of the strings 'left',
+%   'right', '+', or '-', evaluates the left- or right-sided limit as described
+%   in chebfun/feval.
 %
 %   Example:
 %     u = chebfun(@sin);
@@ -25,15 +29,27 @@ if ( isempty(f) )
     return
 end
 
-if ( nargin < 3 )
-    m = 1; % By default, compute first derivative
+% By default, compute first derivative:
+m = 1;      
+
+% Parse the inputs:
+if ( nargin == 3 )
+    if ( isnumeric(varargin{1}) ) % DERIV(F, X, M)
+        m = varargin{1};
+        varargin = {};
+    else                          % DERIV(F, X, S)
+        m = 1;  % By default, compute first derivative
+    end
+elseif ( nargin == 4 )            % DERIV(F, X, S, M)
+    m = varargin{2};
+    varargin{2} = [];
 end
 
 if ( m == 0 )
     % Trivial case
-    out = feval(f, xx);
+    out = feval(f, xx, varargin{:});
 else
-    out = feval(diff(f, m), xx);
+    out = feval(diff(f, m), xx, varargin{:});
 end
 
 end

--- a/@chebfun/deriv.m
+++ b/@chebfun/deriv.m
@@ -9,15 +9,21 @@ function out = deriv(f, xx, varargin)
 %   DERIV(F, X, M) is the same as above, but returns the values of the Mth
 %   derivative of F.
 %
-%   DERIV(F, X, S) or DERIV(F, X, S) where S is one of the strings 'left',
+%   DERIV(F, X, S) or DERIV(F, X, S, M) where S is one of the strings 'left',
 %   'right', '+', or '-', evaluates the left- or right-sided limit as described
 %   in chebfun/feval.
 %
-%   Example:
+%   Example 1:
 %     u = chebfun(@sin);
 %     deriv(u, 1) % u'(1)
 %     deriv(u, .5, 2) % u''(.5)
 %     deriv(u, 0.1:0.01:0.2) % u'(0.1:0.01:0.2)
+%
+%   Example 2:
+%     x = chebfun('x')
+%     u = abs(x);
+%     deriv(u, 0, 'left')  % ans = -1
+%     deriv(u, 0, 'right') % ans = +1
 %
 % See also chebfun/diff, chebfun/feval.
 

--- a/tests/chebfun/test_deriv.m
+++ b/tests/chebfun/test_deriv.m
@@ -24,4 +24,10 @@ pass(4) = norm(deriv(u, xx, 4) - feval(diff(u, 4), xx)) == 0;
 pass(5) = norm(deriv([u cos(u)], xx) - feval(diff([u cos(u)]), xx)) == 0;
 pass(6) = norm(deriv([u cos(u)], xx, 2) - feval(diff([u cos(u)], 2), xx)) == 0;
 
+%% Left- and right-sided evaluation
+x = chebfun(@(x) x, [-1 1]);
+v = cumsum(sign(x));
+pass(7) = norm(feval(diff(v), 0, 'left') - deriv(v, 0, 'left')) == 0;
+pass(8) = norm(feval(diff(v, 2), 0, '+') - deriv(v, 0, '+', 2)) == 0;
+
 end


### PR DESCRIPTION
Allow left- and right-sided evaluation in `deriv()`.

Closes #1703.