### PR TITLE
Feature chebfun3v/integral2

### DIFF
--- a/@chebfun3v/integral2.m
+++ b/@chebfun3v/integral2.m
@@ -18,25 +18,25 @@ function v = integral2(F, S)
 
 % Check that F is a chebfun3v object with 3 components:
 if ( F.nComponents ~= 3 )
-    error('CHEBFUN:CHEBFUN3V:fluxintegral', ...
+    error('CHEBFUN:CHEBFUN3V:integral2:dimChebfun3v', ...
         'The chebfun3v object must have 3 components.')
 end
 
-% Check that the second input is a chebfun2v object with 2 components:
+% Check that S is a chebfun2v object with 3 components:
 if ( isa(S, 'chebfun2v') )
     if ( S.nComponents ~= 3 )
-        error('CHEBFUN:CHEBFUN3V:fluxintegral', ...
+        error('CHEBFUN:CHEBFUN3V:integral2:dimChebfun2v', ...
             'The parametrisation must have 3 components.')
     end
 else
-    error('CHEBFUN:CHEBFUN3V:fluxintegral', ...
+    error('CHEBFUN:CHEBFUN3V:integral2:notaChebfun2v', ...
         'The parametrisation must be a chebfun2v object.')
 end
 
 % Get components of F:
-F1 = F(1);
-F2 = F(2);
-F3 = F(3);
+F1 = F.components{1};
+F2 = F.components{2};
+F3 = F.components{3};
 
 % Get components of the surface S:
 S1 = S(1);
@@ -45,7 +45,7 @@ S3 = S(3);
 
 % Build the composition F(S):
 FS1_handle = @(x,y) feval(F1, feval(S1, x, y), feval(S2, x, y), ...
-    feval(S3,x,y));
+    feval(S3, x, y));
 
 FS2_handle = @(x,y) feval(F2, feval(S1, x, y), feval(S2, x, y), ...
     feval(S3, x, y));

--- a/@chebfun3v/integral2.m
+++ b/@chebfun3v/integral2.m
@@ -1,0 +1,70 @@
+function v = integral2(F, S)
+%INTEGRAL2   Flux integral of a Chebfun3v object through a 2D-surface.
+%   INTEGRAL2(F, S) computes the flux integral of the Chebfun3v object F through
+%   the parametric surface S defined as a Chebfun2v object (with 3 components):
+%                           /
+%       INTEGRAL2(F, S) =  |   < F, dS >
+%                          /S
+%                  //
+%               = ||   < F(S(x,y)), cross(S_x(x,y), S_y(x,y)) > dxdy.
+%                 //D
+% 
+% See also CHEBFUN3V/INTEGRAL, CHEBFUN3/INTEGRAL, CHEBFUN3/INTEGRAL2,
+% CHEBFUN3/INTEGRAL3, CHEBFUN3/SUM, CHEBFUN3/SUM2 and CHEBFUN3/SUM3.
+
+% Copyright 2016 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+% Developer Note: If F = F(x,y,z) is a CHEBFUN3v and S : DOM -> R^3 is a
+% chebfun2v object that parametrizes the surface, then
+% \iint_S dot(F, \vec{dS})
+%       = \iint_DOM dot(F(S_1(u,v), S_2(u,v), S_3(u,v))), cross(S_u, S_v)) dudv.
+% Note that the domain of f should contain the range of S.
+% TODO: Check for this in the code.
+
+
+% Check that F is a chebfun3v object with 3 components:
+if ( isa(F, 'chebfun3v') )
+    if ( F.nComponents ~= 3 )
+        error('CHEBFUN:CHEBFUN3V:fluxintegral', ...
+            'The chebfun3v object must have 3 components.')
+    end
+else
+    error('CHEBFUN:CHEBFUN3V:fluxintegral', ...
+        'First input must be a chebfun3v object.')
+end
+
+% Check that the second input is a chebfun2v object with 2 components:
+if ( isa(S, 'chebfun2v') )
+    if ( S.nComponents ~= 3 )
+        error('CHEBFUN:CHEBFUN3V:fluxintegral', ...
+            'The parametrisation must habe 3 components.')
+    end
+else
+    error('CHEBFUN:CHEBFUN3V:fluxintegral', ...
+        'The parametrisation must be a chebfun2v object.')
+end
+
+
+% Get components of Phi:
+S1 = S(1);
+S2 = S(2);
+S3 = S(3);
+
+% Build the composition F(S):
+FS1_handle = @(x,y) feval(F.components{1}, feval(S1,x,y), feval(S2,x,y), ...
+    feval(S3,x,y));
+FS2_handle = @(x,y) feval(F.components{2}, feval(S1,x,y), feval(S2,x,y), ...
+    feval(S3,x,y));
+FS3_handle = @(x,y) feval(F.components{3}, feval(S1,x,y), feval(S2,x,y), ...
+    feval(S3,x,y));
+
+FS = chebfun2v(FS1_handle, FS2_handle, FS3_handle, S1.domain);
+
+% Normal vector to the surface:
+dS = normal(S);
+
+% By definition:
+v = sum2(dot(FS, dS));
+
+end

--- a/@chebfun3v/integral2.m
+++ b/@chebfun3v/integral2.m
@@ -1,7 +1,8 @@
 function v = integral2(F, S)
 %INTEGRAL2   Flux integral of a Chebfun3v object through a 2D-surface.
-%   INTEGRAL2(F, S) computes the flux integral of the Chebfun3v object F through
-%   the parametric surface S defined as a Chebfun2v object (with 3 components):
+%   INTEGRAL2(F, S) computes the flux integral of the Chebfun3v object F 
+%   through the parametric surface S defined as a Chebfun2v object (with 3 
+%   components):
 %                           /
 %       INTEGRAL2(F, S) =  |   < F, dS >
 %                          /S
@@ -15,49 +16,42 @@ function v = integral2(F, S)
 % Copyright 2016 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-% Developer Note: If F = F(x,y,z) is a CHEBFUN3v and S : DOM -> R^3 is a
-% chebfun2v object that parametrizes the surface, then
-% \iint_S dot(F, \vec{dS})
-%       = \iint_DOM dot(F(S_1(u,v), S_2(u,v), S_3(u,v))), cross(S_u, S_v)) dudv.
-% Note that the domain of f should contain the range of S.
-% TODO: Check for this in the code.
-
-
 % Check that F is a chebfun3v object with 3 components:
