### PR TITLE
Higher accuracy eigenvalues in eigs

### DIFF
--- a/@chebmatrix/chebmatrix.m
+++ b/@chebmatrix/chebmatrix.m
@@ -217,7 +217,7 @@ classdef (InferiorClasses = {?chebfun, ?operatorBlock, ?functionalBlock}) chebma
         %   tranposed (which is consistent with the built in CELL class).
             for k = 1:numel(A.blocks)
                 % TODO: TRANSPOSE() or CTRANSPOSE()?
-                A.blocks{k} = transpose(A.blocks{k});
+                A.blocks{k} = ctranspose(A.blocks{k});
             end
             A.blocks = transpose(A.blocks);
         end

--- a/tests/linop/test_eigsRayleigh.m
+++ b/tests/linop/test_eigsRayleigh.m
@@ -1,0 +1,43 @@
+function pass = test_eigs()
+% TAD, 10 Jan 2014
+
+tol = 1e-8;
+
+dom = [-pi/2, pi/2];
+D2 = operatorBlock.diff(dom, 2);
+E = functionalBlock.eval(dom);
+El = E(dom(1));
+Er = E(dom(end));
+L = linop(D2);
+L = addbc(L, El, 0);
+L = addbc(L, Er, 0);
+
+e_true = flipud(-(1:6).'.^2);
+
+%%
+prefs = cheboppref;
+prefs.discretization = @chebcolloc2;
+[v, d] = eigs(L, 6, prefs, 'rayleigh');
+e = diag(d);
+err(1) = norm(e - e_true, inf);
+% check that we actually computed eigenfunctions
+err(2) = norm(L*v-v*d);
+
+%%
+prefs.discretization = @ultraS;
+[V, D] = eigs(L, 6, 0, prefs, 'rayleigh');
+e = diag(D);
+err(3) = norm(e - e_true, inf);
+err(4) = norm(L*V-V*D);
+
+%%
+prefs.discretization = @chebcolloc1;
+[V, D] = eigs(L, 6, prefs, 'rayleigh');
+e = diag(D);
+err(5) = norm(e - e_true, inf);
+err(6) = norm(L*V-V*D);
+
+%%
+pass = err < tol;
+
+end


### PR DESCRIPTION
This pull request allows one to improve the accuracy of the computed eigenpairs in `linop/eigs` by doing one step of inverse (Rayleigh) quotient iteration. This feature is enabled by passing a flag in the call to `eigs`. This feature is only implemented at the `linop` level since I don't think the average user will need to deal with this. This PR depends on #1787.