### PR TITLE
Fix remez for odd functions

### DIFF
--- a/@chebfun/remez.m
+++ b/@chebfun/remez.m
@@ -238,7 +238,7 @@ c = chebcoeffs(f, length(f));
 c(end) = 2*c(end);
 
 % Check for symmetries and reduce degrees accordingly.
-if ( max(abs(c(2:2:end)))/vscale(f) < eps )   % f is even.        
+if ( max(abs(c(2:2:end)))/vscale(f) < eps )   % f is even.
     if ( mod(m, 2) == 1 )
         m = m - 1;
     end

--- a/@chebfun/remez.m
+++ b/@chebfun/remez.m
@@ -238,22 +238,19 @@ c = chebcoeffs(f, length(f));
 c(end) = 2*c(end);
 
 % Check for symmetries and reduce degrees accordingly.
-if ( max(abs(c(2:2:end)))/vscale(f) < eps )   % f is even.
+if ( max(abs(c(2:2:end)))/vscale(f) < eps )   % f is even.        
     if ( mod(m, 2) == 1 )
-        m = max(0, m - 1);
+        m = m - 1;
     end
     if ( mod(n, 2) == 1 )
-        n = max(0, n - 1);
+        n = n - 1;
     end
-elseif ( max(abs(c(1:2:end)))/vscale(f) < eps ) % f is odd.
-    if ( mod(m, 2) == mod(n, 2) ) % reduce one degree 
-        if ( n >= m )
-        n = max(0, n - 1);            
-        else
-        m = max(0, m - 1);
-        end
-    end
-
+elseif ( max(abs(c(1:2:end)))/vscale(f) < eps ) % f is odd. obtain (odd,even) type
+    if ( ~mod(m,2) && ~mod(n,2) ), 
+        m = m - 1; 
+    elseif (mod(m,2) && mod(n,2)), 
+        n = n - 1; 
+    end    
 end
 
 end

--- a/@chebfun/remez.m
+++ b/@chebfun/remez.m
@@ -247,11 +247,12 @@ if ( max(abs(c(2:2:end)))/vscale(f) < eps )   % f is even.
     end
 
 elseif ( max(abs(c(1:2:end)))/vscale(f) < eps ) % f is odd. obtain (odd,even) type
-    if ( ~mod(m,2) && ~mod(n,2) ), 
-        m = max(m - 1,0); 
-    elseif (mod(m,2) && mod(n,2)), 
-        n = n - 1; 
-    end    
+     if ( ~mod(m,2) )
+         m = max(0, m-1);
+     end
+     if ( mod(n,2) )
+         n = n - 1;
+     end   
 
 end
 

--- a/@chebfun/remez.m
+++ b/@chebfun/remez.m
@@ -245,24 +245,14 @@ if ( max(abs(c(2:2:end)))/vscale(f) < eps )   % f is even.
     if ( mod(n, 2) == 1 )
         n = n - 1;
     end
-<<<<<<< HEAD
+
 elseif ( max(abs(c(1:2:end)))/vscale(f) < eps ) % f is odd. obtain (odd,even) type
     if ( ~mod(m,2) && ~mod(n,2) ), 
         m = m - 1; 
     elseif (mod(m,2) && mod(n,2)), 
         n = n - 1; 
     end    
-=======
-elseif ( max(abs(c(1:2:end)))/vscale(f) < eps ) % f is odd.
-    if ( mod(m, 2) == mod(n, 2) ) % reduce one degree 
-        if ( n >= m )
-            n = max(0, n - 1);
-        else
-            m = max(0, m - 1);
-        end
-    end
 
->>>>>>> c5723427095d6dfdda0a274844c0b0d6ce3cba05
 end
 
 end

--- a/@chebfun/remez.m
+++ b/@chebfun/remez.m
@@ -248,7 +248,7 @@ if ( max(abs(c(2:2:end)))/vscale(f) < eps )   % f is even.
 
 elseif ( max(abs(c(1:2:end)))/vscale(f) < eps ) % f is odd. obtain (odd,even) type
     if ( ~mod(m,2) && ~mod(n,2) ), 
-        m = m - 1; 
+        m = max(m - 1,0); 
     elseif (mod(m,2) && mod(n,2)), 
         n = n - 1; 
     end    

--- a/tests/chebfun/test_remez.m
+++ b/tests/chebfun/test_remez.m
@@ -56,6 +56,14 @@ pass(7) = (abs(err-.5) < 1e-10);
 err = norm(f-p./q,inf);
 pass(8) = (abs(err-.043689) < 1e-3);
 
-
+%%
+% Make sure that it works for m=0 and odd f.
+f = x.^3;
+try
+    [p,q] = remez(f,0,2);
+    pass(9) = 1;
+catch ME 
+    pass(9) = false;
+end
 
 end


### PR DESCRIPTION
This is to fix the nightly failure regarding (C) ATAP/chap24.m. 
The 'fix' on Aug 26 was incorrect for remez(odd functions); it should always be (odd,even) to avoid poles at 0. 