### PR TITLE
Major overhaul of input parsing in chebfun2.

### DIFF
--- a/@chebfun/chebfun.m
+++ b/@chebfun/chebfun.m
@@ -310,8 +310,8 @@ classdef chebfun
         % Deprecated function.
         varargin = quad(varargout);
         
-        % Set pointValues property:
-        f = setPointValues(f, j, k, vals)
+        % Reset pointValues property to the average of left and right limits.
+        f = resetPointValues(f);
         
         % Remove all-zero layers of higher-order impulses.
         f = tidyImpulses(f)

--- a/@chebfun/resetPointValues.m
+++ b/@chebfun/resetPointValues.m
@@ -1,0 +1,11 @@
+function f = clearPointValues(f)
+%   F = CLEARPOINTVALS(F) sets the .POINTVALS(j) to the average of the right and
+%   left limits of its neighbouring funs for interior breaks and the limits from
+%   the left and right for the POINTVALS(1) and VALS(end), respectively.
+for k = 1:numel(f)
+    f(k).pointValues = chebfun.getValuesAtBreakpoints(f(k).funs);
+end
+
+end
+
+

--- a/@chebfun/roots.m
+++ b/@chebfun/roots.m
@@ -51,6 +51,7 @@ function r = roots(F, varargin)
 
 % Deal with the trivial empty case:
 if ( isempty(F) )
+    r = [];
     return
 end
 

--- a/@chebfun2/constructor.m
+++ b/@chebfun2/constructor.m
@@ -109,12 +109,12 @@ while ( ~isHappy && ~failure )
     % Check if the column and row slices are resolved.
     colData.hscale = norm(dom(3:4), inf);
     colData.vscale = vscale;
-    colChebtech = tech.make(sum(colVals,2), colData);
-    resolvedCols = happinessCheck(colChebtech, [], sum(colVals, 2), colData, pref);
+    colTech = tech.make(sum(colVals,2), colData);
+    resolvedCols = happinessCheck(colTech, [], sum(colVals, 2), colData, pref);
     rowData.hscale = norm(dom(1:2), inf);
     rowData.vscale = vscale;
