### PR TITLE
fix-mixed-tech-innerProduct

### DIFF
--- a/@chebfun/innerProduct.m
+++ b/@chebfun/innerProduct.m
@@ -39,6 +39,14 @@ out = zeros(numColsF, numColsG);
 
 if ( numel(f) == 1 && numel(g) == 1 )
     % Array-valued CHEBFUN case:
+
+    % If one of the two CHEBFUNs uses a PERIODICTECH representation, cast it to
+    % a NONPERIODICTECH.
+    if ( ~isPeriodicTech(f.funs{1}) && isPeriodicTech(g.funs{1}) )
+        g = chebfun(g, g.domain, 'tech', get(f.funs{1}, 'tech'));
+    elseif ( isPeriodicTech(f.funs{1}) && ~isPeriodicTech(g.funs{1}) )
+        f = chebfun(f, f.domain, 'tech', get(g.funs{1}, 'tech'));
+    end
     
     % Overlap the CHEBFUN objects:
     [f, g] = overlap(f, g);
@@ -50,6 +58,12 @@ if ( numel(f) == 1 && numel(g) == 1 )
     
 else
     % QUASIMATRIX case:
+
+    % NB:  No need to convert periodic representations to nonperiodic ones here
+    % if we're computing an inner product between a periodically represented
+    % and a nonperiodically represented one, since we'll wind up in the
+    % array-valued (single-column) case when we call innerProduct() in the loop
+    % below, and the conversion will get done there.
     
     % Convert to a cell array:
     f = mat2cell(f);

--- a/@chebtech/innerProduct.m
+++ b/@chebtech/innerProduct.m
@@ -16,12 +16,9 @@ if ( isempty(f) || isempty(g) )
     return
 end
 
-% if g is a trigtech convert it to a chebtech
-if ( isa(g, 'trigtech') )
-    g = chebtech2.make(@(x) feval(g,x));
-elseif ( ~isa(g, 'chebtech') )
+if ( ~isa(f, 'chebtech') || ~isa(g, 'chebtech') )
     error('CHEBFUN:CHEBTECH:innerProduct:input', ...
-        'innerProduct() only operates on CHEB/TRIGTECH objects.');
+        'innerProduct() only operates on two CHEBTECH objects.');
 end
 
 % Prolong to sum of current lengths (so that quadrature is exact):

--- a/@trigtech/innerProduct.m
+++ b/@trigtech/innerProduct.m
@@ -16,14 +16,9 @@ if ( isempty(f) || isempty(g) )
     return
 end
 
-% if g is a chebtech convert f to a chebtech and call chebtech/innerProduct
-if ( isa(g, 'chebtech') )
-    f = chebtech2.make(@(x) feval(f,x));
-    out = innerProduct(f,g);
-    return
-elseif ( ~isa(g, 'trigtech') )
+if ( ~isa(f, 'trigtech') || ~isa(g, 'trigtech') )
     error('CHEBFUN:TRIGTECH:innerProduct:input', ...
-        'innerProduct() only operates on CHEB/TRIGTECH objects.');
+        'innerProduct() only operates on two TRIGTECH objects.');
 end
 
 % Prolong to sum of current lengths (so that quadrature is exact):

--- a/tests/chebfun/test_innerProduct.m
+++ b/tests/chebfun/test_innerProduct.m
@@ -87,4 +87,23 @@ err = norm(I - 1.634574774192848, inf);
 tol = max(eps*get(E,'vscale'));
 pass(6) = err < tol;
 
+% Test inner products between chebfuns based on mixed techs.  (See #1784.)
+f = chebfun(@(x) sin(pi*x));
+g = chebfun(@(x) sin(pi*x), 'trig');
+err = abs(innerProduct(f, g) - 1);
+tol = 10*eps*get(f, 'vscale');
+pass(7) = err < tol;
+
+f = chebfun(@(x) [sin(pi*x) cos(pi*x)]);
+g = chebfun(@(x) [sin(pi*x) cos(pi*x)], 'trig');
+err = norm(innerProduct(f, g) - [1 0 ; 0 1], Inf);
+tol = 10*eps*get(f, 'vscale');
+pass(8) = err < tol;
+
+f = cheb2quasi(f);
+g = cheb2quasi(g);
+err = norm(innerProduct(f, g) - [1 0 ; 0 1], Inf);
+tol = 10*eps*get(f, 'vscale');
+pass(9) = err < tol;
+
 end


### PR DESCRIPTION
This is a re-do of #1787 that moves the tech type-casting in `innerProdcut()` to `chebfun`, where it belongs, instead of `chebtech` and `trigtech`.  We do all other casting for binary operations with mixed tech types in `chebfun`, so this should be done there as well.  Also adds some tests.