### PR TITLE
added symmetry reinforcement to chebtech1 and chebtech2

### DIFF
--- a/@chebtech1/coeffs2vals.m
+++ b/@chebtech1/coeffs2vals.m
@@ -21,6 +21,13 @@ function values = coeffs2vals(coeffs)
 % Polynomials". Chapman & Hall/CRC (2003).
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+% *Note about symmetries* The code below takes steps to 
+% ensure that the following symmetries are enforced:
+% even Chebyshev COEFFS exactly zero ==> VALUES are exactly odd
+% odd Chebychev COEFFS exactly zero ==> VALUES are exactly even
+% These corrections are required because the MATLAB FFT does not
+% guarantee that these symmetries are enforced.
+
 % Get the length of the input:
 [n, m] = size(coeffs);
 

--- a/@chebtech1/coeffs2vals.m
+++ b/@chebtech1/coeffs2vals.m
@@ -30,6 +30,10 @@ if ( n <= 1 )
     return
 end
 
+% check for symmetry
+isEven = max(abs(coeffs(2:2:end,:)),[],1) == 0;
+isOdd = max(abs(coeffs(1:2:end,:)),[],1) == 0;
+
 % Computing the weight vector often accounts for at least half the cost of this
 % transformation. Given that (a) the weight vector depends only on the length of
 % the coefficients and not the coefficients themselves and (b) that we often
@@ -60,5 +64,9 @@ elseif ( isreal(1i*coeffs) )
     % Imaginary-valued case:
     values = 1i*imag(values);
 end
+
+% enforce symmetry
+values(:,isEven) = (values(:,isEven)+flipud(values(:,isEven)))/2;
+values(:,isOdd) = (values(:,isOdd)-flipud(values(:,isOdd)))/2;
 
 end

--- a/@chebtech1/vals2coeffs.m
+++ b/@chebtech1/vals2coeffs.m
@@ -31,6 +31,10 @@ if ( n <= 1 )
     return
 end
 
+% check for symmetry
+isEven = max(abs(values-flipud(values)),[],1) == 0;
+isOdd = max(abs(values+flipud(values)),[],1) == 0;
+
 % Computing the weight vector often accounts for at least half the cost of this
 % transformation. Given that (a) the weight vector depends only on the length of
 % the coefficients and not the coefficients themselves and (b) that we often
@@ -59,5 +63,9 @@ elseif ( isreal(1i*values) )
     % Imaginary-valued case:
     coeffs = 1i*imag(coeffs);
 end
+
+% adjust coefficients for symmetry
+coeffs(2:2:end,isEven) = 0;
+coeffs(1:2:end,isOdd) = 0;
 
 end

--- a/@chebtech1/vals2coeffs.m
+++ b/@chebtech1/vals2coeffs.m
@@ -22,6 +22,13 @@ function coeffs = vals2coeffs(values)
 % Polynomials". Chapman & Hall/CRC (2003).
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+% *Note about symmetries* The code below takes steps to 
+% ensure that the following symmetries are enforced:
+% VALUES exactly even ==> odd Chebyshev COEFFS are exactly zero
+% VALUES exactly odd ==> even Chebyshev COEFFS are exactly zero
+% These corrections are required because the MATLAB FFT does not
+% guarantee that these symmetries are enforced.
+
 % Get the length of the input:
 n = size(values, 1);
 

--- a/@chebtech2/coeffs2vals.m
+++ b/@chebtech2/coeffs2vals.m
@@ -30,6 +30,10 @@ if ( n <= 1 )
     return
 end
 
+% check for symmetry
+isEven = max(abs(coeffs(2:2:end,:)),[],1) == 0;
+isOdd = max(abs(coeffs(1:2:end,:)),[],1) == 0;
+
 % Scale them by 1/2:
 coeffs(2:n-1,:) = coeffs(2:n-1,:)/2;
 
@@ -49,5 +53,9 @@ end
 
 % Flip and truncate:
 values = values(n:-1:1,:);
+
+% enforce symmetry
+values(:,isEven) = (values(:,isEven)+flipud(values(:,isEven)))/2;
+values(:,isOdd) = (values(:,isOdd)-flipud(values(:,isOdd)))/2;
 
 end

--- a/@chebtech2/coeffs2vals.m
+++ b/@chebtech2/coeffs2vals.m
@@ -21,6 +21,13 @@ function values = coeffs2vals(coeffs)
 % Polynomials". Chapman & Hall/CRC (2003).
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+% *Note about symmetries* The code below takes steps to 
+% ensure that the following symmetries are enforced:
+% even Chebyshev COEFFS exactly zero ==> VALUES are exactly odd
+% odd Chebychev COEFFS exactly zero ==> VALUES are exactly even
+% These corrections are required because the MATLAB FFT does not
+% guarantee that these symmetries are enforced.
+
 % Get the length of the input:
 n = size(coeffs, 1);
 

