### PR TITLE
fixed typo in tests/linop/test_eigsRayleigh

### DIFF
--- a/tests/linop/test_eigsRayleigh.m
+++ b/tests/linop/test_eigsRayleigh.m
@@ -1,7 +1,10 @@
-function pass = test_eigs()
-% TAD, 10 Jan 2014
+function pass = test_eigsRayleigh(pref)
 
-tol = 1e-8;
+if ( nargin < 1 )
+    pref = cheboppref();
+end
+
+tol = 1e2*pref.bvpTol;
 
 dom = [-pi/2, pi/2];
 D2 = operatorBlock.diff(dom, 2);


### PR DESCRIPTION
There was some missing text in a test in #1788 that is fixed by this commit.