### PR TITLE
Add cheb.xy and cheb.xyzsphere shortcut commands

### DIFF
--- a/+cheb/x.m
+++ b/+cheb/x.m
@@ -1,10 +1,27 @@
-function out = x
+function varargout = x
 %X   A chebfun of the identity on [-1,1].
 %   CHEB.X is shorthand for the expression CHEBFUN(@(X) X).
 
-% Copyright 2015 by The University of Oxford and The Chebfun Developers.
+% Copyright 2016 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-out = chebfun(@(x) x);
+x = chebfun(@(x) x);
 
+if ( nargout > 0 ) 
+    
+    % For the syntax x = cheb.x:
+    varargout{1} = x; 
+    
+    if ( nargout > 1 ) 
+        error('CHEB:X:TooManyOutputs',... 
+            'Too many output arguments. CHEB.X only returns "x".')
+    end
+    
+else
+    
+   % Put 'x' into the workspace:
+   assignin('base', 'x', x)
+   display(x)
+   
+end
 end

--- a/+cheb/x.m
+++ b/+cheb/x.m
@@ -1,6 +1,8 @@
 function varargout = x
 %X   A chebfun of the identity on [-1,1].
-%   CHEB.X is shorthand for the expression CHEBFUN(@(X) X).
+%   X = CHEB.X returns a chebfun object for the function @(x)x on [-1,1].
+%
+%   CHEB.X is shorthand for the expression X = CHEBFUN(@(X) X).
 
 % Copyright 2016 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.

--- a/+cheb/xy.m
+++ b/+cheb/xy.m
@@ -4,8 +4,8 @@ function varargout = xy
 %   and @(x,y)y defined on [-1,1]^2.
 %   
 %   CHEB.XY is shorthand for the expressions 
-%   CHEBFUN2(@(X,Y) X), and 
-%   CHEBFUN2(@(X,Y) Y).
+%   X = CHEBFUN2(@(X,Y) X), and 
+%   Y = CHEBFUN2(@(X,Y) Y).
 
 % Copyright 2016 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.

--- a/+cheb/xy.m
+++ b/+cheb/xy.m
@@ -1,5 +1,8 @@
 function varargout = xy
-%XY   A chebfun2 of the @(x,y)x and @(x,y)y on [-1,1]^2.
+%XY   Chebfun2 objects for the @(x,y)x and @(x,y)y on [-1,1]^2.
+%   [X, Y] = CHEB.XY returns chebfun2 objects for the functions @(x,y)x 
+%   and @(x,y)y defined on [-1,1]^2.
+%   
 %   CHEB.XY is shorthand for the expressions 
 %   CHEBFUN2(@(X,Y) X), and 
 %   CHEBFUN2(@(X,Y) Y).
@@ -11,17 +14,18 @@ x = chebfun2(@(x,y) x);
 y = chebfun2(@(x,y) y);
 
 if ( nargout > 1 )
+    
     % For the syntax [x, y] = cheb.xy:
     varargout{1} = x;
     varargout{2} = y;
+    
 else
-    % For the syntax cheb.xy we still want to put these variables into the 
-    % workspace:
+    % Put 'x' and'y' into the workspace:
     assignin('base', 'x', x)
     assignin('base', 'y', y)
-    % and display
+    
+    % And display the variables:
     display(x)
     display(y)
 end
-
 end

--- a/+cheb/xy.m
+++ b/+cheb/xy.m
@@ -1,5 +1,5 @@
 function varargout = xy
-%XY   Chebfun2 objects for the @(x,y)x and @(x,y)y on [-1,1]^2.
+%XY   Chebfun2 objects for the functions x and y on [-1,1]^2.
 %   [X, Y] = CHEB.XY returns chebfun2 objects for the functions @(x,y)x 
 %   and @(x,y)y defined on [-1,1]^2.
 %   

--- a/+cheb/xy.m
+++ b/+cheb/xy.m
@@ -13,14 +13,19 @@ function varargout = xy
 x = chebfun2(@(x,y) x);
 y = chebfun2(@(x,y) y);
 
-if ( nargout > 1 )
+if ( nargout > 0 )
     
     % For the syntax [x, y] = cheb.xy:
     varargout{1} = x;
     varargout{2} = y;
     
+    if ( nargout > 2 ) 
+        error('CHEB:XY:TooManyOutputs',... 
+            'Too many output arguments. CHEB.XY only returns "x" and "y".')
+    end
+    
 else
-    % Put 'x' and'y' into the workspace:
+    % Put 'x' and 'y' into the workspace:
     assignin('base', 'x', x)
     assignin('base', 'y', y)
     

