### PR TITLE
removed "(1 smooth surface)" from @chebfun2/disp.m

### DIFF
--- a/@chebfun2/disp.m
+++ b/@chebfun2/disp.m
@@ -26,7 +26,7 @@ vals = vals(:);
 vscl = vscale(F);                         % vertical scale
 
 % Display the information: 
-disp('   chebfun2 object (1 smooth surface)')
+disp('   chebfun2 object')
 fprintf('       domain                 rank       corner values\n');
 if ( isreal(vals) )
     fprintf('[%4.2g,%4.2g] x [%4.2g,%4.2g]   %6i     [%4.2g %4.2g %4.2g %4.2g]\n', ...


### PR DESCRIPTION
This does what it says on the tin: removes that pesky expression "1 smooth surface" from every display of a chebfun2.   (This is my first pull request!)