### PR TITLE
Fix chebcoeffs helptext

### DIFF
--- a/@chebfun/chebcoeffs.m
+++ b/@chebfun/chebcoeffs.m
@@ -1,5 +1,8 @@
 function out = chebcoeffs(f, varargin)
 %CHEBCOEFFS   Chebyshev polynomial coefficients of a CHEBFUN.
+%   A = CHEBCOEFFS(F) returns the Chebyshev coefficients of F assuming
+%   it is a global (not piecewise) chebfun.
+
 %   A = CHEBCOEFFS(F, N) returns the first N Chebyshev coefficients of F is
 %   the column vector A such that F = A(1) T_0(x) +  A(2) T_1(x) + ... + 
 %   A(N) T_(N-1)(x), where T_M(x) denotes the M-th Chebyshev polynomial of the

--- a/@chebfun/chebcoeffs.m
+++ b/@chebfun/chebcoeffs.m
@@ -1,25 +1,35 @@
 function out = chebcoeffs(f, varargin)
-%CHEBCOEFFS   Chebyshev polynomial coefficients of a CHEBFUN.
-%   A = CHEBCOEFFS(F) returns the Chebyshev coefficients of F assuming
-%   it is a global (not piecewise) chebfun.
-
-%   A = CHEBCOEFFS(F, N) returns the first N Chebyshev coefficients of F is
-%   the column vector A such that F = A(1) T_0(x) +  A(2) T_1(x) + ... + 
-%   A(N) T_(N-1)(x), where T_M(x) denotes the M-th Chebyshev polynomial of the
-%   first kind.
+%CHEBCOEFFS   Chebyshev coefficients of a CHEBFUN.
+%   A = CHEBCOEFFS(F) returns the Chebyshev coefficients of F assuming 
+%   it is a global (not piecewise) chebfun.  This is column vector of
+%   coefficients such that  F = A(1) T_0(x) + ... + A(N) T_(N-1)(x),
+%   where N is the length of F.
 %
-%   If F has a 'finite' Chebyshev expansion (i.e., it is a smooth CHEBFUN with
-%   no breakpoints or endpoint singularities and is based on a CHEBTECH), then
-%   CHEBCOEFFS(F) is equivalent to CHEBCOEFFS(F, LENGTH(F)). This syntax should
-%   be used with caution, and passing N is preferred.
+%   If F is an array-valued chebfun, then A is a matrix with the
+%   same number of columns as F.
 %
-%   If F is array-valued with M columns, then A is an NxM matrix.
+%   If the domain of F is [a,b] rather than [-1,1], then the 
+%   coefficients are those of F transplanted to [-1,1].
 %
-%   C = CHEBCOEFFS(F, N, 'kind', 2) returns the vector of coefficients of F
-%   such that F = C(1) + C(2) U_1(x) + ... + C(N) U_(N-1)(x), where U_M(x)
-%   denotes the M-th Chebyshev polynomial of the second kind.
+%   If F is a piecewise chebfun, you can extract the Chebyshev
+%   coefficients of the pieces with, e.g., A = CHEBCOEFFS(F.FUNS{1}).
 %
-% See also LEGCOEFFS, FOURCOEFFS.
+%   Alternatively, A = CHEBCOEFFS(F, N) returns the first N Chebyshev
+%   coefficients of a piecewise chebfun F even though F is not
+%   represented by a global Chebyshev expansion.  Chebfun does this
+%   by evaluating appropriate integrals. 
+%
+%   A = CHEBCOEFFS(F, 'kind', 2) or A = CHEBCOEFFS(F, N, 'kind', 2)
+%   return vectors or matrices corresponding to expansions 
+%   F = A(1) U_0(x) + ... + A(N) U_(N-1)(x) in Chebyshev polynomials
+%   of the second kind.
+%
+%   Examples:
+%    x = chebfun('x');
+%    chebcoeffs(exp(x))
+%    chebcoeffs(abs(x),10)
+%
+% See also LEGCOEFFS, TRIGCOEFFS.
 
 % Copyright 2016 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.

--- a/@chebfun/chebcoeffs.m
+++ b/@chebfun/chebcoeffs.m
@@ -12,7 +12,7 @@ function out = chebcoeffs(f, varargin)
 %   coefficients are those of F transplanted to [-1,1].
 %
 %   If F is a piecewise chebfun, you can extract the Chebyshev
-%   coefficients of the pieces with, e.g., A = CHEBCOEFFS(F.FUNS{1}).
+%   coefficients of the pieces with GET(F, 'COEFFS').
 %
 %   Alternatively, A = CHEBCOEFFS(F, N) returns the first N Chebyshev
 %   coefficients of a piecewise chebfun F even though F is not

--- a/@chebfun/legcoeffs.m
+++ b/@chebfun/legcoeffs.m
@@ -10,7 +10,7 @@ function out = legcoeffs(f, varargin)
 %
 %   LEGCOEFFS does not support quasimatrices.
 %
-% See also CHEBCOEFFS, JACCOEFFS, FOURCOEFFS.
+% See also CHEBCOEFFS, JACCOEFFS, TRIGCOEFFS.
 
 % Copyright 2016 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.