--- a/+cheb/xy.m
+++ b/+cheb/xy.m
@@ -1,0 +1,27 @@
+function varargout = xy
+%XY   A chebfun2 of the @(x,y)x and @(x,y)y on [-1,1]^2.
+%   CHEB.XY is shorthand for the expressions 
+%   CHEBFUN2(@(X,Y) X), and 
+%   CHEBFUN2(@(X,Y) Y).
+
+% Copyright 2016 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+x = chebfun2(@(x,y) x);
+y = chebfun2(@(x,y) y);
+
+if ( nargout > 1 )
+    % For the syntax [x, y] = cheb.xy:
+    varargout{1} = x;
+    varargout{2} = y;
+else
+    % For the syntax cheb.xy we still want to put these variables into the 
+    % workspace:
+    assignin('base', 'x', x)
+    assignin('base', 'y', y)
+    % and display
+    display(x)
+    display(y)
+end
+
+end

--- a/+cheb/xyzsphere.m
+++ b/+cheb/xyzsphere.m
@@ -16,12 +16,17 @@ x = spherefun(@(x,y,z) x);
 y = spherefun(@(x,y,z) y);
 z = spherefun(@(x,y,z) z);
 
-if ( nargout > 1 )
+if ( nargout > 0 )
     
     % For the syntax [x, y, z] = cheb.xyzsphere:
     varargout{1} = x;
     varargout{2} = y;
     varargout{3} = z;
+    
+    if ( nargout > 3 ) 
+        error('CHEB:XYZSPHERE:TooManyOutputs',... 
+            'Too many output arguments. CHEB.XYZSPHERE only returns "x", "y", and "z".')
+    end
     
 else
     % Put 'x', 'y', and 'z' into the workspace:

--- a/+cheb/xyzsphere.m
+++ b/+cheb/xyzsphere.m
@@ -1,0 +1,37 @@
+function varargout = xyzsphere
+%XYYSPHERE  Spherefun objects for x, y, and z on the surface of the sphere.
+%   [X, Y, Z] = CHEB.XYZSPHERE returns spherefun objects for the functions 
+%   @(x,y,z) x, @(x,y,z) y, and @(x,y,z) z defined on the surface of the
+%   sphere. 
+%
+%   CHEB.XYZSPHERE is shorthand for the expressions 
+%   SPHEREFUN(@(X,Y,Z) X), 
+%   SPHEREFUN(@(X,Y,Z) Y), and 
+%   SPHEREFUN(@(X,Y,Z) Z). 
+
+% Copyright 2016 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+x = spherefun(@(x,y,z) x);
+y = spherefun(@(x,y,z) y);
+z = spherefun(@(x,y,z) z);
+
+if ( nargout > 1 )
+    
+    % For the syntax [x, y, z] = cheb.xyzsphere:
+    varargout{1} = x;
+    varargout{2} = y;
+    varargout{3} = z;
+    
+else
+    % Put 'x', 'y', and 'z' into the workspace:
+    assignin('base', 'x', x)
+    assignin('base', 'y', y)
+    assignin('base', 'z', z)
+    
+    % And display the variables:
+    display(x)
+    display(y)
+    display(z)
+end
+end

--- a/+cheb/xyzsphere.m
+++ b/+cheb/xyzsphere.m
@@ -5,9 +5,9 @@ function varargout = xyzsphere
 %   sphere. 
 %
 %   CHEB.XYZSPHERE is shorthand for the expressions 
-%   SPHEREFUN(@(X,Y,Z) X), 
-%   SPHEREFUN(@(X,Y,Z) Y), and 
-%   SPHEREFUN(@(X,Y,Z) Z). 
+%   X = SPHEREFUN(@(X,Y,Z) X), 
+%   Y = SPHEREFUN(@(X,Y,Z) Y), and 
+%   Z = SPHEREFUN(@(X,Y,Z) Z). 
 
 % Copyright 2016 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.


### PR DESCRIPTION
This pull request implements the commands `cheb.xy` and `cheb.xyzsphere`. 
```
cheb.xy 
x =
   chebfun2 object
       domain                 rank       corner values
[  -1,   1] x [  -1,   1]        1     [  -1    1   -1    1]
vertical scale =   1 
y =
   chebfun2 object
       domain                 rank       corner values
[  -1,   1] x [  -1,   1]        1     [  -1   -1    1    1]
vertical scale =   1 
```

Note that `cheb.x` has changed from
```
cheb.x
ans =
   chebfun column (1 smooth piece)
       interval       length     endpoint values  
[      -1,       1]        2        -1        1 
vertical scale =   1 
```
to (see variable name `x`)
```
cheb.x
x =
   chebfun column (1 smooth piece)
       interval       length     endpoint values  
[      -1,       1]        2        -1        1 
vertical scale =   1 
```
Closes #1821 and also #1816.  ( This is also the last `spherefun` issue on the tracker. )

Remark:  #1816 closes because @bhashemi has implemented `cheb.xyz` in the Chebfun3 PR.