### PR TITLE
The cols and rows need to be trigtechs for a spherefun object.

### DIFF
--- a/@spherefun/constructor.m
+++ b/@spherefun/constructor.m
@@ -1007,7 +1007,7 @@ elseif ( fixedRank > 0 )
         for jj = length(g.pivotValues) : fixedRank - 1
             g.cols = [g.cols zcols];
             g.rows = [g.rows zrows];
-            g.pivotValues = [g.pivotValues 0];
+            g.pivotValues = [g.pivotValues ; 0];
         end
     end
 elseif ( fixedRank == 0 )

--- a/@spherefun/constructor.m
+++ b/@spherefun/constructor.m
@@ -1002,8 +1002,8 @@ elseif ( fixedRank > 0 )
         g.idxMinus = g.idxMinus( g.idxMinus <= fixedRank );
     elseif ( length(g.pivotValues) < fixedRank )
         % Pad things with zero columns:
-        zcols = chebfun(0, g.cols.domain);
-        zrows = chebfun(0, g.rows.domain);
+        zcols = chebfun(0, g.cols.domain, 'trig');
+        zrows = chebfun(0, g.rows.domain, 'trig');
         for jj = length(g.pivotValues) : fixedRank - 1
             g.cols = [g.cols zcols];
             g.rows = [g.rows zrows];
@@ -1011,8 +1011,8 @@ elseif ( fixedRank > 0 )
         end
     end
 elseif ( fixedRank == 0 )
-    g.cols = chebfun(0, g.cols.domain);
-    g.rows = chebfun(0, g.rows.domain); 
+    g.cols = chebfun(0, g.cols.domain, 'trig');
+    g.rows = chebfun(0, g.rows.domain, 'trig'); 
     g.pivotValues = Inf;
     g.idxPlus = [];
     g.idxMinus = 1;

--- a/tests/spherefun/test_constructor.m
+++ b/tests/spherefun/test_constructor.m
@@ -98,41 +98,46 @@ f = spherefun(ff);
 g = spherefun(f,7);
 pass(19) = ( rank(g) == 7 );
 
+% Test zero rank construction gives zero.
+g = spherefun(f,0);
+pass(20) = ( rank(g) == 0 );
+pass(21) = norm(g) < tol;
+
 try
     f = spherefun(ff,-1);
-    pass(20) = false;
+    pass(22) = false;
 catch ME
-    pass(20) = strcmp(ME.identifier,'CHEBFUN:SPHEREFUN:constructor:parseInputs:domain3');
+    pass(22) = strcmp(ME.identifier,'CHEBFUN:SPHEREFUN:constructor:parseInputs:domain3');
 end
 
 % Check the 'eps' flag works.
 ff = @(x,y,z) exp(-10*((x-1/sqrt(2)).^2 + (z-1/sqrt(2)).^2 + y.^2));
 f = spherefun(ff);
 g = spherefun(ff,'eps',1e-8);
-pass(21) = rank(g) < rank(f);
+pass(23) = rank(g) < rank(f);
 [mf,nf] = length(f);
 [mg,ng] = length(g);
-pass(22) = ( (mg < mf) && (ng < nf) );
+pass(24) = ( (mg < mf) && (ng < nf) );
 
 % Construction from a single value
 f = spherefun(1);
-pass(23) = norm(f-1,inf) == 0;
+pass(25) = norm(f-1,inf) == 0;
 
 % Construction from a string with (x,y,z) variables
 f = spherefun(@(x,y,z) exp(-10*((x-1/sqrt(2)).^2 + (z-1/sqrt(2)).^2 + y.^2)));
 g = spherefun('exp(-10*((x-1/sqrt(2)).^2 + (z-1/sqrt(2)).^2 + y.^2))');
-pass(24) = norm(f-g,inf) == 0;
+pass(26) = norm(f-g,inf) == 0;
 
 % Construction from a string with (l,t) variables
 f = spherefun(@(l,t) cos(l).*sin(t) );
 g = spherefun('cos(l).*sin(t)');
-pass(25) = norm(f-g,inf) == 0;
+pass(27) = norm(f-g,inf) == 0;
 
 try
     f = spherefun('x.*y.*z.*w');
-    pass(26) = false;
+    pass(28) = false;
 catch ME
-    pass(26) = strcmp(ME.identifier,'CHEBFUN:SPHEREFUN:constructor:str2op:depvars');
+    pass(28) = strcmp(ME.identifier,'CHEBFUN:SPHEREFUN:constructor:str2op:depvars');
 end
 
 end


### PR DESCRIPTION
Fix this (coming from `g.cols` not being `trigtech` objects): 
```
f = spherefun(@(x,y,z) cos(x));
g = spherefun(f,0)
g =
No appropriate method, property, or field 'isReal' for class
'chebtech2'.
Error in chebfun/subsref (line 150)
            out = subsref(out, index);
Error in spherefun/sample (line 59)
if ( all(cols.funs{:}.onefun.isReal) &&
all(rows.funs{:}.onefun.isReal) )
Error in separableApprox/vscale (line 27)
vals = sample(f, m, n);
Error in spherefun/vscale (line 10)
[varargout{1:nargout}] = vscale@separableApprox(varargin{:});
Error in spherefun/disp (line 23)
vscl = vscale(F);                         % vertical scale
Error in spherefun/display (line 18)
	disp(X); 
>> edit spherefun/constructor.m
```