### PR TITLE
NARGCHK() is deprecated in R2016a.

### DIFF
--- a/@chebfun2v/roots.m
+++ b/@chebfun2v/roots.m
@@ -1150,7 +1150,7 @@ function [x0,y0,iout,jout] = intersections(x1,y1,x2,y2,robust)
 
 
 % Input checks.
-error(nargchk(2,5,nargin))
+narginchk(2,5)
 
 % Adjustments when fewer than five arguments are supplied.
 switch nargin


### PR DESCRIPTION
`nargchk()`-->`narginchk()` to avoid to following warnings:

```
>> cd tests/chebfun2v
>> test_roots01
Warning: NARGCHK will be removed in a future release. Use NARGINCHK or NARGOUTCHK instead. 
> In chebfun2v/roots>intersections (line 1153)
  In chebfun2v/roots>roots_marchingSquares (line 973)
  In chebfun2v/roots (line 67)
  In test_roots01 (line 14) 
```