### PR TITLE
Fix chebfun2 roots

### DIFF
--- a/@separableApprox/roots.m
+++ b/@separableApprox/roots.m
@@ -42,11 +42,19 @@ if ( nargin == 1 )
         
         cols = f.cols;
         rows = f.rows;
-        yrts = roots( cols ) + realmin*1i;  % Add complex to ensure its not real
-        xrts = roots( rows ) + realmin*1i;
-        ry = chebfun( yrts.' );
-        rx = chebfun( xrts.' );
-        r = [ry rx];
+        yrts = 1i*(roots( cols )+realmin);  
+        xrts = roots( rows ) + realmin*1i; % Add complex to ensure its not real
+        r = chebfun; 
+        % Go though col(yrts) = 0, make into a horizontal line: 
+        for j = 1 : numel(yrts)
+            f = chebfun(@(x) x + yrts(j));
+            r = [r f];
+        end
+        % Go though row(xrts) = 0, make into a vertical line: 
+        for j = 1 : numel(xrts)
+            f = chebfun(@(x) 1i*x + xrts(j));
+            r = [r f];
+        end
         
     elseif ( isreal( f ) )
         % Function is real-valued.

--- a/tests/chebfun2/test_roots.m
+++ b/tests/chebfun2/test_roots.m
@@ -1,0 +1,35 @@
+function pass = test_roots( )
+% Test the chebfun2/roots command.
+
+tol = 1e-14;
+
+% Here, we check that the roots command is working for separable functions. 
+
+f = chebfun2( @(x,y) 1/2-y);
+r = roots( f );
+exact = chebfun( @(x) x + 1i/2 );
+pass(1) = ( norm( r - exact ) < tol );
+
+f = chebfun2( @(x,y) 1/2-x);
+r = roots( f );
+exact = chebfun( @(x) 1i*x + 1/2 );
+pass(2) = ( norm( r - exact ) < tol );
+
+
+f = chebfun2( @(x,y) x.*y);
+r = roots( f );
+exact = chebfun( @(x) [x, 1i*x]  );
+pass(3) = ( norm( r - exact ) < tol );
+
+
+f = chebfun2( @(x,y) cos(5*pi*x));
+s = roots( squeeze( f ) );
+r = roots( f );
+exact = chebfun;
+for j = 1:numel(s)
+    exact = [ exact chebfun(@(x) s(j) + 1i*x )];
+end
+pass(4) = ( norm( r - exact ) < tol );
+
+
+end


### PR DESCRIPTION
The following was failing: 
```
f = chebfun2( @(x,y) 1/2-y);
r = roots( f );
```
because of an internal bug when `f` is of rank 1.  Fixed now. 
