### PR TITLE
Fix trigpts symmetry

### DIFF
--- a/@trigtech/coeffs2vals.m
+++ b/@trigtech/coeffs2vals.m
@@ -38,7 +38,18 @@ else
 end
 coeffs = bsxfun(@times, coeffs, even_odd_fix);
 
+% test for symmetry
+isEven = max(abs(imag(coeffs)),[],1) == 0;
+isOdd = max(abs(real(coeffs)),[],1) == 0;
+
 % Shift the coefficients properly.
 values = ifft(ifftshift(n*coeffs, 1), [], 1);
+
+% correct if symmetric
+vals = [values;values(1,:)];
+evals = (vals+flipud(conj(vals)))/2;
+ovals = (vals-flipud(conj(vals)))/2;
+values(:,isEven) = evals(1:end-1,isEven);
+values(:,isOdd) = ovals(1:end-1,isOdd);
 
 end

--- a/@trigtech/coeffs2vals.m
+++ b/@trigtech/coeffs2vals.m
@@ -18,6 +18,13 @@ function values = coeffs2vals(coeffs)
 % Copyright 2015 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.
 
+% *Note about symmetry*.  Some of the code below is designed to
+% enforce two symmetries whose failure might disturb users:
+% COEFFS exactly real ==> VALUES exactly hermitian
+% COEFFS exactly imaginary ==> VALUES exactly skew-hermitian
+% This is necessary because the MATLAB FFT code does not
+% exactly preserve symmetries.
+
 % Get the length of the input:
 n = size(coeffs, 1);
 
@@ -39,17 +46,17 @@ end
 coeffs = bsxfun(@times, coeffs, even_odd_fix);
 
 % test for symmetry
-isEven = max(abs(imag(coeffs)),[],1) == 0;
-isOdd = max(abs(real(coeffs)),[],1) == 0;
+isHerm = max(abs(imag(coeffs)),[],1) == 0;
+isSkew = max(abs(real(coeffs)),[],1) == 0;
 
 % Shift the coefficients properly.
 values = ifft(ifftshift(n*coeffs, 1), [], 1);
 
 % correct if symmetric
 vals = [values;values(1,:)];
-evals = (vals+flipud(conj(vals)))/2;
-ovals = (vals-flipud(conj(vals)))/2;
-values(:,isEven) = evals(1:end-1,isEven);
-values(:,isOdd) = ovals(1:end-1,isOdd);
+hermvals = (vals+flipud(conj(vals)))/2;
+skewvals = (vals-flipud(conj(vals)))/2;
+values(:,isHerm) = hermvals(1:end-1,isHerm);
+values(:,isSkew) = skewvals(1:end-1,isSkew);
 
 end

--- a/@trigtech/refine.m
+++ b/@trigtech/refine.m
@@ -63,7 +63,7 @@ function [values, giveUp] = refineResampling(op, values, pref)
     
     % Force the value at -1 to be equal to the value at 1, thus
     % enforcing symmetry.
-    valRightBoundary = feval(op,x(1)+2);
+    valRightBoundary = feval(op,1);
     
     values(1,:) = 0.5*(values(1,:) + valRightBoundary);
 end

--- a/@trigtech/vals2coeffs.m
+++ b/@trigtech/vals2coeffs.m
@@ -45,8 +45,8 @@ isOdd = max(abs(vals+flipud(conj(vals))),[],1) == 0;
 coeffs = (1/n)*fftshift(fft(values, [], 1), 1);
 
 % correct if symmetric
-coeffs = real(coeffs) + 1i*bsxfun(@times,1-isEven,imag(coeffs));
-coeffs = bsxfun(@times,1-isOdd,real(coeffs)) + 1i*imag(coeffs);
+coeffs(:,isEven) = real(coeffs(:,isEven));
+coeffs(:,isOdd) = 1i*imag(coeffs(:,isOdd));
 
 % These coefficients are for interpolation defined on [0,2*pi), but we want
 % to work on [-pi,pi). To fix the coefficients for this we just need to

--- a/@trigtech/vals2coeffs.m
+++ b/@trigtech/vals2coeffs.m
@@ -21,6 +21,13 @@ function coeffs = vals2coeffs(values)
 % Copyright 2015 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.
 
+% *Note about symmetry*.  Some of the code below is designed to
+% enforce two symmetries whose failure might disturb users:
+% VALUES exactly hermitian ==> COEFFS exactly real
+% VALUES exactly skew-hermitian ==> % COEFFS exactly imaginary
+% This is necessary because the MATLAB FFT code does not
+% exactly preserve symmetries.
+
 % Get the length of the input:
 n = size(values, 1);
 
@@ -38,15 +45,15 @@ end
 
 % test for symmetry
 vals = double([values;values(1,:)]);