--- a/@chebtech2/vals2coeffs.m
+++ b/@chebtech2/vals2coeffs.m
@@ -31,6 +31,10 @@ if ( n <= 1 )
     return
 end
 
+% check for symmetry
+isEven = max(abs(values-flipud(values)),[],1) == 0;
+isOdd = max(abs(values+flipud(values)),[],1) == 0;
+
 % Mirror the values (to fake a DCT using an FFT):
 tmp = [values(n:-1:2,:) ; values(1:n-1,:)];
 
@@ -52,5 +56,9 @@ coeffs = coeffs(1:n,:);
 
 % Scale the interior coefficients:
 coeffs(2:n-1,:) = 2*coeffs(2:n-1,:);
+
+% adjust coefficients for symmetry
+coeffs(2:2:end,isEven) = 0;
+coeffs(1:2:end,isOdd) = 0;
 
 end

--- a/@chebtech2/vals2coeffs.m
+++ b/@chebtech2/vals2coeffs.m
@@ -22,6 +22,13 @@ function coeffs = vals2coeffs(values)
 % Polynomials". Chapman & Hall/CRC (2003).
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+% *Note about symmetries* The code below takes steps to 
+% ensure that the following symmetries are enforced:
+% VALUES exactly even ==> odd Chebyshev COEFFS are exactly zero
+% VALUES exactly odd ==> even Chebyshev COEFFS are exactly zero
+% These corrections are required because the MATLAB FFT does not
+% guarantee that these symmetries are enforced.
+
 % Get the length of the input:
 n = size(values, 1);
 

--- a/tests/chebtech1/test_coeffs2vals.m
+++ b/tests/chebtech1/test_coeffs2vals.m
@@ -69,4 +69,11 @@ v = chebtech1.coeffs2vals([c, -c]);
 pass(13) = norm(v(:,1) - vTrue, inf) < tol && ...
           norm(v(:,2) + vTrue, inf) < tol;
       
+%%
+% Test for symmetry preservation
+c = kron(ones(10,1),eye(2));
+v = chebtech1.coeffs2vals(c);
+pass(14) = norm(v(:,1) - flipud(v(:,1)), inf) == 0 && ...
+          norm(v(:,2) + flipud(v(:,2)), inf) == 0;
+      
 end

--- a/tests/chebtech1/test_vals2coeffs.m
+++ b/tests/chebtech1/test_vals2coeffs.m
@@ -70,4 +70,11 @@ tmp = ones(size(cTrue)); tmp(end-1:-2:1) = -1;
 pass(13) = norm(c(:,1) - cTrue, inf) < tol && ...
           norm(c(:,2) - tmp.*cTrue, inf) < tol;
       
+%%
+% Test for symmetry preservation
+v = kron([1,-1;1,1],ones(10,1));
+c = chebtech1.vals2coeffs(v);
+pass(14) = norm(c(2:2:end,1), inf) == 0 && ...
+          norm(c(1:2:end,2), inf) == 0;
+      
 end

--- a/tests/chebtech2/test_coeffs2vals.m
+++ b/tests/chebtech2/test_coeffs2vals.m
@@ -41,4 +41,11 @@ tmp(end-1:-2:1) = -1;
 pass(7) = norm(v(:,1) - vTrue, inf) < tol && ...
           norm(v(:,2) - tmp.*vTrue, inf) < tol;
       
+%%
+% Test for symmetry preservation
+c = kron(ones(10,1),eye(2));
+v = chebtech1.coeffs2vals(c);
+pass(8) = norm(v(:,1) - flipud(v(:,1)), inf) == 0 && ...
+          norm(v(:,2) + flipud(v(:,2)), inf) == 0;
+      
 end

--- a/tests/chebtech2/test_vals2coeffs.m
+++ b/tests/chebtech2/test_vals2coeffs.m
@@ -41,4 +41,11 @@ tmp(end-1:-2:1) = -1;
 pass(7) = norm(c(:,1) - cTrue, inf) < tol && ...
           norm(c(:,2) - tmp.*cTrue, inf) < tol;
       
+%%
+% Test for symmetry preservation
+v = kron([1,-1;1,1],ones(10,1));
+c = chebtech2.vals2coeffs(v);
+pass(8) = norm(c(2:2:end,1), inf) == 0 && ...
+          norm(c(1:2:end,2), inf) == 0;
+      
 end


### PR DESCRIPTION
This pull request enforces symmetry that is lost using Matlab's `fft` in `chebtech1` and `chebtech2`. See #1814.