### PR TITLE
Fix spherefun roots

### DIFF
--- a/@spherefun/roots.m
+++ b/@spherefun/roots.m
@@ -29,7 +29,7 @@ rts = roots@separableApprox(varargin{:});
 x = chebpts(max(length(rts),17) + 1);
 
 vals = feval(rts, x);
-r = cellmat(size(vals,2), 1);
+r = cell(size(vals,2), 1);
 
 % Go through each component and make it an array-valued chebfun: 
 for k = 1:size(vals, 2)


### PR DESCRIPTION
```
>> test_roots
Undefined function or variable 'cellmat'.
Error in spherefun/roots (line 32)
r = cellmat(size(vals,2), 1);
Error in test_roots (line 14)
r = roots(f); 
```

Presumably `cellmat()` is from some toolbox that I don't have?

Anyway, it only needed a cell.