### PR TITLE
Fix #1963: g(f) is periodic if f is periodic and g is smooth

### DIFF
--- a/@chebfun/compose.m
+++ b/@chebfun/compose.m
@@ -342,18 +342,18 @@ end
 %% Locate breakpoints in G:
 
 % If g has breakpoints, find the corresponding x-points in the domain of f:
-newDom = f.domain;
 if ( numel(g.domain) > 2 )
+    newDom = f.domain;
     gDom = g.domain(2:end-1);
     for k = 1:length(gDom)
         r = roots(f - gDom(k));
         newDom = [newDom, r(:).'];
     end
+    newDom = chebfun.tolUnique(sort(newDom));
+    
+    % Restrict f to the new domain:
+    f = restrict(f, newDom);
 end
-newDom = chebfun.tolUnique(sort(newDom));
-
-% Restrict f to the new domain:
-f = restrict(f, newDom);
 
 %% Call COMPOSE():
 

--- a/tests/chebfun/test_compose_chebfuns.m
+++ b/tests/chebfun/test_compose_chebfuns.m
@@ -91,6 +91,20 @@ ep = 0.25;
 x = chebfun('x');
 F = (abs(x) < ep)/(2*ep);
 pass(12) = get(F(x), 'ishappy');
+j = 13;
+
+%% Test composition g(f) of a periodic chebfun f and a chebfun g.  See #1963.
+f = chebfun(@(x) sin(pi*x), 'trig');
+cheb.x
+g = x.^2;
+h = g(f);
+pass(j) = isPeriodicTech(h);
+j = j + 1;
+G = [exp(x), abs(x)];
+H = G(f);
+pass(j) = isPeriodicTech(H(:,1));
+j = j + 1;
+pass(j) = ~isPeriodicTech(H(:,2));
 
 end
 

--- a/tests/chebfun/test_compose_chebfuns.m
+++ b/tests/chebfun/test_compose_chebfuns.m
@@ -91,20 +91,18 @@ ep = 0.25;
 x = chebfun('x');
 F = (abs(x) < ep)/(2*ep);
 pass(12) = get(F(x), 'ishappy');
-j = 13;
 
 %% Test composition g(f) of a periodic chebfun f and a chebfun g.  See #1963.
 f = chebfun(@(x) sin(pi*x), 'trig');
 cheb.x
 g = x.^2;
 h = g(f);
-pass(j) = isPeriodicTech(h);
-j = j + 1;
+pass(13) = isPeriodicTech(h);
+
 G = [exp(x), abs(x)];
 H = G(f);
-pass(j) = isPeriodicTech(H(:,1));
-j = j + 1;
-pass(j) = ~isPeriodicTech(H(:,2));
+pass(14) = isPeriodicTech(H(:,1));
+pass(15) = ~isPeriodicTech(H(:,2));
 
 end
 


### PR DESCRIPTION
On development, if `f` is a 1D `trigtech` and `g` is a chebfun, then `h = g(f)` is not a `trigtech`:
```
f = chebfun(@(x) sin(pi*x), 'trig');
g = chebfun(@(x) x.^2);
h = g(f)
h =
   chebfun column (1 smooth piece)
       interval       length     endpoint values  
[      -1,       1]       29  -8.2e-17 -8.2e-17 
vertical scale = 0.99
```
On this branch, if `g` is a smooth chebfun (no breakpoints), then `h = g(f)` is again a `trigtech`:
```
h =
   chebfun column (1 smooth piece)
       interval       length     endpoint values trig
[      -1,       1]        5   5.6e-17  5.6e-17 
vertical scale = 0.9
```
If `g` has breakpoints, then `g(f)` will not be a `trigtech`.  Closes #1963 .
(The same will be true for a periodic Chebfun2, 2v, 3, 3v object `f` after #1962 is merged.)