### PR TITLE
fix-chebfun-minandmax-again

### DIFF
--- a/@chebfun/max.m
+++ b/@chebfun/max.m
@@ -84,7 +84,7 @@ function [y, x] = globalMax(f)
 % Call MINANDMAX():
 [y, x] = minandmax(f);
 
-% Extract the minimum:
+% Extract the maximum:
 y = y(2,:);
 x = x(2,:);
 

--- a/@chebtech/minandmax.m
+++ b/@chebtech/minandmax.m
@@ -73,7 +73,12 @@ function [vals, pos] = minandmaxColumn(f, fp, xpts)
     % Initialise output
     pos = [ 0; 0 ];
     vals = [ 0; 0 ];
-
+    
+    if ( length(f) == 1 )
+        vals = feval(f, pos);
+        return
+    end
+    
     % Compute turning points:
     r = roots(fp);
     r = [ -1; r; 1 ];

--- a/tests/chebfun/test_max.m
+++ b/tests/chebfun/test_max.m
@@ -168,10 +168,15 @@ err1 = abs(y - y_exact);
 err2 = abs(feval(f, x) - y_exact);
 pass(20) = err1 < tol && err2 < tol;
 
+% Ensure minimum of a constant function is returned at the middle of the domain:
+f = chebfun(7, [1 3]);
+[y, x] = max(f);
+pass(21) = (y == 7) && (x == 2);
+
 %% Check max of a CHEBFUN and a scalar:
 f = chebfun(@(x) [sin(x) cos(x)]);
 h = max(f, .75);
-pass(21) = norm(h([-.9 0 .8 .9].') - ...
+pass(22) = norm(h([-.9 0 .8 .9].') - ...
     [.75 .75 ;.75 1 ; .75 .75 ; sin(.9) .75]) < 10*eps*vscale(h);
 
 %% Test on function defined on unbounded domain:
@@ -188,7 +193,7 @@ yExact = exp(-1);
 xExact = 1;
 errY = y - yExact;
 errX = x - xExact;
-pass(22) = norm([errY errX], inf) < 1e3*eps*vscale(f);
+pass(23) = norm([errY errX], inf) < 1e3*eps*vscale(f);
 
 
 end

--- a/tests/chebfun/test_min.m
+++ b/tests/chebfun/test_min.m
@@ -155,10 +155,15 @@ catch ME
     pass(18) = strcmp(ME.identifier, 'CHEBFUN:CHEBFUN:max:flag');
 end
 
+% Ensure minimum of a constant function is returned at the middle of the domain:
+f = chebfun(1);
+[y, x] = min(f);
+pass(19) = (y == 1) && (x == 0);
+
 %% Check min of a CHEBFUN and a scalar:
 f = chebfun(@(x) [sin(x) cos(x)]);
 h = min(f, .75);
-pass(19) = norm(h([-.9 0 .9].') - [sin(-.9) cos(-.9) ; 0 .75 ; .75 cos(.9)]) ...
+pass(20) = norm(h([-.9 0 .9].') - [sin(-.9) cos(-.9) ; 0 .75 ; .75 cos(.9)]) ...
     < 3*eps*vscale(h);
 
 %% test on function defined on unbounded domain:
@@ -175,7 +180,7 @@ f = chebfun(op, dom, 'exps', [0 -1]);
 yExact = -Inf;
 xExact = dom(2);
 errX = x - xExact;
-pass(20) = ( norm(errX, inf) < eps*vscale(f) ) && ...
+pass(21) = ( norm(errX, inf) < eps*vscale(f) ) && ...
     ( y == yExact );
 
 end


### PR DESCRIPTION
Ensure min and max of constant functions are at the centre of the domain. (Consistent with roots.)

On development:
```
>> [y, x] = min(chebfun(0))
y =
     0
x =
    -1
```

On this branch:
```
>> [y, x] = min(chebfun(0))
y =
     0
x =
     0
```