### PR TITLE
Fix bounds checking on third argument of chebfun2/coeffs2

### DIFF
--- a/@chebfun2/coeffs2.m
+++ b/@chebfun2/coeffs2.m
@@ -41,7 +41,7 @@ if ( nargin > 1 )
     else
         cols_coeffs = cols_coeffs(1:m,:);
     end
-    if ( mf <= m ) 
+    if ( nf <= n )
         rows_coeffs = [ rows_coeffs ; zeros(n-nf, rf) ];
     else
         rows_coeffs = rows_coeffs(1:n, :);

--- a/tests/chebfun2/test_chebcoeffs2.m
+++ b/tests/chebfun2/test_chebcoeffs2.m
@@ -23,4 +23,7 @@ pass(j) = norm( X - Exact ) < tol; j = j + 1;
 Z = chebfun2.vals2coeffs( chebpolyval2( f ) );
 pass(j) = norm( Z - Exact ) < tol; j = j + 1; 
 
+f = chebfun2( @(x,y) x + y );
+pass(j) = isequal( size(coeffs2(f,2,1)), [2 1] ); j = j + 1;
+
 end


### PR DESCRIPTION
The third argument of `coeffs2` (i.e. the requested number of columns in the coefficient matrix) is ignored if the second argument (i.e. the requested number of rows) is greater than the number of rows stored in the `chebfun2`. For example,
```
>> f = chebfun2(@(x,y) x+y);
>> coeffs2(f,1,2) % correct
ans =
     0     1
>> coeffs2(f,2,1) % incorrect
ans =
     0     1
     1     0
```
The bug exists on line 44 of coeffs2.m. `if ( mf <= m )` should be `if ( nf <= n )`.