### PR TITLE
fix  #1956

### DIFF
--- a/@separableApprox/subsref.m
+++ b/@separableApprox/subsref.m
@@ -30,14 +30,14 @@ switch index(1).type
         
         % Where to evaluate:
         x = idx{1}; 
-        if ( length(idx) == 2) 
+        if ( length(idx) == 2 ) 
             y = idx{2};
         elseif ( isa(x, 'chebfun2v') ) 
             % f(F), where f is a chebfun2 and F is a chebfun2v. 
             out = feval(f, x); 
             varargout = { out }; 
             return
-        elseif ( ( length(idx) == 1 ) && ( ~isreal(x) ) && ~isa(x, 'chebfun'))
+        elseif ( ( length(idx) == 1 ) && ~isa(x, 'chebfun') )
             x = real( idx{1} );
             y = imag( idx{1} ); 
             out = feval(f, x, y); 

--- a/tests/chebfun2/test_subsref.m
+++ b/tests/chebfun2/test_subsref.m
@@ -41,4 +41,9 @@ g = f{-1,1,-.5,.25};
 exact = chebfun2(@(x,y) sin(x.*(y-.1)), [-1,1,-.5,.25]);
 pass(11) = ( norm( g -  exact ) < 10*tol );
 
+% Evaluation of complex-valued Chebfun2 objects, #1956
+f = chebfun2(@(z) z);
+pass(12) = norm(f(1i) -  1i) < tol; 
+pass(13) = norm(f(1) -  1) < tol; 
+
 end


### PR DESCRIPTION
In Line 40 of `separableApprox/subsref`, a single input was
unnecessarily assumed to be complex. This is now removed. A test is
also added for this.