### PR TITLE
Fix jacpts

### DIFF
--- a/jacpts.m
+++ b/jacpts.m
@@ -161,7 +161,7 @@ end
 
 % Compute the constant for the weights:
 if ( ~strcmpi(method,'GW') )
-    if ( strcmpi(method,'ASY') )
+    if ( n >= 100 )
         cte1 = ratiogamma(n+a+1,b);
         cte2 = ratiogamma(n+1,b);
         C = 2^(a+b+1)*(cte2/cte1);

--- a/jacpts.m
+++ b/jacpts.m
@@ -69,17 +69,17 @@ end
 % Check inputs:
 if ( nargin > 3 )
     if ( nargin == 5 )
-        % Calling sequence = LEGPTS(N, INTERVAL, METHOD)
+        % Calling sequence = JACPTS(N, INTERVAL, METHOD)
         interval = int;
         method = meth;
         method_set = 1;
     elseif ( nargin == 4 )
         if ( ischar(int) )
-            % Calling sequence = LEGPTS(N, METHOD)
+            % Calling sequence = JACPTS(N, METHOD)
             method = int;
             method_set = true;
         else
-            % Calling sequence = LEGPTS(N, INTERVAL)
+            % Calling sequence = JACPTS(N, INTERVAL)
             interval = int;
         end
     end
@@ -887,22 +887,23 @@ if ( nargout < 6 )
     return
 end
 
-% A2p:
+% A3p:
 A3p = D*A3;
 A3p = A3p - A3p(1);
 A3p_t = A3p./t;
 % Extrapolate point at t = 0:
 w = pi/2-t(2:end);
 w(2:2:end) = -w(2:2:end);
+w(end) = .5*w(end);
 A3p_t(1) = sum(w.*A3p_t(2:end))/sum(w);
 
-% B2:
+% B3:
 tB3 = -.5*A3p - (.5+alph)*(C*A3p_t) + .5*C*(f.*A3);
 B3 = tB3./t;
 % Extrapolate point at t = 0
 B3(1) = sum(w.*B3(2:end))/sum(w);
 
-% A3:
+% A4:
 K = C*(f.*tB3);
 A4 = .5*(D*tB3) - (.5+alph)*B3 - .5*K;
 A4 = A4 - A4(1);

--- a/jacpts.m
+++ b/jacpts.m
@@ -159,13 +159,16 @@ else
     
 end
 
-% Compute the constant for weights:
+% Compute the constant for the weights:
 if ( ~strcmpi(method,'GW') )
-    cte1 = ratiogamma(n+a+1,b);
-    cte2 = ratiogamma(n+1,b);
-    C = 2^(a+b+1) * (cte2/cte1);
-
-    w = C*w; 
+    if ( strcmpi(method,'ASY') )
+        cte1 = ratiogamma(n+a+1,b);
+        cte2 = ratiogamma(n+1,b);
+        C = 2^(a+b+1)*(cte2/cte1);
+    else
+        C = 2^(a+b+1)*beta(a+1, b+1)/sum(w);
+    end
+    w = C*w;
 end
 
 % Scale the nodes and quadrature weights:

--- a/jacpts.m
+++ b/jacpts.m
@@ -878,44 +878,8 @@ K = C*(f.*tB2);
 A3 = .5*(D*tB2) - (.5+alph)*B2 - .5*K;
 A3 = A3 - A3(1);
 
