### PR TITLE
More graceful bailing out of Newton iteration when linear solves go awry

### DIFF
--- a/@chebop/dampingErrorBased.m
+++ b/@chebop/dampingErrorBased.m
@@ -126,7 +126,17 @@ while ( ~accept )
     
     % Compute a simplified Newton step using the current derivative of the
     % operator, but with a new right-hand side.
-    [deltaBar, disc] = linsolve(L, deResFunTrial, disc, vscale(u), pref);
+    [deltaBar, disc, converged] = linsolve(L, deResFunTrial, disc, ...
+        vscale(u), pref);
+    
+    % If solving for the simplified Newton update did not converge, we have a
+    % gibberish update. This will cause the solution process to halt (we're
+    % solving something that's way too noisy), so bail out of the Newton
+    % iteration:
+    if ( ~converged )
+        giveUp = true;
+        break
+    end
     
     % We had two output arguments above, need to negate deltaBar:
     deltaBar = -deltaBar;    

--- a/@chebop/solvebvpNonlinear.m
+++ b/@chebop/solvebvpNonlinear.m
@@ -247,6 +247,7 @@ end
 % Return useful information in the INFO structure
 info.normDelta = normDeltaVec(1:newtonCounter);
 info.error = errEst;
+info.converged = success;
 
 end
 

--- a/@chebop/solvebvpNonlinear.m
+++ b/@chebop/solvebvpNonlinear.m
@@ -218,14 +218,6 @@ while ( ~terminate )
         res = res - rhs;    
     end
     
-    if ( newtonCounter > 1 && isnan(cFactor) )
-        % If we get a contraction factor that's a NaN, something has gone
-        % terribly wrong with the latest update. If we try to keep the Newton
-        % iteration running, we expect the process to halt, so break out of the
-        % iteration
-        giveUp = true;
-    end
-    
     % Should we stop the Newton iteration?
     if ( success || maxIterExceeded || ( giveUp == 1) || stopReq )
         break

--- a/@linop/linsolve.m
+++ b/@linop/linsolve.m
@@ -1,4 +1,4 @@
-function [u, disc] = linsolve(L, f, varargin)
+function [u, disc, converged] = linsolve(L, f, varargin)
 %LINSOLVE  Solve a linear differential/integral equation.
 %   Important: A CHEBOPPREF object PREFS has to be passed. When this method
 %   is called via CHEBOP/MLDIVIDE, PREFS is inherited from the CHEBOP level.
@@ -14,6 +14,11 @@ function [u, disc] = linsolve(L, f, varargin)
 %
 %   LINSOLVE(...,PREFS) accepts a CHEBOPPREF to control the behavior of
 %   the algorithms. If empty, defaults are used.
+%
+%   [U, DISC, CONVERGED] = LINSOLVE(L, ...) also returns the OPDISCRETIZATION
+%   object DISC, used for solving the linear differential/integral equation, and
+%   the Boolean flag CONVERGED, which has value TRUE if the linear system
+%   solution converged, and FALSE otherwise.
 %
 %   EXAMPLE:
 %     d = [0,pi];
@@ -155,9 +160,11 @@ for dim = [dimVals inf]
     
 end
 
+converged = true;
 if ( ~all(isDone) )
     warning('CHEBFUN:LINOP:linsolve:noConverge', ...
         'Linear system solution may not have converged.')
+    converged = false;
 end
 
 %% Tidy the solution for output:


### PR DESCRIPTION
If when solving the linear system for the Newton update did not converge, we end up with a gibberish update, from which there is little chance to converge afterward. This will cause the solution process to halt (we're solving something that's way too noisy, with a large discretization size), so it's better to bail out of the Newton iteration. This PR allows the Newton algorithm to exit more gracefully out of such situations.