### PR TITLE
Fix chebfun2 and spherefun sample method

### DIFF
--- a/@chebfun2/sample.m
+++ b/@chebfun2/sample.m
@@ -30,8 +30,8 @@ end
 
 % Use CDR decomposition so we can keep it in low rank form: 
 [C, D, R] = cdr( f ); 
-Cvals = sample(C, m);
-Rvals = sample(R, n);
+Cvals = sample(C, n);
+Rvals = sample(R, m);
 
 % Evaluate: 
 if ( nargout <= 1 )

--- a/@chebfun2/sample.m
+++ b/@chebfun2/sample.m
@@ -30,8 +30,8 @@ end
 
 % Use CDR decomposition so we can keep it in low rank form: 
 [C, D, R] = cdr( f ); 
-Cvals = sample(chebfun(C), m);
-Rvals = sample(chebfun(R), n);
+Cvals = sample(C, m);
+Rvals = sample(R, n);
 
 % Evaluate: 
 if ( nargout <= 1 )

--- a/@spherefun/sample.m
+++ b/@spherefun/sample.m
@@ -41,25 +41,10 @@ end
 % Get the low rank representation for f. 
 [cols, d, rows] = cdr(f);
 
-% I really wish techs had a "sample" function too that would return m values
-% of the tech at it's natural grid.  This has been on the chebfun tracker
-% for sometime now.
-
-% Ugly!
-if ( n > 1 )
-    C = trigtech.coeffs2vals(trigtech.alias(cols.funs{:}.onefun.coeffs, ...
-        max(2*n-2, 1)));
-else
-    C = cols.funs{:}.onefun.values;
-end
+% Use CDR decomposition so we can keep it in low rank form: 
+C = real( sample(cols, max(2*n-2,1)) );
 C = C([n:2*n-2 1], :);  % Remove doubled up points.
-R = trigtech.coeffs2vals(trigtech.alias(rows.funs{:}.onefun.coeffs, m)); 
-
-% More ugliness
-if ( all(cols.funs{:}.onefun.isReal) && all(rows.funs{:}.onefun.isReal) )
-    C = real(C);
-    R = real(R);
-end
+R = real( sample(rows, m) );
 
 % Evaluate: 
 if ( nargout <= 1 )


### PR DESCRIPTION
This PR includes the following:

First, `chebfun2/sample` now calls the `sample` function of the techs that makes up the the rows and columns instead of always sampling on a tensor product Chebyshev grid.  This dramatically improves the speed of some operations.  Here's an example where two Chebfun2 objects are constructed with the `trig` flag:
```
>> f = chebfun2(@(x,y) tanh(10*(1+cos(5*pi*(x-0.2)).*sin(7*pi*y))),'trig');
>> g = chebfun2(@(x,y) cos(20*pi*cos(pi*x).*sin(pi*y)),'trig');
```
Adding these together and displaying the result on the development branch takes the following amount of time:
```
>> tic, h = f+g, toc 
h =
   chebfun2 object
       domain                 rank       corner values
[  -1,   1] x [  -1,   1]       62     [   2    2    2    2]
vertical scale =   2 
Elapsed time is 4.836512 seconds.
```
Here are the timings on this branch:
```
>> tic, h = f+g, toc
h =
   chebfun2 object
       domain                 rank       corner values
[  -1,   1] x [  -1,   1]       62     [   2    2    2    2]
vertical scale =   2 
Elapsed time is 0.652679 seconds.
```

Second, the `spherefun/sample` method now calls the `sample` method of `trigtech` instead of breaking encapsulation.

Closes #1808.