### PR TITLE
Feature chebfun2 eig

### DIFF
--- a/@chebfun2/eig.m
+++ b/@chebfun2/eig.m
@@ -24,7 +24,7 @@ function varargout = eig(f)
 % Copyright 2016 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-    dom = f.domain; 
+dom = f.domain; 
 if ( (dom(1) ~= dom(3)) || (dom(2) ~= dom(4)) )% domain check
     error('CHEBFUN2:CHEBFUN2:eig:domainerr',...
           'Domain of chebfun2 needs to be in form [a b a b]');

--- a/@chebfun2/eig.m
+++ b/@chebfun2/eig.m
@@ -1,43 +1,41 @@
 function varargout = eig(f)
-%EIG    Eigenvalues and eigenfunctions of a CHEBFUN2.
+%EIG   Eigenvalues and eigenfunctions of a CHEBFUN2.
 %   EIG(F) returns the eigenvalues of F. The number of nonzero eigenvalues
 %   returned is at most the rank of the CHEBFUN2. F.domain needs to be
 %   square: [a b a b], just as matrices need to be square for eigenvalues
-%   to be defined. 
+%   to be defined.
 %
-%   S = EIG(F) returns the eigenvalues of F. S is a vector of 
-%   eigenvalues.
+%   S = EIG(F) returns the eigenvalues of F. S is a vector of eigenvalues.
 %
-%   [V,D] = EIG(F) returns the eigenvalues and eigenfunctions of F. V is a quasi-matrices of
-%   CHEBFUN objects and D is a diagonal matrix with the eigenvalues
-%   on the diagonal.
+%   [V, D] = EIG(F) returns the eigenvalues and eigenfunctions of F. V is a
+%   quasimatrix of CHEBFUN objects and D is a diagonal matrix with the 
+%   eigenvalues on the diagonal.
 %
 %   If d is an eigenvalue of F with eigenfunction w, then this holds: 
-%   \int f(x,y)w(x)dx = d w(y). 
+%   \int f(x,y) w(x) dx = d w(y).
 %   This can be checked as follows: 
-%   [V,D] = eig(f);
+%   [V, D] = eig(f);
 %   w = V(:,1); d = D(1,1);
-%   fw = chebfun(@(y)sum(chebfun(@(x)f(x,y),w.domain).*w),w.domain);
-%   and check that norm(fw-d*w) is O(eps). 
-%
+%   fw = chebfun(@(y) sum(chebfun(@(x) f(x, y), w.domain).*w), w.domain);
+%   and check that norm(fw-d*w) is O(eps).
 
 % Copyright 2016 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
 dom = f.domain; 
