### PR TITLE
Fix colormap issue in separableApprox/plot

### DIFF
--- a/@separableApprox/plot.m
+++ b/@separableApprox/plot.m
@@ -118,6 +118,7 @@ if ( ~isempty(varargin) )
 else
     if ( isreal( f ) )
         h = surf( f );
+        colormap default
         
     else
         %% Phase Protrait plot 


### PR DESCRIPTION
closes #2017 : When plotting a complex-valued function, the
colormap is set to hsv (phase portraits).  In a subsequent plot of a
real-valued function, the colormap is not changed back to default.