### PR TITLE
modified trigtech and chebtech innerProducts to handle mixed tech cases

### DIFF
--- a/@chebtech/innerProduct.m
+++ b/@chebtech/innerProduct.m
@@ -16,9 +16,12 @@ if ( isempty(f) || isempty(g) )
     return
 end
 
-if ( ~isa(f, 'chebtech') || ~isa(g, 'chebtech') )
+% if g is a trigtech convert it to a chebtech
+if ( isa(g, 'trigtech') )
+    g = chebtech2.make(@(x) feval(g,x));
+elseif ( ~isa(g, 'chebtech') )
     error('CHEBFUN:CHEBTECH:innerProduct:input', ...
-        'innerProduct() only operates on two CHEBTECH objects.');
+        'innerProduct() only operates on CHEB/TRIGTECH objects.');
 end
 
 % Prolong to sum of current lengths (so that quadrature is exact):

--- a/@trigtech/innerProduct.m
+++ b/@trigtech/innerProduct.m
@@ -16,9 +16,14 @@ if ( isempty(f) || isempty(g) )
     return
 end
 
-if ( ~isa(f, 'trigtech') || ~isa(g, 'trigtech') )
+% if g is a chebtech convert f to a chebtech and call chebtech/innerProduct
+if ( isa(g, 'chebtech') )
+    f = chebtech2.make(@(x) feval(f,x));
+    out = innerProduct(f,g);
+    return
+elseif ( ~isa(g, 'trigtech') )
     error('CHEBFUN:TRIGTECH:innerProduct:input', ...
-        'innerProduct() only operates on two TRIGTECH objects.');
+        'innerProduct() only operates on CHEB/TRIGTECH objects.');
 end
 
 % Prolong to sum of current lengths (so that quadrature is exact):


### PR DESCRIPTION
This pull request allows one to take inner-products between `chebtechs` and `trigtechs` by doing the appropriate conversions at the tech level. See issue #1784.