-if ( (dom(1) ~= dom(3)) || (dom(2) ~= dom(4)) )% domain check
-    error('CHEBFUN2:CHEBFUN2:eig:domainerr',...
+if ( (dom(1) ~= dom(3)) || (dom(2) ~= dom(4)) ) % domain check
+    error('CHEBFUN:CHEBFUN2:eig:domainerr',...
           'Domain of chebfun2 needs to be in form [a b a b]');
-end    
+end
 
-    [u, S, v] = svd( f ); % SVD of chebfun2
-    [V, D] = eig( v'*u*S ); % eig(AB) = eig(BA)
-    V = u * S * V; % eigenfunctions
+[u, S, v] = svd(f); % SVD of chebfun2
+[V, D] = eig(v' * u * S); % eig(AB) = eig(BA)
+V = u * S * V; % eigenfunctions
 
-    if ( nargout > 1 )
-        varargout = { V, D };
-    else
-        varargout = { diag( D ) };
-    end
+if ( nargout > 1 )
+    varargout = { V, D };
+else
+    varargout = { diag(D) };
+end
 
 end

--- a/@chebfun2/eig.m
+++ b/@chebfun2/eig.m
@@ -15,9 +15,7 @@ function varargout = eig(f)
 %   \int f(x,y) w(x) dx = d w(y).
 %   This can be checked as follows: 
 %   [V, D] = eig(f);
-%   w = V(:,1); d = D(1,1);
-%   fw = chebfun(@(y) sum(chebfun(@(x) f(x, y), w.domain).*w), w.domain);
-%   and check that norm(fw-d*w) is O(eps).
+%   and check that norm(f*V-V*D) is O(eps).
 
 % Copyright 2016 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.

--- a/@chebfun2/eig.m
+++ b/@chebfun2/eig.m
@@ -2,7 +2,8 @@ function varargout = eig(f)
 %EIG    Eigenvalues and eigenfunctions of a CHEBFUN2.
 %   EIG(F) returns the eigenvalues of F. The number of nonzero eigenvalues
 %   returned is at most the rank of the CHEBFUN2. F.domain needs to be
-%   square: [a b a b].
+%   square: [a b a b], just as matrices need to be square for eigenvalues
+%   to be defined. 
 %
 %   S = EIG(F) returns the eigenvalues of F. S is a vector of 
 %   eigenvalues.

--- a/@chebfun2/eig.m
+++ b/@chebfun2/eig.m
@@ -29,8 +29,8 @@ if ( (dom(1) ~= dom(3)) || (dom(2) ~= dom(4)) )% domain check
           'Domain of chebfun2 needs to be in form [a b a b]');
 end    
 
-    [u,S,v] = svd( f ); % SVD of chebfun2
-    [V,D] = eig( v'*u*S ); % eig(AB) = eig(BA)
+    [u, S, v] = svd( f ); % SVD of chebfun2
+    [V, D] = eig( v'*u*S ); % eig(AB) = eig(BA)
     V = u * S * V; % eigenfunctions
 
     if ( nargout > 1 )

--- a/@chebfun2/eig.m
+++ b/@chebfun2/eig.m
@@ -1,0 +1,42 @@
+function varargout = eig(f)
+%EIG    Eigenvalues and eigenfunctions of a CHEBFUN2.
+%   EIG(F) returns the eigenvalues of F. The number of nonzero eigenvalues
+%   returned is at most the rank of the CHEBFUN2. F.domain needs to be
+%   square: [a b a b].
+%
+%   S = EIG(F) returns the eigenvalues of F. S is a vector of 
+%   eigenvalues.
+%
+%   [V,D] = EIG(F) returns the eigenvalues and eigenfunctions of F. V is a quasi-matrices of
+%   CHEBFUN objects and D is a diagonal matrix with the eigenvalues
+%   on the diagonal.
+%
+%   If d is an eigenvalue of F with eigenfunction w, then this holds: 
+%   \int f(x,y)w(x)dx = w(y). 
+%   This can be checked as follows: 
+%   [V,D] = eig(f);
+%   w = V(:,1); d = D(1,1);
+%   fw = chebfun(@(y)sum(chebfun(@(x)f(x,y),w.domain).*w),w.domain);
+%   and check that norm(fw-d*w) is O(eps). 
+%
+
+% Copyright 2016 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+    dom = f.domain; 
+if ( (dom(1) ~= dom(3)) || (dom(2) ~= dom(4)) )% domain check
+    error('CHEBFUN2:CHEBFUN2:eig:domainerr',...
+          'Domain of chebfun2 needs to be in form [a b a b]');
+end    
+
+    [u,S,v] = svd( f ); % SVD of chebfun2
+    [V,D] = eig( v'*u*S ); % eig(AB) = eig(BA)
+    V = u * S * V; % eigenfunctions
+
+    if ( nargout > 1 )
+        varargout = { V, D };
+    else
+        varargout = { diag( D ) };
+    end
+
+end

--- a/@chebfun2/eig.m
+++ b/@chebfun2/eig.m
@@ -13,7 +13,7 @@ function varargout = eig(f)
 %   on the diagonal.
 %
 %   If d is an eigenvalue of F with eigenfunction w, then this holds: 
-%   \int f(x,y)w(x)dx = w(y). 
+%   \int f(x,y)w(x)dx = d w(y). 
 %   This can be checked as follows: 
 %   [V,D] = eig(f);
 %   w = V(:,1); d = D(1,1);

--- a/tests/chebfun2/test_eig.m
+++ b/tests/chebfun2/test_eig.m
@@ -1,0 +1,27 @@
+function pass = test_eig( pref ) 
+% Test for EIG command of Chebfun2.
+
+if ( nargin == 0 ) 
+    pref = chebfunpref;
+end 
+
+tol = 100*pref.cheb2Prefs.chebfun2eps;
+
+% Decomposition on a square domain.
+f = cheb.gallery2('challenge');
+[V, D] = eig(f);
+
+% Is it correct?
+pass(1) = norm(f * V - V * D') < tol;
+
+%%
+% The following should give an error message as the domain is not square.
+f = chebfun2(@(x,y,z) x+y, [-1 1 -2 2]);
+try
+    d = eig(f);
+    pass(2) = false;
+catch ME 
+    pass(2) = strcmp(ME.identifier, 'CHEBFUN:CHEBFUN2:eig:domainerr');
+end
+
+end

--- a/tests/chebfun2/test_eig.m
+++ b/tests/chebfun2/test_eig.m
@@ -4,15 +4,14 @@ function pass = test_eig( pref )
 if ( nargin == 0 ) 
     pref = chebfunpref;
 end 
-
-tol = 100*pref.cheb2Prefs.chebfun2eps;
+tol = 1e4*pref.cheb2Prefs.chebfun2eps;
 
 % Decomposition on a square domain.
 f = cheb.gallery2('challenge');
 [V, D] = eig(f);
 
 % Is it correct?
-pass(1) = norm(f * V - V * D') < tol;
+pass(1) = norm(f * V - V * D) < tol;
 
 %%
 % The following should give an error message as the domain is not square.


### PR DESCRIPTION
Adds chebfun2.eig, which computes the eigenvalues and eigenfunctions of a chebfun2 object. 
If d is an eigenvalue of F with eigenfunction w, then this holds: \int f(x,y)w(x)dx = d w(y). 
The domain needs to be square but the chebfun2 can be nonsymmetric. Uses eig(AB) = eig(BA) as a crucial tool. 
