### PR TITLE
Pass vscale to smoothfun constructor in singfun.plus().

### DIFF
--- a/@singfun/plus.m
+++ b/@singfun/plus.m
@@ -139,13 +139,17 @@ else
     
     % Define a function handle for the sum:
     op = @(x) feval(f, x) + feval(g, x);
-        
+
+    % The new scales for the sum:
+    vScale = get(f, 'vscale') + get(g, 'vscale');
+
     % Take the smallest exponents to be those for the summation:
     exps = [get(f, 'exponents'); get(g, 'exponents')];
     exps = min(exps);
     
     % Construct a new SINGFUN for the sum:
     data.exponents = exps;
+    data.vscale = vScale;
     s = singfun(op, data, []);
 end
 

--- a/tests/singfun/test_plus.m
+++ b/tests/singfun/test_plus.m
@@ -74,6 +74,21 @@ tol = 10*max(get(h1, 'vscale')*eps, ...
     get(h2, 'vscale')*eps);
 pass(14) = norm(feval(h1, x) - feval(h2, x), inf) < tol;
 
+% Check that plus handles "small" results appropriately in the case of a
+% non-integer exponent difference.
+warnState = warning('off', 'CHEBFUN:SINGFUN:plus:exponentDiff');
+
+pref_fixed = pref;
+pref_fixed.fixedLength = 256;
+op = @(x) ((x + 1)/2).^pi;
+data.exponents = [pi - 3, 0];
+f = singfun(op, data, pref);
+g = singfun(op, [], pref_fixed);
+h = f - g;
+pass(15) = get(h, 'ishappy') && (length(h) < 1024);
+
+warning(warnState);
+
 end
 
 % Test the addition of a SINGFUN F, specified by Fh, to a scalar C using


### PR DESCRIPTION
This partially reverts f337559b.  One of the changes in that commit
removed the lines that pass the vscale information down to the smoothfun
constructor when we hit the case in which the exponents differ by
non-integer values in singfun.plus().  This was causing the example
cheb/Convergence.m to hang because one of the functions it constructs (a
rare instance of a case that actually hits this code and an even rarer
example of one where the construction succeeds) is built by subtracting
two functions that are very close, and the constructor was failing due
to the resulting noise.