-    rowChebtech = tech.make(sum(rowVals.',2), rowData);
-    resolvedRows = happinessCheck(rowChebtech, [], sum(rowVals.', 2), rowData, pref);
+    rowTech = tech.make(sum(rowVals.',2), rowData);
+    resolvedRows = happinessCheck(rowTech, [], sum(rowVals.', 2), rowData, pref);
     isHappy = resolvedRows & resolvedCols;
     
     % If the function is zero, set midpoint of domain as pivot location.
@@ -127,6 +127,7 @@ while ( ~isHappy && ~failure )
     end
     
     %% %%% PHASE 2: %%%
+    pref.eps = tol;
     % Now resolve along the column and row slices:
     n = grid;  m = grid;
     while ( ~isHappy && ~failure  )
@@ -168,12 +169,12 @@ while ( ~isHappy && ~failure )
         
         % Are the columns and rows resolved now?
         if ( ~resolvedCols )
-            colChebtech = tech.make(sum(colVals,2));
-            resolvedCols = happinessCheck(colChebtech,[],sum(colVals,2), colData, pref);
+            colTech = tech.make(sum(colVals,2));
+            resolvedCols = happinessCheck(colTech,[],sum(colVals,2), colData, pref);
         end
         if ( ~resolvedRows )
-            rowChebtech = tech.make(sum(rowVals.',2));
-            resolvedRows = happinessCheck(rowChebtech,[],sum(rowVals.',2), rowData, pref);
+            rowTech = tech.make(sum(rowVals.',2));
+            resolvedRows = happinessCheck(rowTech,[],sum(rowVals.',2), rowData, pref);
         end
         isHappy = resolvedRows & resolvedCols;
         
@@ -221,7 +222,7 @@ while ( ~isHappy && ~failure )
 end
 
 % Simplifying rows and columns after they are happy.
-g = simplify( g, pref.eps );
+% g = simplify( g, tol );
 
 % Fix the rank, if in nonadaptive mode.
 g = fixTheRank( g , fixedRank );

--- a/@chebfun2/constructor.m
+++ b/@chebfun2/constructor.m
@@ -529,11 +529,12 @@ end
 function [op, dom, pref, isEqui, fixedRank, vectorize] = parseInputs(op, varargin)
 
 if ( isa(op, 'char') )     % CHEBFUN2( CHAR )
-    op = str2op( op );
+    op = str2op(op);
 end
-if ( isa(op, 'function_handle') && nargin(op) == 1 )
-    % If the operator has one argument, then make it complex.
-    op = @(x, y) op( x + 1i*y );
+
+% If the operator has one argument, then make it complex.
+if ( isa(op, 'function_handle') && (nargin(op) == 1) )
+    op = @(x, y) op(x + 1i*y);
 end
 
 % Get the domain: (Always first if given)
@@ -543,25 +544,25 @@ if ( nargin > 1 && isnumeric(varargin{1}) )
     d = varargin{1};
     varargin(1) = [];
     
-    if ( numel(d) == 4 )
+    if ( numel(d) == 4 )                 % CHEBFUN2(OP, [A B C D])
         dom = d;
         
     elseif ( numel(d) == 2 )
-        if ( ( nargin > 2) && isa(varargin{1}, 'double') )
+        if ( (nargin > 2) && isa(varargin{1}, 'double') )
             ends = varargin{1};
-            if ( numel( ends ) == 2 )
+            if ( numel( ends ) == 2 )    % CHEBFUN2(OP, [A B], [C D])
                 dom = [d(:) ; ends(:)].';
-            elseif ( numel(ends) == 4 )
+            elseif ( numel(ends) == 4 )  % CHEBFUN2(OP, [M N], [A B C D])
                 % Interpret this as the user wants a degree (dom(1),dom(2))
                 % chebfun2 on the domain [ends].
                 [xx, yy] = chebfun2.chebpts2(d(1), d(2), ends);
                 op = op(xx, yy);
                 dom = ends;
             else
-                error('CHEBFUN:CHEBFUN2:constructor:domain1', ...
+                error('CHEBFUN:CHEBFUN2:constructor:parseInputs:domain1', ...
                     'Domain not valid or fully determined.');
             end
-        else
+        else                             % CHEBFUN2(OP, [M N])
             % The domain is not given, but perhaps the user
             % wants a degree (dom(1),dom(2)) representation.
             if ( d(2) - d(1) > 0 && d(1) > 0 && ...  % Valid bivariate degree?
@@ -570,22 +571,22 @@ if ( nargin > 1 && isnumeric(varargin{1}) )
                 [xx, yy] = chebfun2.chebpts2(d(1), d(2));
                 op = op(xx, yy);
             else
-                error('CHEBFUN:CHEBFUN2:constructor:domain2', ...
+                error('CHEBFUN:CHEBFUN2:constructor:parseInputs:domain2', ...
                     'Domain not valid or fully determined.');
             end
         end
-    elseif ( numel(d) == 1 )
+    elseif ( numel(d) == 1 )             % CHEBFUN2(OP, K)
         fixedRank = d;
         
     elseif ( numel(d) ~= 4 )
-        error('CHEBFUN:CHEBFUN2:constructor:DOMAIN', ...
-            'Domain not fully determined.');
+        error('CHEBFUN:CHEBFUN2:constructor:parseInputs:domain3', ...
+            'Domain not valid or fully determined.');
     end
 end
 
 % Check for infinite domains:
-if ( any( isinf( dom ) ) )
-    error('CHEBFUN2:DOMAIN:INFINITE', ...
+if ( any(isinf(dom) ) )
+    error('CHEBFUN:CHEBFUN2:constructor:parseInputs:infDomain', ...
         'Chebfun2 cannot approximation functions on infinite domains.');
 end
 
@@ -633,6 +634,7 @@ if ( vectorize )
 else
     vectorize = false;
 end
+
 % If the vectorize flag is off, do we need to give user a warning?
 if ( ~vectorize && ~isnumeric(op) ) % another check
     [vectorize, op] = vectorCheck(op, dom, pref.eps);
@@ -641,14 +643,14 @@ end
 isPadua = find(cellfun(@(p) strcmpi(p, 'padua'), varargin));
 if ( isPadua )
     varargin(isPadua) = [];
-    op = chebfun2.paduaVals2coeffs( op );
-    op = chebfun2.coeffs2vals( op );
+    op = chebfun2.paduaVals2coeffs(op);
+    op = chebfun2.coeffs2vals(op);
 end
 
 isCoeffs = find(cellfun(@(p) strcmpi(p, 'coeffs'), varargin));
 if ( isCoeffs )
     varargin(isCoeffs) = [];
-    op = chebfun2.coeffs2vals( op );
+    op = chebfun2.coeffs2vals(op);
 end
 
 end

--- a/@chebfun2/constructor.m
+++ b/@chebfun2/constructor.m
@@ -222,7 +222,7 @@ while ( ~isHappy && ~failure )
 end
 
 % Simplifying rows and columns after they are happy.
-% g = simplify( g, tol );
+g = simplify( g );
 
 % Fix the rank, if in nonadaptive mode.
 g = fixTheRank( g , fixedRank );

--- a/@chebfun2/constructor.m
+++ b/@chebfun2/constructor.m
@@ -1,4 +1,4 @@
-function g = constructor(g, op, dom, varargin)
+function g = constructor(g, op, varargin)
 %CONSTRUCTOR   The main CHEBFUN2 constructor.
 %
 % This code is when functions of two variables are represented as CHEBFUN2
@@ -38,237 +38,45 @@ if ( isa(op, 'chebfun2') )  % CHEBFUN2( CHEBFUN2 )
     return
 end
 
-% If domain is empty take [-1 1 -1 1]:
-if ( nargin < 3 || isempty(dom) )
-    dom = [-1 1 -1 1];
-end
-% Get preferences:
-if ( nargin > 3 && isa(varargin{1}, 'chebfunpref') )
-    pref = chebfunpref(varargin{1});
-else
-    pref = chebfunpref();
-end
+[op, dom, pref, localPrefs] = parseInputs(op, varargin{:});
 
-if ( isa(dom, 'chebfunpref') )
-    % Support chebfun2(op, pref);
-    pref = dom;
-    dom = [-1 1 -1 1];
-end
-
-% Get default preferences from chebfunpref:
-prefStruct = pref.cheb2Prefs;
-sampleTest = prefStruct.sampleTest;
-maxRank = prefStruct.maxRank;
-
-% Get default preferences from the techPref:
+% Preferences:
 tech = pref.tech();
-tpref = chebfunpref.mergeTechPrefs(pref, tech.techPref);
+tpref = tech.techPref;
 minSample = tpref.minSamples;
 maxSample = tpref.maxLength;
-pseudoLevel = tpref.eps;
+cheb2Prefs = pref.cheb2Prefs;
+sampleTest = cheb2Prefs.sampleTest;
+maxRank = cheb2Prefs.maxRank;
+pseudoLevel = pref.eps;
+isEqui = localPrefs.isEqui;
+vectorize = localPrefs.vectorize;
+fixedRank = localPrefs.fixedRank;
 
-% Deal with periodic functions:
-if ( any(strcmpi(dom, {'trig', 'periodic'})) )
-    % If periodic flag, then map chebfun2 with TRIGTECHs.
-    pref.tech = @trigtech;
-    tpref = chebfunpref.mergeTechPrefs(pref, tech.techPref);
-    minSample = tpref.minSamples;
-    maxSample = tpref.maxLength;
-    pseudoLevel = tpref.eps;
-    dom = [-1 1 -1 1];
-elseif ( (nargin > 3) && (any(strcmpi(varargin{1}, {'trig', 'periodic'}))) )
-    % If periodic flag, then map chebfun2 with TRIGTECHs
-    pref.tech = @trigtech;
-    tpref = chebfunpref.mergeTechPrefs(pref, tech.techPref);
-    minSample = tpref.minSamples;
-    maxSample = tpref.maxLength;
-    pseudoLevel = tpref.eps;
-end
 
 % Deal with constructions from equally spaced data:
-if ( any(strcmpi(dom, 'equi')) || ((nargin > 3) && (any(strcmpi(varargin{1}, 'equi')))) )
-    % Equally spaced data:
-    if ( any(strcmpi(dom, 'equi')) )
-        dom = [-1 1 -1 1];
-    end
-    % Calculate a tolerance and find numerical rank to this tolerance:
-    % The tolerance assumes the samples are from a function. It depends
-    % on the size of the sample matrix, hscale of domain, vscale of
-    % the samples, condition number of the function, and the accuracy
-    % target in chebfun2 preferences.
-    [xx, yy] = meshgrid(linspace(dom(1), dom(2), size(op,2)), linspace(dom(3), dom(4), size(op,1)));
-    tol = GetTol(xx, yy, op, dom, pseudoLevel);
-    [pivotValue, ignored, rowValues, colValues] = CompleteACA(op, tol, 0); % Do ACA on matrices
-    
-    % Make a chebfun2:
-    g.pivotValues = pivotValue;
-    g.cols = chebfun(colValues, dom(3:4), 'equi' );
-    g.rows = chebfun(rowValues.', dom(1:2), 'equi'  );
-    g.domain = dom;
-    return
-end
 
 if ( isa(op, 'double') )    % CHEBFUN2( DOUBLE )
-    if ( numel( op ) == 1 && ~any(strcmpi(dom, 'coeffs')) )
-        % LNT wants this:
-        g = constructor(g, @(x,y) op + 0*x, dom);
-        
-    elseif ( any(strcmpi(dom, 'coeffs')) )
-        % Look for coeffs flag:
-        op = chebfun2.coeffs2vals( op );
-        g = chebfun2( op, varargin{:} );
-        return
-    elseif ( any(strcmpi(dom, 'padua')) )
-        op = chebfun2.paduaVals2coeffs( op );
-        op = chebfun2.coeffs2vals( op );
-        g = chebfun2( op, 'coeffs' );
-        return
-    elseif ( (nargin > 3) && (any(strcmpi(varargin{1}, 'coeffs'))) )
-        op = chebfun2.coeffs2vals( op );
-        g = chebfun2( op, dom );
-        return
-    elseif ( (nargin > 3) && (any(strcmpi(varargin{1}, 'padua'))) )
-        op = chebfun2.paduaVals2coeffs( op, dom );
-        op = chebfun2.coeffs2vals( op );
-        g = chebfun2( op, dom );
-        return
+    if ( isEqui )
+        g = constructFromEqui(op, dom, pref);
     else
-        % If CHEBFUN2(f, rk), then nonadaptive call:
-        if ( numel(dom) == 1 )
-            fixedRank = dom;
-            dom = [-1 1 -1 1];
-        else
-            % Otherwise its an adaptive call:
-            fixedRank = 0;
-        end
-        
-        % Calculate a tolerance and find numerical rank to this tolerance:
-        % The tolerance assumes the samples are from a function. It depends
-        % on the size of the sample matrix, hscale of domain, vscale of
-        % the samples, condition number of the function, and the accuracy
-        % target in chebfun2 preferences.
-        [xx, yy] = points2D(size(op,2), size(op,1), dom, pref);
-        tol = GetTol(xx, yy, op, dom, pseudoLevel);
-        
-        % Perform GE with complete pivoting:
-        [pivotValue, ignored, rowValues, colValues] = CompleteACA(op, tol, 0);
-        
-        % Construct a CHEBFUN2:
-        g.pivotValues = pivotValue;
-        g.cols = chebfun(colValues, dom(3:4), pref );
-        g.rows = chebfun(rowValues.', dom(1:2), pref );
-        g.domain = dom;
-        
-        % Did we have a nonadaptive construction?:
-        g = fixTheRank(g, fixedRank);
+        g = constructFromDouble(op, dom, pref, localPrefs);
     end
+    g = fixTheRank(g, fixedRank);
     return
-end
-
-if ( isa(op, 'char') )     % CHEBFUN2( CHAR )
-    op = str2op( op );
-end
-
-% If the operator has one argument, then make it complex.
-if ( nargin(op) == 1 )
-    op = @(x, y) op( x + 1i*y );
-end
-
-% Look for vectorize flag:
-vectorize = 0;
-if (any(strcmpi(dom, 'vectorize')) || any(strcmpi(dom, 'vectorise')))
-    vectorize = 1;
-    dom = [-1 1 -1 1];
-elseif ( (nargin > 3) && (any(strcmpi(varargin{1}, 'vectorize')) ||...
-        any(strcmpi(varargin{1}, 'vectorise'))))
-    vectorize = 1;
-end
-
-fixedRank = 0;
-% If the domain isn't of length 4, search for the other 2 endpoints: For
-% instance, allow CHEBFUN2( OP, [-1 1], [-1 1]).
-if ( numel(dom) == 2 )
-    if ( ( nargin > 3) && isa(varargin{1}, 'double') )
-        ends = varargin{1};
-        if ( numel( ends ) == 2 )
-            dom = [dom(:) ; ends(:)].';
-        elseif ( numel(ends) == 4 )
-            % Interpret this as the user wants a degree (dom(1),dom(2))
-            % chebfun2 on the domain [ends].
-            [xx, yy] = chebfun2.chebpts2(dom(1), dom(2), ends);
-            g = chebfun2( op(xx, yy), varargin{:} );
-            return
-        else
-            error('CHEBFUN:CHEBFUN2:constructor:domain1', ...
-                'Domain not valid or fully determined.');
-        end
-    else
-        % The domain is not given, but perhaps the user
-        % wants a degree (dom(1),dom(2)) representation.
-        if ( dom(2) - dom(1) > 0 && dom(1)>0 &&...   % A valid bivariate degree?
-                abs(round(dom(1)) - dom(1))< eps &&...
-                abs(round(dom(2)) - dom(2))< eps)
-            [xx, yy] = chebfun2.chebpts2(dom(1), dom(2));
-            g = chebfun2( op(xx, yy), varargin );
-            return
-        else
-            error('CHEBFUN:CHEBFUN2:constructor:domain2', ...
-                'Domain not valid or fully determined.');
-        end
-    end
-elseif ( numel(dom) == 1 )
-    fixedRank = dom;
-    dom = [-1 1 -1 1];
-elseif ( numel(dom) ~= 4 )
-    error('CHEBFUN:CHEBFUN2:constructor:DOMAIN', ...
-        'Domain not fully determined.');
-end
-
-% Check for infinite domains:
-if ( any( isinf( dom ) ) )
-    error('CHEBFUN2:DOMAIN:INFINITE', ...
-        'Chebfun2 cannot approximation functions on infinite domains.');
-end
-
-% If the vectorize flag is off, do we need to give user a warning?
-if ( vectorize == 0 ) % another check
-    % Check for cases: @(x,y) x*y, and @(x,y) x*y'
-    [xx, yy] = meshgrid( dom(1:2), dom(3:4));
-    A = op(xx, yy);
-    if ( isscalar(A) )
-        op = @(x,y) op(x,y) + 0*x + 0*y;
-        A = op(xx, yy);
-    end
-    B = zeros(2);
-    for j = 1:2
-        for k = 1:2
-            B(j,k) = op(dom(j), dom(2+k));
-        end
-    end
-    if ( any(any( abs(A - B.') > min( 1000*pseudoLevel, 1e-4 ) ) ) )
-        % Function handle probably needs vectorizing, give user a warning and
-        % then vectorize.
-        
-        warning('CHEBFUN:CHEBFUN2:constructor:vectorize',...
-            ['Function did not correctly evaluate on an array.\n', ...
-            'Turning on the ''vectorize'' flag. Did you intend this?\n', ...
-            'Use the ''vectorize'' flag in the CHEBFUN2 constructor\n', ...
-            'call to avoid this warning message.']);
-        g = chebfun2(op, dom, 'vectorize', pref);
-        return
-    end
 end
 
 factor = 4;  % ratio between size of matrix and no. pivots.
 isHappy = 0; % If we are currently unresolved.
 failure = 0; % Reached max discretization size without being happy.
+
 while ( ~isHappy && ~failure )
     grid = minSample;
     
     % Sample function on a Chebyshev tensor grid:
     [xx, yy] = points2D(grid, grid, dom, pref);
     vals = evaluate(op, xx, yy, vectorize);
-    
+   
     % Does the function blow up or evaluate to NaN?:
     vscale = max(abs(vals(:)));
     if ( isinf(vscale) )
@@ -314,7 +122,6 @@ while ( ~isHappy && ~failure )
     % Check if the column and row slices are resolved.
     colData.hscale = norm(dom(3:4), inf);
     colData.vscale = vscale;
-    tech = pref.tech();
     colChebtech = tech.make(sum(colValues,2), colData);
     resolvedCols = happinessCheck(colChebtech, [], sum(colValues, 2), colData);
     rowData.hscale = norm(dom(1:2), inf);
@@ -426,18 +233,75 @@ while ( ~isHappy && ~failure )
 end
 
 % Simplifying rows and columns after they are happy.
-g = simplify( g ); 
+g = simplify( g );
 
 % Reconstruct using simplified coefficients to guarantee endpoint values are
 % correct.
 g.cols = chebfun(get(g.cols, 'coeffs'), domain(g.cols), 'coeffs', ...
-                  'tech', @tech.make);
+    'tech', @tech.make);
 g.rows = chebfun(get(g.rows, 'coeffs'), domain(g.rows), 'coeffs', ...
-                  'tech', @tech.make);
+    'tech', @tech.make);
 
 % Fix the rank, if in nonadaptive mode.
 g = fixTheRank( g , fixedRank );
 
+end
+
+
+function g = constructFromDouble(op, dom, pref, localPrefs)
+g = chebfun2();
+
+if ( localPrefs.coeffs )
+    op = chebfun2.coeffs2vals( op );
+elseif ( localPrefs.padua )
+    op = chebfun2.paduaVals2coeffs( op );
+    op = chebfun2.coeffs2vals( op );
+end
+
+if ( numel( op ) == 1 )
+    % LNT wants this:
+    g = constructor(g, @(x,y) op + 0*x, dom);
+
+else
+
+    % Calculate a tolerance and find numerical rank to this tolerance:
+    % The tolerance assumes the samples are from a function. It depends
+    % on the size of the sample matrix, hscale of domain, vscale of
+    % the samples, condition number of the function, and the accuracy
+    % target in chebfun2 preferences.
+    [xx, yy] = points2D(size(op,2), size(op,1), dom, pref);
+    tol = GetTol(xx, yy, op, dom, pref.eps);
+    
+    % Perform GE with complete pivoting:
+    [pivotValue, ~, rowValues, colValues] = CompleteACA(op, tol, 0);
+    
+    % Construct a CHEBFUN2:
+    g.pivotValues = pivotValue;
+    g.cols = chebfun(colValues, dom(3:4), pref );
+    g.rows = chebfun(rowValues.', dom(1:2), pref );
+    g.domain = dom;
+    
+end
+end
+
+function g = constructFromEqui(op, dom, pref)
+% Calculate a tolerance and find numerical rank to this tolerance:
+% The tolerance assumes the samples are from a function. It depends
+% on the size of the sample matrix, hscale of domain, vscale of
+% the samples, condition number of the function, and the accuracy
+% target in chebfun2 preferences.
+x = linspace(dom(1), dom(2), size(op,2));
+y = linspace(dom(3), dom(4), size(op,1));
+[xx, yy] = meshgrid(x, y);
+tol = GetTol(xx, yy, op, dom, pref.eps);
+[pivotValue, ~, rowValues, colValues] = CompleteACA(op, tol, 0); % Do ACA on matrices
+
+% Make a chebfun2:
+g = chebfun2();
+g.pivotValues = pivotValue;
+g.cols = chebfun(colValues, dom(3:4), 'equi' );
+g.rows = chebfun(rowValues.', dom(1:2), 'equi');
+g.domain = dom;
 end
 
 function [pivotValue, pivotElement, rows, cols, ifail] = ...
@@ -671,11 +535,11 @@ function tol = GetTol(xx, yy, vals, dom, pseudoLevel)
 %  This is the 2D analogue of the tolerance employed in the chebtech
 %  constructors. It is based on a finite difference approximation to the
 %  gradient, the size of the approximation domain, the internal working
-%  tolerance, and an arbitrary (2/3) exponent. 
+%  tolerance, and an arbitrary (2/3) exponent.
 
-[m, n] = size( vals ); 
+[m, n] = size( vals );
 grid = max( m, n );
-% Remove some edge values so that df_dx and df_dy have the same size. 
+% Remove some edge values so that df_dx and df_dy have the same size.
 dfdx = diff(vals(1:m-1,:),1,2) ./ diff(xx(1:m-1,:),1,2); % xx diffs column-wise.
 dfdy = diff(vals(:,1:n-1),1,1) ./ diff(yy(:,1:n-1),1,1); % yy diffs row-wise.
 % An approximation for the norm of the gradient over the whole domain.
@@ -683,4 +547,175 @@ Jac_norm = max( max( abs(dfdx(:)), abs(dfdy(:)) ) );
 vscale = max( abs( vals(:) ) );
 tol = grid.^(2/3) * max( abs(dom(:) ) ) * max( Jac_norm, vscale) * pseudoLevel;
 
+end
+
+function [op, dom, pref, localPrefs] = parseInputs(op, varargin)
+
+localPrefs = struct('isEqui', false, ...
+                   'fixedRank', 0, ...
+                   'vectorize', false, ...
+                   'coeffs', false, ...
+                   'padua', false);
+
+if ( isa(op, 'char') )     % CHEBFUN2( CHAR )
+    op = str2op( op );
+end
+if ( isa(op, 'function_handle') && nargin(op) == 1 )
+    % If the operator has one argument, then make it complex.
+    op = @(x, y) op( x + 1i*y );
+end
+
+% Get the domain: (Always first if given)
+dom = [-1, 1, -1, 1];
+fixedRank = 0;
+if ( nargin > 1 && isnumeric(varargin{1}) )
+    d = varargin{1};
+    varargin(1) = [];
+    
+    if ( numel(d) == 4 )
+        dom = d;
+        
+    elseif ( numel(d) == 2 )
+        if ( ( nargin > 2) && isa(varargin{1}, 'double') )
+            ends = varargin{1};
+            if ( numel( ends ) == 2 )
+                dom = [d(:) ; ends(:)].';
+            elseif ( numel(ends) == 4 )
+                % Interpret this as the user wants a degree (dom(1),dom(2))
+                % chebfun2 on the domain [ends].
+                [xx, yy] = chebfun2.chebpts2(d(1), d(2), ends);
+                op = op(xx, yy);
+                dom = ends;
+            else
+                error('CHEBFUN:CHEBFUN2:constructor:domain1', ...
+                    'Domain not valid or fully determined.');
+            end
+        else
+            % The domain is not given, but perhaps the user
+            % wants a degree (dom(1),dom(2)) representation.
+            if ( d(2) - d(1) > 0 && d(1) > 0 && ...  % Valid bivariate degree?
+                    abs(round(d(1)) - d(1))< eps && ...
+                    abs(round(d(2)) - d(2))< eps)
+                [xx, yy] = chebfun2.chebpts2(d(1), d(2));
+                op = op(xx, yy);
+            else
+                error('CHEBFUN:CHEBFUN2:constructor:domain2', ...
+                    'Domain not valid or fully determined.');
+            end
+        end
+    elseif ( numel(d) == 1 )
+        fixedRank = d;
+        
+    elseif ( numel(d) ~= 4 )
+        error('CHEBFUN:CHEBFUN2:constructor:DOMAIN', ...
+            'Domain not fully determined.');
+    end
+end
+localPrefs.fixedRank = fixedRank;
+
+% Check for infinite domains:
+if ( any( isinf( dom ) ) )
+    error('CHEBFUN2:DOMAIN:INFINITE', ...
+        'Chebfun2 cannot approximation functions on infinite domains.');
+end
+
+% Preferences structure given?
+isPref = find(cellfun(@(p) isa(p, 'chebfunpref'), varargin));
+if ( any(isPref) )
+    pref = varargin{isPref};
+    varargin(isPref) = [];
+elseif ( isa(dom, 'chebfunpref') )
+    % Support chebfun2(op, pref);
+    pref = dom;
+    dom = [-1 1 -1 1];
+else
+    pref = chebfunpref();
+end
+
+isEqui = find(cellfun(@(p) strcmpi(p, 'equi'), varargin));
+if ( isEqui )
+    varargin(isEqui) = [];
+    localPrefs.isEqui = true;
+end
+
+isTrig = find(cellfun(@(p) any(strcmpi(p, {'trig', 'periodic'})), varargin));
+if ( isTrig )
+    varargin(isTrig) = [];
+    pref.tech = @trigtech;
+end
+
+isEpsGiven = find(cellfun(@(p) strcmpi(p, 'eps'), varargin));
+if ( isEpsGiven )
+    pseudoLevel = varargin{isEpsGiven+1};
+    varargin(isEpsGiven+(0:1)) = [];
+else
+    pseudoLevel = 0;
+end
+pref.eps = max(pref.eps, pseudoLevel);
+
+% Look for vectorize flag:
+vectorize = find(cellfun(@(p) strncmpi(p, 'vectori', 7), varargin));
+if ( vectorize )
+    varargin(vectorize) = [];
+    localPrefs.vectorize = true;
+end
+
+% If the vectorize flag is off, do we need to give user a warning?
+if ( localPrefs.vectorize == 0 && ~isnumeric(op) ) % another check
+    [localPrefs.vecotorize, op] = vectorCheck(op, dom, pref.eps);
+end
+
+isPadua = find(cellfun(@(p) strcmpi(p, 'padua'), varargin));
+if ( isPadua )
+    varargin(isPadua) = [];
+    localPrefs.padua = true;
+end
+
+isCoeffs = find(cellfun(@(p) strcmpi(p, 'coeffs'), varargin));
+if ( isCoeffs )
+    varargin(isCoeffs) = [];
+    localPrefs.coeffs = true;
+end
+
+end
+
+function [vectorize, op] = vectorCheck(op, dom, pseudoLevel)
+% Check for cases: @(x,y) x*y, and @(x,y) x*y'
+
+    vectorize = false;
+    [xx, yy] = meshgrid( dom(1:2), dom(3:4));
+    
+    try 
+        A = op(xx, yy);
+    catch
+        throwVectorWarning();
+        vectorize = true;
+        return
+    end
+    
+    if ( isscalar(A) )
+        op = @(x,y) op(x,y) + 0*x + 0*y;
+        A = op(xx, yy);
+        
+    end
+    B = zeros(2);
+    for j = 1:2
+        for k = 1:2
+            B(j,k) = op(dom(j), dom(2+k));
+        end
+    end
+    if ( any(any( abs(A - B.') > min( 1000*pseudoLevel, 1e-4 ) ) ) )
+        % Function handle probably needs vectorizing.
+        % Give user a warning and then vectorize.
+        throwVectorWarning();
+        vectorize = true;
+    end
+    
+    function throwVectorWarning()
+        warning('CHEBFUN:CHEBFUN2:constructor:vectorize',...
+        ['Function did not correctly evaluate on an array.\n', ...
+        'Turning on the ''vectorize'' flag. Did you intend this?\n', ...
+        'Use the ''vectorize'' flag in the CHEBFUN2 constructor\n', ...
+        'call to avoid this warning message.']);
+    end
 end

--- a/@chebfun2/constructor.m
+++ b/@chebfun2/constructor.m
@@ -595,10 +595,6 @@ isPref = find(cellfun(@(p) isa(p, 'chebfunpref'), varargin));
 if ( any(isPref) )
     pref = varargin{isPref};
     varargin(isPref) = [];
-elseif ( isa(dom, 'chebfunpref') )
-    % Support chebfun2(op, pref);
-    pref = dom;
-    dom = [-1 1 -1 1];
 else
     pref = chebfunpref();
 end

--- a/@chebop2/solvepde.m
+++ b/@chebop2/solvepde.m
@@ -143,7 +143,7 @@ end
 X = cutTrailingCoefficients(X);
 
 % Form a CHEBFUN2 object to represent the solution:
-u = chebfun2(X, 'coeffs', rect); 
+u = chebfun2(X, rect, 'coeffs'); 
 
 end
 

--- a/@separableApprox/simplify.m
+++ b/@separableApprox/simplify.m
@@ -19,4 +19,8 @@ end
 f.cols = simplify( f.cols, tol, 'globaltol' ); 
 f.rows = simplify( f.rows, tol, 'globaltol' ); 
 
+% Ensure the left and right limits match the endpoints:
+f.cols = resetPointValues(f.cols);
+f.rows = resetPointValues(f.rows);
+
 end 

--- a/tests/chebfun2/test_constructor2.m
+++ b/tests/chebfun2/test_constructor2.m
@@ -51,4 +51,13 @@ f = chebfun2(1,'coeffs');
 pass(12) = ( norm( f - 1 ) < tol );
 f = chebfun2('x'); z = .5 + sqrt(3)/3*1i;
 pass(13) = ( norm( f(real(z),imag(z)) - z ) < tol ) ; 
+
+% Test passing an 'eps' value.  (Just make sure it doesn't crash.)
+try
+    chebfun2(@(x, y) sin(x.*y), 'eps', 1e-6);
+    pass(14) = true;
+catch ME
+    pass(14) = false;
+end
+
 end

--- a/tests/chebfun2/test_ctorsyntax.m
+++ b/tests/chebfun2/test_ctorsyntax.m
@@ -42,5 +42,8 @@ g = chebfun2( f, [10 15], [-2 1 -2 1]);
 pass(4) = ( m == 10 ) && (n == 15) ;
 pass(5) = any( g.domain == [-2 1 -2 1] ); 
 
+f = @(x, y) sin(x.*y);
+g = chebfun2(f, 1);
+pass(6) = rank(g) == 1;
 
 end


### PR DESCRIPTION
Major overhaul of `chebfun2` constructor input parsing. All the tests pass (remarkably..)

As a consequence we can now do this (see #1764).
```
>> chebfun2(@(x,y) 1./(1+25*(x.^2+y.^2)))
ans =
   chebfun2 object (1 smooth surface)
       domain                 rank       corner values
[  -1,   1] x [  -1,   1]       19     [0.02 0.02 0.02 0.02]
vertical scale =   1 
>> chebfun2(@(x,y) 1./(1+25*(x.^2+y.^2)), 'eps', 1e-8)
ans =
   chebfun2 object (1 smooth surface)
       domain                 rank       corner values
[  -1,   1] x [  -1,   1]        9     [0.02 0.02 0.02 0.02]
vertical scale =   1 
```