-if ( nargout < 6 )
-    % Make function for output
-    tB1 = @(theta) bary(theta, tB1, t, v);
-    A2 = @(theta) bary(theta, A2, t, v);
-    tB2 = @(theta) bary(theta, tB2, t, v);
-    A3 = @(theta) bary(theta, A3, t, v);
-    return
-end
-
-% A3p:
-A3p = D*A3;
-A3p = A3p - A3p(1);
-A3p_t = A3p./t;
-% Extrapolate point at t = 0:
-w = pi/2-t(2:end);
-w(2:2:end) = -w(2:2:end);
-w(end) = .5*w(end);
-A3p_t(1) = sum(w.*A3p_t(2:end))/sum(w);
-
-% B3:
-tB3 = -.5*A3p - (.5+alph)*(C*A3p_t) + .5*C*(f.*A3);
-B3 = tB3./t;
-% Extrapolate point at t = 0
-B3(1) = sum(w.*B3(2:end))/sum(w);
-
-% A4:
-K = C*(f.*tB3);
-A4 = .5*(D*tB3) - (.5+alph)*B3 - .5*K;
-A4 = A4 - A4(1);
-
-% Make function for output:
 tB1 = @(theta) bary(theta, tB1, t, v);
 A2 = @(theta) bary(theta, A2, t, v);
 tB2 = @(theta) bary(theta, tB2, t, v);
 A3 = @(theta) bary(theta, A3, t, v);
-tB3 = @(theta) bary(theta, tB3, t, v);
-A4 = @(theta) bary(theta, A4, t, v);
-
 end
-
-

--- a/jacpts.m
+++ b/jacpts.m
@@ -161,9 +161,10 @@ end
 
 % Compute the constant for weights:
 if ( ~strcmpi(method,'GW') )
-    C = 2^(a+b+1) * exp( gammaln(n+a+1) - gammaln(n+a+b+1) + ...
-                         gammaln(n+b+1) - gammaln(n+1) ); 
-                     
+    cte1 = ratiogamma(n+a+1,b);
+    cte2 = ratiogamma(n+1,b);
+    C = 2^(a+b+1) * (cte2/cte1);
+
     w = C*w; 
 end
 
@@ -186,6 +187,27 @@ function [x, w] = rescale(x, w, interval, a, b)
         x = c1 + c2*x;    
     end
 end
+
+function [cte] = ratiogamma(m,delta)
+%RATIOGAMMA Compute the ratio gamma(m+delta)/gamma(m). See [2].
+    % cte = gamma(m+delta)/gamma(m)
+    ds = .5*delta^2/(m-1);
+    s = ds;
+    j = 1;
+    while ( abs(ds/s) > eps/100 ) % Taylor series in expansion 
+        j = j+1;
+        ds = -delta*(j-1)/(j+1)/(m-1)*ds;
+        s = s + ds;
+    end
+    p2 = exp(s)*sqrt(1+delta/(m-1))*(m-1)^(delta);
+    % Stirling's series:
+    g = [1, 1/12, 1/288, -139/51840, -571/2488320, 163879/209018880, ...
+        5246819/75246796800, -534703531/902961561600, ...
+        -4483131259/86684309913600, 432261921612371/514904800886784000];
+    f = @(z) sum(g.*[1, cumprod(ones(1, 9)./z)]);
+    cte = p2*(f(m+delta-1)/f(m-1));
+end
+
 
 %% ------------------------- Routines for GW ----------------------------
     

--- a/tests/misc/test_jacpts.m
+++ b/tests/misc/test_jacpts.m
@@ -51,4 +51,15 @@ pass(22) = abs( w - 2^(a+b+1)*beta(a+1, b+1) ) < tol;
 [x1, w1] = jacpts(2e5, .2, .2);
 pass(23) = abs(sum(w1*x1)) < 10*eps;
 
+% See #1707
+[~, w] = jacpts(1e6, -.5, 0);
+pass(24) = sum(w) - 2*sqrt(2) < 100*eps;
+
+[~, w] = jacpts(114, -.5, 0);
+pass(25) = sum(w) - 2*sqrt(2) < 10*eps;
+
+[x, w] = jacpts(1e5, 1, 1);
+pass(26) = sum(w) - 4/3 < 100*eps;
+pass(27) = w*x.^2 - 4/15 < 10*eps;
+
 end


### PR DESCRIPTION
Compute the constant out the front in a more stable way using the ratio of gamma functions. See #1707.