### PR TITLE
Fix for chebfun2/surf parametric surfaces

### DIFF
--- a/@separableApprox/surf.m
+++ b/@separableApprox/surf.m
@@ -92,7 +92,7 @@ if ( isa(f,'separableApprox') )
         x = feval(x, xx, yy);
         y = feval(y, xx, yy);
         if ( isa(argin{2}, 'separableApprox') )         % surf(x,y,f,...)
-            vals = feval(argin{2}, x, y);
+            vals = feval(argin{2}, xx, yy);
             if ( nargin < 4 )                    % surf(x,y,f)
                 C = vals;
             elseif ( isa(argin{3}, 'double') )   % surf(x,y,f,C,...)


### PR DESCRIPTION
Fix this:

```
t = chebfun2(@(t,p) t,[0 2*pi -pi/2 pi/2]);
p = chebfun2(@(t,p) p,[0 2*pi -pi/2 pi/2]);
[x,y,z] = sph2cart(t,p,0*t+1);
surf(x,y,z), axis equal
```

(The code should return a surface plot of the sphere.)