-if ( isa(F, 'chebfun3v') )
-    if ( F.nComponents ~= 3 )
-        error('CHEBFUN:CHEBFUN3V:fluxintegral', ...
-            'The chebfun3v object must have 3 components.')
-    end
-else
+if ( F.nComponents ~= 3 )
     error('CHEBFUN:CHEBFUN3V:fluxintegral', ...
-        'First input must be a chebfun3v object.')
+        'The chebfun3v object must have 3 components.')
 end
 
 % Check that the second input is a chebfun2v object with 2 components:
 if ( isa(S, 'chebfun2v') )
     if ( S.nComponents ~= 3 )
         error('CHEBFUN:CHEBFUN3V:fluxintegral', ...
-            'The parametrisation must habe 3 components.')
+            'The parametrisation must have 3 components.')
     end
 else
     error('CHEBFUN:CHEBFUN3V:fluxintegral', ...
         'The parametrisation must be a chebfun2v object.')
 end
 
+% Get components of F:
+F1 = F(1);
+F2 = F(2);
+F3 = F(3);
 
-% Get components of Phi:
+% Get components of the surface S:
 S1 = S(1);
 S2 = S(2);
 S3 = S(3);
 
 % Build the composition F(S):
-FS1_handle = @(x,y) feval(F.components{1}, feval(S1,x,y), feval(S2,x,y), ...
+FS1_handle = @(x,y) feval(F1, feval(S1, x, y), feval(S2, x, y), ...
     feval(S3,x,y));
-FS2_handle = @(x,y) feval(F.components{2}, feval(S1,x,y), feval(S2,x,y), ...
-    feval(S3,x,y));
-FS3_handle = @(x,y) feval(F.components{3}, feval(S1,x,y), feval(S2,x,y), ...
-    feval(S3,x,y));
+
+FS2_handle = @(x,y) feval(F2, feval(S1, x, y), feval(S2, x, y), ...
+    feval(S3, x, y));
+
+FS3_handle = @(x,y) feval(F3, feval(S1, x, y), feval(S2, x, y), ...
+    feval(S3, x, y));
 
 FS = chebfun2v(FS1_handle, FS2_handle, FS3_handle, S1.domain);
 

--- a/tests/chebfun3v/test_integral2.m
+++ b/tests/chebfun3v/test_integral2.m
@@ -1,19 +1,21 @@
 function pass = test_integral2(pref)
-% Test FLUXINTEGRAL
+% Test chebfun3v/integral2
 
 if ( nargin == 0 )
     pref = chebfunpref; 
 end
 tol = 1e4*pref.cheb3Prefs.chebfun3eps;
 
-
 % Surface parametrisation (unit disk in xy-plane)
 S = chebfun2v(@(r,phi) r.*cos(phi), @(r,phi) r.*sin(phi), @(r,phi) 0*r, ... 
     [0, 1, 0, 2*pi]);
+
 % Constant vector field [0; 0; 1]
 F = chebfun3v(@(x,y,z) 0*x, @(x,y,z) 0*y, @(x,y,z) 0*x + 1);
+
 % Flux integral, exact value is pi:
 I = integral2(F, S);
+
 pass(1) = ( abs(I-pi) < tol );
 
 end

--- a/tests/chebfun3v/test_integral2.m
+++ b/tests/chebfun3v/test_integral2.m
@@ -1,0 +1,19 @@
+function pass = test_integral2(pref)
+% Test FLUXINTEGRAL
+
+if ( nargin == 0 )
+    pref = chebfunpref; 
+end
+tol = 1e4*pref.cheb3Prefs.chebfun3eps;
+
+
+% Surface parametrisation (unit disk in xy-plane)
+S = chebfun2v(@(r,phi) r.*cos(phi), @(r,phi) r.*sin(phi), @(r,phi) 0*r, ... 
+    [0, 1, 0, 2*pi]);
+% Constant vector field [0; 0; 1]
+F = chebfun3v(@(x,y,z) 0*x, @(x,y,z) 0*y, @(x,y,z) 0*x + 1);
+% Flux integral, exact value is pi:
+I = integral2(F, S);
+pass(1) = ( abs(I-pi) < tol );
+
+end


### PR DESCRIPTION
Adds an integral2 command to compute the flux of a chebfun3v object through a 2D-surface.
This addresses #1924 .