### PR TITLE
fix-chebfun2-disp-trig

### DIFF
--- a/@chebfun2/disp.m
+++ b/@chebfun2/disp.m
@@ -25,8 +25,16 @@ vals = feval(F, xx, yy ).';               % Corner values
 vals = vals(:);
 vscl = vscale(F);                         % vertical scale
 
+% Check underlying tech is a TRIGTECH: 
+techCol = get(F.cols.funs{1}, 'tech');
+techRow = get(F.rows.funs{1}, 'tech');
+
 % Display the information: 
-disp('   chebfun2 object')
+if ( isa(techCol(), 'trigtech') && isa(techRow(), 'trigtech') )
+    disp('   chebfun2 object  (trig)')
+else
+    disp('   chebfun2 object')
+end
 fprintf('       domain                 rank       corner values\n');
 if ( isreal(vals) )
     fprintf('[%4.2g,%4.2g] x [%4.2g,%4.2g]   %6i     [%4.2g %4.2g %4.2g %4.2g]\n', ...


### PR DESCRIPTION
Closes #1915 

This displays “trig” if the chebfun2 object is doubly periodic. For example:
```
>> f = chebfun2(@(x,y) sin(pi*(x+y)), 'trig')
f =
   chebfun2 object  (trig)
       domain                 rank       corner values
[  -1,   1] x [  -1,   1]        2     [4.2e-16 1.5e-16 1.5e-16 -1.1e-16]
vertical scale = 0.98 
```