### PR TITLE
Speed up separableApprox/feval

### DIFF
--- a/@separableApprox/feval.m
+++ b/@separableApprox/feval.m
@@ -31,7 +31,7 @@ elseif ( strcmpi(x, ':') && isnumeric( y ) ) % f(:, y)
     % Make evaluation points a vector.
     y = y(:);
     % Evaluate (returns a column chebfun):
-    out = feval( cols, y ) * D * rows.'; 
+    out = feval( cols, y ) * D * rows.';
     % Simplify:
     out = simplify( out, [], 'globaltol' );
     
@@ -39,7 +39,7 @@ elseif ( isnumeric( x ) && strcmpi(y, ':') ) % f(x, :)
     % Make evaluation points a vector.
     x = x( : );
     % Evaluate (returns a row chebfun):
-    out = cols * D * feval( rows, x ).'; 
+    out = cols * D * feval( rows, x ).';
     % Simplify:
     out = simplify( out, [], 'globaltol' );
     
@@ -48,33 +48,41 @@ elseif ( isnumeric( x ) && isnumeric( y ) )  % f(x, y)
     takeTranspose = 0;
     
     % If the evaluation points are derived from meshgrid, then there is a
-    % fast way to evaluate a separableApprox. Check for this property. 
+    % fast way to evaluate a separableApprox. Check for this property.
     if ( min(size(x)) > 1 && all(size(x) == size(y)) && numel(size(x)) == 2 )
         % Check to see if the input is a meshgrid:
-        if ( max(max(abs(bsxfun(@minus, x, x(1,:))))) <= 10*eps  && ... 
+        if ( max(max(abs(bsxfun(@minus, x, x(1,:))))) <= 10*eps  && ...
                 max(max(abs(bsxfun(@minus, y, y(:,1))))) <= 10*eps )
-            % This allows someone to do: 
+            % This allows someone to do:
             % [xx,yy] = meshgrid(linspace(-1,1));
             % f(xx,yy)
             
             x = x(1,:);
             y = y(:,1);
             
-        elseif ( max(max(abs(bsxfun(@minus, y, y(1,:))))) <= 10*eps && ... 
+        elseif ( max(max(abs(bsxfun(@minus, y, y(1,:))))) <= 10*eps && ...
                 max(max(abs(bsxfun(@minus, x, x(:,1))))) <= 10*eps )
-            % This allows someone to do: 
+            % This allows someone to do:
             % [yy,xx] = meshgrid(linspace(-1,1));
             % f(xx,yy)
             
-            x = x(:,1); 
+            x = x(:,1);
             y = y(1,:);
             takeTranspose = 1;
         else
-            % Evaluate at matrices, but they're not from meshgrid: 
-            out = zeros( size( x ) ); 
-            for jj = 1:size(out,1)
-                for kk = 1: size(out,2)
-                    out(jj, kk) = feval( f, x(jj,kk), y(jj,kk) ); 
+            % Evaluate at matrices, but they're not from meshgrid:
+            [m,n] = size( x );
+            out = zeros( m, n );
+            % Unroll the loop that is the longest
+            if m > n
+                for ii = 1:n
+                    out(:,ii) = dot(feval(cols, ...
+                        y(:,ii))*D,feval(rows, x(:,ii)),2);
+                end
+            else
+                for jj = 1:m
+                    out(jj,:) = dot(feval(cols, ...
+                        y(jj,:).')*D,feval(rows, x(jj,:).'),2);
                 end
             end
             return
@@ -82,18 +90,18 @@ elseif ( isnumeric( x ) && isnumeric( y ) )  % f(x, y)
     else
     end
     
-% Evaluate:
-if ( isvector(x) && ~isscalar(x) && all(size(x) == size(y)) )
-    % Determine whether inputs are pure vectors.
-    out = feval(cols, y(:)) .* feval(rows, x(:)) * diag(D); 
-else
-    out = feval(cols, y(:)) * D * feval(rows, x(:)).';
-end
-
-    % Take transpose: 
-    if ( takeTranspose ) 
-        out = transpose( out ); 
-    end 
+    % Evaluate:
+    if ( isvector(x) && ~isscalar(x) && all(size(x) == size(y)) )
+        % Determine whether inputs are pure vectors.
+        out = feval(cols, y(:)) .* feval(rows, x(:)) * diag(D);
+    else
+        out = feval(cols, y(:)) * D * feval(rows, x(:)).';
+    end
+    
+    % Take transpose:
+    if ( takeTranspose )
+        out = transpose( out );
+    end
     
 elseif ( isa(x, 'chebfun') )
     if ( min( size( x ) ) > 1 )
@@ -103,7 +111,7 @@ elseif ( isa(x, 'chebfun') )
     
     if ( ~isreal(x) )      % Complex valued chebfun.
         % Extract chebfun along the path,  F(real(X(t)),imag(X(t)))
-        out = chebfun(@(t) feval(f, real(x(t))', imag(x(t))'), x.domain, 'vectorize' );  
+        out = chebfun(@(t) feval(f, real(x(t))', imag(x(t))'), x.domain, 'vectorize' );
     elseif ( isa(y, 'chebfun') )
         if ( isreal( y ) ) % Both x and y are real valued.
             % Check domains of x and y match
@@ -118,12 +126,12 @@ elseif ( isa(x, 'chebfun') )
                 'Cannot evaluate along complex-valued CHEBFUN.');
         end
     end
-elseif ( isa(x, 'chebfun2v') ) 
-    components = x.components; 
-    % [TODO]: Check domain and range are compatible? 
+elseif ( isa(x, 'chebfun2v') )
+    components = x.components;
+    % [TODO]: Check domain and range are compatible?
     domain = components{1}.domain;
     out = f.constructor(@(s,t) feval(f, feval(components{1},s,t),...
-                                        feval(components{2},s,t)), domain);
+        feval(components{2},s,t)), domain);
 else
     error('CHEBFUN:SEPARABLEAPPROX:feval:inputs', ...
         'Unrecognized arguments for evaluation.');


### PR DESCRIPTION
This pull request improves the speed of `separableApprox/feval` in the case that the input arguments are matrices.  Here's a demonstration of the speed up for `spherefun` objects:
```
>> g = spherefun(@(lam,th) cos(10*cos(lam-0.2).*sin(th)+2*cos(th).^2));
>> ll = rand(100,100);  tt = rand(100,100);
>> tic, h = g(ll,tt); toc  % On development
Elapsed time is 4.683748 seconds.
>> tic, h = g(ll,tt); toc  % On branch speedup-separableApprox-feval
Elapsed time is 0.148328 seconds.
```
