### PR TITLE
Fix help text for ultraS.convertmat().

### DIFF
--- a/@ultraS/convertmat.m
+++ b/@ultraS/convertmat.m
@@ -1,10 +1,13 @@
 function S = convertmat(n, K1, K2)
 %CONVERTMAT  Conversion matrix used in the ultraspherical spectral method.
-%   S = CONVERTMAT(N, K1, K2 ) is a private method for constructing conversion
-%   matrices. It returns the N-by-N matrix realization of the conversion
-%   operator. The matrix S maps N coefficients in a C^{(K1)} basis to N
-%   coefficients in a C^{K2} basis. Here, C^{(K)} is the ultraspherical
-%   polynomial basis with parameter K.
+%   S = CONVERTMAT(N, K1, K2) computes the N-by-N matrix realization of the
+%   conversion operator between two bases of ultrapherical polynomials.  The
+%   matrix S maps N coefficients in a C^{(K1)} basis to N coefficients in a
+%   C^{(K2 + 1)} basis, where, C^{(K)} denotes ultraspherical polynomial basis
+%   with parameter K.  If K2 < K1, S is the N-by-N identity matrix.
+%
+%   This function is meant for internal use only and does not validate its
+%   inputs.
 
 % Copyright 2015 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.


### PR DESCRIPTION
See comments on #1729 and #1509.  This is documentation that occurs in a part of the system that I don't completely understand, so I'm issuing a pull request for it.  It might actually be a better idea to tweak `ultraS.convertmat()` to do what its help text originally said, as that interface would be less confusing.  