### PR TITLE
Fix chebfun2v/dot: Respect underlying tech

### DIFF
--- a/@chebfun2v/dot.m
+++ b/@chebfun2v/dot.m
@@ -1,4 +1,4 @@
-function f = dot( F, G )
+function H = dot( F, G )
 %DOT   Vector dot product.
 %   DOT(F, G) returns the dot product of the CHEBFUN2V objects F and G. DOT(F,
 %   G) is the same as F'*G.
@@ -8,13 +8,20 @@ function f = dot( F, G )
 % Copyright 2015 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information. 
 
-if ( isempty( F ) || isempty( G ) ) 
-    f = chebfun2();
+if ( isempty( F ) ) 
+    H = F;
+    return
+end
+
+if ( isempty( G ) ) 
+    H = G;
     return
 end
 
 nF = F.nComponents; 
 nG = G.nComponents; 
+
+% Check that F and G have the same number of components:
 if ( nG ~= nF ) 
     error('CHEBFUN:CHEBFUN2V:dot:components', ...
         'CHEBFUN2V object should have the same number of components.');
@@ -26,9 +33,9 @@ for jj = 1:nF
     Fc{jj} = times(Fc{jj}, Gc{jj}); 
 end
 
-f = chebfun2( 0, G.components{1}.domain );
-for jj = 1 : nF
-    f = f + Fc{jj};
+H = Fc{1};
+for jj = 2 : nF
+    H = H + Fc{jj};
 end
 
 end


### PR DESCRIPTION
The `chebfun2v/dot` command now respects the underlying tech.  

Now we have
```
chebfunpref.setDefaults('tech',@trigtech)
x = chebfun2(@(u,v) (3+cos(v)).*cos(u), [-pi pi -pi pi]);
y = chebfun2(@(u,v) (3+cos(v)).*sin(u), [-pi pi -pi pi]);
z = chebfun2(@(u,v) sin(v), [-pi pi -pi pi]);
S = [x; y; z];

E           =   dot(S,S);
[C,D,R] = cdr( E ) 
C =
   chebfun column (1 smooth piece)
       interval       length     endpoint values  trig
[    -3.1,     3.1]       10     -0.15    -0.15 
vertical scale = 0.59 
D =
  68.252862777426245
R =
   chebfun column (1 smooth piece)
       interval       length     endpoint values  trig
[    -3.1,     3.1]        4      -0.4     -0.4 
vertical scale = 0.4 
```
showing that periodic output was calculated from periodic input. 