--- a/@chebtech/chebcoeffs.m
+++ b/@chebtech/chebcoeffs.m
@@ -16,7 +16,7 @@ function out = chebcoeffs(f, N, kind)
 %
 %   If F is array-valued with P columns, then A is an MxP matrix.
 %
-% See also LEGCOEFFS, FOURCOEFFS.
+% See also LEGCOEFFS, TRIGCOEFFS.
 
 % Copyright 2016 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.

--- a/@chebtech/poly.m
+++ b/@chebtech/poly.m
@@ -12,7 +12,7 @@ function out = poly(f)
 %   This strange behaviour is a result of MATLAB's decision to return a row
 %   vector from the POLY command, even for column vector input.
 %
-% See also CHEBCOEFFS, FOURCOEFFS, LEGCOEFFS.
+% See also CHEBCOEFFS, TRIGCOEFFS, LEGCOEFFS.
 
 % Copyright 2016 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.

--- a/@classicfun/chebcoeffs.m
+++ b/@classicfun/chebcoeffs.m
@@ -2,7 +2,7 @@ function out = chebcoeffs(f, varargin)
 %CHEBCOEFFS   Chebyshev polynomial coefficients of a CLASSICFUN.
 %   CHEBCOEFFS(F) returns the Chebyshev coefficients of F.ONEFUN.
 %
-% See also LEGPOLY FOURCOEFFS.
+% See also LEGPOLY, TRIGCOEFFS.
 
 % Copyright 2016 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.

--- a/@spherefun/chebcoeffs2.m
+++ b/@spherefun/chebcoeffs2.m
@@ -1,5 +1,5 @@
 function varargout = chebcoeffs2(varargin)
-%CHEBCOEFFS2    Bivariate expansion coefficient
+%CHEBCOEFFS2    Bivariate expansion coefficients
 %   X = CHEBCOEFFS2(F) returns the matrix of bivariate coefficients such that
 %       F= sum_{i=0}^{n-1} ( sum_{j=0}^{n-1} X(i+1,j+1) T_i(y) T_j(x) ).
 %


### PR DESCRIPTION
This pull request mainly adjusts help text in `@chebfun/plotcoeffs` in response to questions raised by @klauszuoxinwang.  The old and new help texts are reproduced below.  In addition, a number of spurious appearances of `FOURCOEFFS` in help texts have been changed to `TRIGCOEFFFS`.

Old help text:
```
 chebcoeffs   Chebyshev polynomial coefficients of a CHEBFUN.
    A = chebcoeffs(F, N) returns the first N Chebyshev coefficients of F is
    the column vector A such that F = A(1) T_0(x) +  A(2) T_1(x) + ... + 
    A(N) T_(N-1)(x), where T_M(x) denotes the M-th Chebyshev polynomial of the
    first kind.
 
    If F has a 'finite' Chebyshev expansion (i.e., it is a smooth CHEBFUN with
    no breakpoints or endpoint singularities and is based on a CHEBTECH), then
    chebcoeffs(F) is equivalent to chebcoeffs(F, LENGTH(F)). This syntax should
    be used with caution, and passing N is preferred.
 
    If F is array-valued with M columns, then A is an NxM matrix.
 
    C = chebcoeffs(F, N, 'kind', 2) returns the vector of coefficients of F
    such that F = C(1) + C(2) U_1(x) + ... + C(N) U_(N-1)(x), where U_M(x)
    denotes the M-th Chebyshev polynomial of the second kind.
 
  See also legcoeffs, FOURCOEFFS.
```
New help text:
```
 chebcoeffs   Chebyshev coefficients of a CHEBFUN.
    A = chebcoeffs(F) returns the Chebyshev coefficients of F assuming 
    it is a global (not piecewise) chebfun.  This is column vector of
    coefficients such that  F = A(1) T_0(x) + ... + A(N) T_(N-1)(x),
    where N is the length of F.
 
    If F is an array-valued chebfun, then A is a matrix with the
    same number of columns as F.
 
    If the domain of F is [a,b] rather than [-1,1], then the 
    coefficients are those of F transplanted to [-1,1].
 
    If F is a piecewise chebfun, you can extract the Chebyshev
    coefficients of the pieces with, e.g., A = chebcoeffs(F.FUNS{1}).
 
    Alternatively, A = chebcoeffs(F, N) returns the first N Chebyshev
    coefficients of a piecewise chebfun F even though F is not
    represented by a global Chebyshev expansion.  Chebfun does this
    by evaluating appropriate integrals. 
 
    A = chebcoeffs(F, 'kind', 2) or A = chebcoeffs(F, N, 'kind', 2)
    return vectors or matrices corresponding to expansions 
    F = A(1) U_0(x) + ... + A(N) U_(N-1)(x) in Chebyshev polynomials
    of the second kind.
 
    Examples:
     x = chebfun('x');
     chebcoeffs(exp(x))
     chebcoeffs(abs(x),10)
 
  See also legcoeffs, trigcoeffs.
```