### PR TITLE
Fix #1980

### DIFF
--- a/@chebfun3/mtimes.m
+++ b/@chebfun3/mtimes.m
@@ -6,10 +6,10 @@ function h = mtimes(f, g)
 %   and c is a scalar.
 %
 % See also CHEBFUN3/TIMES.
-
+ 
 % Copyright 2016 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
-
+ 
 if ( isa(f, 'chebfun3') )           % CHEBFUN3 * ???
     
     if ( isa(g, 'double') )         % CHEBFUN3 * DOUBLE
@@ -35,9 +35,10 @@ if ( isa(f, 'chebfun3') )           % CHEBFUN3 * ???
         temp = squeeze(chebfun3.txm(fCore, X.', 1));
         [U, S, V] = svd(temp);
         h = chebfun2();
-        h.cols = fRows * U;
-        h.rows = fTubes * V;
+        h.rows = fRows * U;
+        h.cols = fTubes * V;
         h.pivotValues = 1 ./ diag(S);
+        h.domain = f.domain(3:6);
         
     elseif ( isa(g, 'chebfun2') ) % CHEBFUN3 * CHEBFUN2: Mode 1 only for now.
         % The output is another CHEBFUN3. Recall that, mode-1 contraction 
@@ -59,11 +60,12 @@ if ( isa(f, 'chebfun3') )           % CHEBFUN3 * ???
         h.rows = fRows;   % 2nd variable of h is the 2nd variable of f.
         h.tubes = fTubes; % 3rd variable of h is 3rd variable of f.
         h.core = chebfun3.txm(temp, gPivots, 1);
-        h.domain = f.domain;
+        h.domain(1:2) = g.domain(3:4);
+        h.domain(3:6) = f.domain(3:6);
                            
     elseif ( isa(g, 'chebfun3') )    % CHEBFUN3 * CHEBFUN3
         error('CHEBFUN:CHEBFUN3:mtimes', 'CHEBFUN3 does not support this operation.');
-
+ 
     elseif ( isa(g, 'chebfun3v') )  % CHEBFUN3 * CHEBFUN3V
         nG = g.nComponents; 
         h = g; 
@@ -84,5 +86,5 @@ elseif ( isa(f, 'double') && isa(g, 'chebfun3') )  % DOUBLE * CHEBFUN3
 else
     error('CHEBFUN:CHEBFUN3:mtimes:size', 'Sizes are inconsistent.');
 end
-
+ 
 end

--- a/@chebfun3/mtimes.m
+++ b/@chebfun3/mtimes.m
@@ -56,15 +56,16 @@ if ( isa(f, 'chebfun3') )           % CHEBFUN3 * ???
         
         % Form the output:
         h = chebfun3();
-        h.cols = gCols;   % 1st variable of g sits in place of 1st variable of h.
-        h.rows = fRows;   % 2nd variable of h is the 2nd variable of f.
-        h.tubes = fTubes; % 3rd variable of h is 3rd variable of f.
+        h.cols = gCols;  % 1st variable of g sits in place of 1st variable of h.
+        h.rows = fRows;  % 2nd variable of h is the 2nd variable of f.
+        h.tubes = fTubes;% 3rd variable of h is 3rd variable of f.
         h.core = chebfun3.txm(temp, gPivots, 1);
         h.domain(1:2) = g.domain(3:4);
         h.domain(3:6) = f.domain(3:6);
                            
     elseif ( isa(g, 'chebfun3') )    % CHEBFUN3 * CHEBFUN3
-        error('CHEBFUN:CHEBFUN3:mtimes', 'CHEBFUN3 does not support this operation.');
+        error('CHEBFUN:CHEBFUN3:mtimes', ['CHEBFUN3 does not support this', ...
+            'operation.']);
  
     elseif ( isa(g, 'chebfun3v') )  % CHEBFUN3 * CHEBFUN3V
         nG = g.nComponents; 
@@ -78,7 +79,6 @@ if ( isa(f, 'chebfun3') )           % CHEBFUN3 * ???
         error('CHEBFUN:CHEBFUN3:mtimes:unknown', ...
             ['Undefined function ''mtimes'' for input arguments of type %s ' ...
             'and %s.'], class(f), class(g));
-        
     end
     
 elseif ( isa(f, 'double') && isa(g, 'chebfun3') )  % DOUBLE * CHEBFUN3

--- a/tests/chebfun3/test_mtimes.m
+++ b/tests/chebfun3/test_mtimes.m
@@ -1,31 +1,32 @@
 function pass = test_mtimes(pref)
 % Test chebfun3/mtimes
-
+ 
 if ( nargin == 0) 
     pref = chebfunpref; 
 end
 tol = 1000*pref.cheb3Prefs.chebfun3eps;
-
-f = chebfun3(@(x,y,z) x + cos(y+z));
-
+fDom = [-1 1 0 2 -4 -2];
+f = chebfun3(@(x,y,z) x + cos(y+2*z), fDom);
+ 
 % Apply f to a scalar:
 c = 10;
 h = f*c;
-hExact = chebfun3(@(x,y,z) c.*(x + cos(y+z)));
+hExact = chebfun3(@(x,y,z) c.*(x + cos(y+2*z)), fDom);
 pass(1) = norm(hExact - h) < tol;
-
+ 
 % Apply f to a 1D Chebfun:
 g1D = chebfun(@(x) 2*x+3);
 h = f*g1D;
-hExact = chebfun2(@(y,z) 4/3+6*cos(y+z));
+hExact = chebfun2(@(y,z) 4/3+6*cos(y+2*z), fDom(3:6));
 pass(2) = norm(hExact - h) < tol;
-
+ 
 % Apply f to a Chebfun2:
-g2D = chebfun2(@(x,t) x+t);
+gDom = [-1 1 3 5];
+g2D = chebfun2(@(x,t) x+t, gDom);
 h = f*g2D;
-hExact = chebfun3(@(t,y,z) 2/3+2*t.*cos(y+z));
+hExact = chebfun3(@(t,y,z) 2/3+2*t.*cos(y+2*z), [gDom(3:4) fDom(3:6)]);
 pass(3) = norm(hExact - h) < tol;
-
+ 
 % Apply f to another CHEBFUN3. 1-index contraction of two CHEBFUN3 objects
 % will be a 4D function. 2-index contraction of two CHEBFUN3 objects will
 % also be a CHEBFUN2. The first one is not possible in CHEBFUN and the
@@ -38,5 +39,5 @@ try
 catch ME
     pass(4) = true;
 end
-
+ 
 end


### PR DESCRIPTION
Chebfun3/mtimes wasn’t checking the domain of the constructed objects. The case chebfun3 * chebfun2 was also permuting the variables. These are both fixed.