-isEven = max(abs(vals-flipud(conj(vals))),[],1) == 0;
-isOdd = max(abs(vals+flipud(conj(vals))),[],1) == 0;
+isHerm = max(abs(vals-flipud(conj(vals))),[],1) == 0;
+isSkew = max(abs(vals+flipud(conj(vals))),[],1) == 0;
 
 % compute coefficients
 coeffs = (1/n)*fftshift(fft(values, [], 1), 1);
 
 % correct if symmetric
-coeffs(:,isEven) = real(coeffs(:,isEven));
-coeffs(:,isOdd) = 1i*imag(coeffs(:,isOdd));
+coeffs(:,isHerm) = real(coeffs(:,isHerm));
+coeffs(:,isSkew) = 1i*imag(coeffs(:,isSkew));
 
 % These coefficients are for interpolation defined on [0,2*pi), but we want
 % to work on [-pi,pi). To fix the coefficients for this we just need to

--- a/@trigtech/vals2coeffs.m
+++ b/@trigtech/vals2coeffs.m
@@ -30,7 +30,23 @@ if ( n <= 1 )
     return
 end
 
+% zero case
+if ( norm(double(values)) == 0 )
+    coeffs = values; 
+    return
+end
+
+% test for symmetry
+vals = double([values;values(1,:)]);
+isEven = max(abs(vals-flipud(conj(vals))),[],1) == 0;
+isOdd = max(abs(vals+flipud(conj(vals))),[],1) == 0;
+
+% compute coefficients
 coeffs = (1/n)*fftshift(fft(values, [], 1), 1);
+
+% correct if symmetric
+coeffs = real(coeffs) + 1i*bsxfun(@times,1-isEven,imag(coeffs));
+coeffs = bsxfun(@times,1-isOdd,real(coeffs)) + 1i*imag(coeffs);
 
 % These coefficients are for interpolation defined on [0,2*pi), but we want
 % to work on [-pi,pi). To fix the coefficients for this we just need to

--- a/tests/trigtech/test_coeffs2vals.m
+++ b/tests/trigtech/test_coeffs2vals.m
@@ -72,5 +72,15 @@ pass(12) = norm(v - (1+1i)*vTrue, inf) < tol;
 v = trigtech.coeffs2vals([c, -c]);
 pass(13) = norm(v(:,1) - vTrue, inf) < tol && ...
           norm(v(:,2) + vTrue, inf) < tol;
-      
+
+%%
+% Tougher even/odd case
+c = ones(100,1);
+v = trigtech.coeffs2vals(c);
+v = [v;v(1)];
+pass(14) = norm(v-flipud(conj(v))) == 0;      
+v = trigtech.coeffs2vals(1i*c);
+v = [v;v(1)];
+pass(15) = norm(v+flipud(conj(v))) == 0;      
+
 end

--- a/tests/trigtech/test_roots.m
+++ b/tests/trigtech/test_roots.m
@@ -47,7 +47,7 @@ r = roots(f, 'complex', 1);
 r = r(:);
 [temp, id] = sort(real(r));
 r = r(id);
-r2 = [-1 -0.75 -0.25 0 0.25 0.75 NaN NaN].';
+r2 = [-0.75 -0.25 0 0.25 0.75 1 NaN NaN].';
 pass(7) = all( abs(r(:) - sort(r2)) < 1e1*length(f)*eps | isnan(r2) );
 
 end

--- a/tests/trigtech/test_vals2coeffs.m
+++ b/tests/trigtech/test_vals2coeffs.m
@@ -71,4 +71,15 @@ c = trigtech.vals2coeffs([vals, -vals]);
 pass(9) = norm(c(:,1) - cTrue, inf) < tol && ...
           norm(c(:,2) + cTrue, inf) < tol;
       
+%%
+% Test for symmetry
+x = trigpts(123);
+vals = [cos(pi*x),sin(pi*x),cos(pi*x)+sin(pi*x)];
+vals(1,2) = 0;
+c = trigtech.vals2coeffs(vals);
+pass(10) = norm(c(:,1) - flipud(c(:,1)), inf) == 0 && ...
+           norm(c(:,2) + flipud(c(:,2)), inf) == 0 && ...
+           norm(c(:,3) - flipud(c(:,3)), inf) > 0 && ...
+           norm(c(:,3) + flipud(c(:,3)), inf) > 0;
+
 end

--- a/trigpts.m
+++ b/trigpts.m
@@ -23,6 +23,7 @@ end
 
 x = linspace(-pi, pi, n+1).';
 x = x./pi;
+x = (x-x(end:-1:1))/2; % enforce symmetry
 x(end) = [];
 
 if ( nargout > 1 )


### PR DESCRIPTION
This pull request enforces symmetry in `tripts`, `trigtech/vals2coeffs` and `trigtech/coeffs2vals`. See #1814.