### PR TITLE
HM and I changed linop/adjoint to linop/linopAdjoint, and put in exam…

### DIFF
--- a/@chebop/adjoint.m
+++ b/@chebop/adjoint.m
@@ -7,7 +7,15 @@ function Nstar = adjoint(N, u)
 %   NSTAR = ADJOINT(N, U) linearizes around the function U then computes
 %   the adjoint.
 %
-% See also LINOP/ADJOINT.
+% Examples:
+%   L = chebop(-1,1); L.op = @(x,u) diff(u,2) + x*u;
+%   L.lbc = 0; L.rbc = 'neumann', Ls = adjoint(L)
+%
+%   N = chebop(0,3); N.op = @(x,u) diff(u) + u^2;
+%   u = chebfun('exp(x)',[0 3]);
+%   N.lbc = 1, Ns = adjoint(N,u)
+%
+% See also LINOP/LINOPADJOINT.
 
 % Copyright 2016 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.
@@ -30,7 +38,7 @@ if ( n == 0 )
 end
 
 % Call linop adjoint:
-[Lstar, op, bcOpL, bcOpR, bcOpM] = adjoint(L, getBCType(N));
+[Lstar, op, bcOpL, bcOpR, bcOpM] = linopAdjoint(L, getBCType(N));
 
 % Construct chebop of the adjoint with pretty print bcs:
 Nstar = chebop(Lstar.domain);

--- a/@linop/linop.m
+++ b/@linop/linop.m
@@ -76,7 +76,13 @@ classdef (InferiorClasses = {?chebfun, ?operatorBlock, ?functionalBlock}) linop 
         end
     end
     
-    
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    %% NON-STATIC METHODS:
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    methods ( Access = public, Static = false )
+        [Lstar, op, bcOpL, bcOpR, bcOpM] = linopAdjoint(L, BC)
+    end
+
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     %% STATIC METHODS:
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/@linop/linopAdjoint.m
+++ b/@linop/linopAdjoint.m
@@ -1,9 +1,9 @@
-function [Lstar, op, bcOpL, bcOpR, bcOpM] = adjoint(L, bcType)
-%ADJOINT   Compute the adjoint of a LINOP.
-%   [LSTAR, OP, BCOPL, BCOPR, BCOPM] = ADJOINT(L, BCTYPE) computes the adjoint
-%   of the LINOP L. ADJOINT requires that L represents a linear differential
-%   operator with either endpoint or periodic boundary conditions. If L
-%   represents a system of differential equations then the highest order
+function [Lstar, op, bcOpL, bcOpR, bcOpM] = linopAdjoint(L, bcType)
+%LINOPADJOINT   Compute the adjoint of a LINOP.
+%   [LSTAR, OP, BCOPL, BCOPR, BCOPM] = LINOPADJOINT(L, BCTYPE) computes the 
+%   adjoint of the LINOP L. LINOPADJOINT requires that L represents a linear 
+%   differential operator with either endpoint or periodic boundary conditions.
+%   If L represents a system of differential equations then the highest order
 %   derivative in each variable must be the same. Integral operators and exotic
 %   functional constraints are not supported.
 %
@@ -18,10 +18,11 @@ function [Lstar, op, bcOpL, bcOpR, bcOpM] = adjoint(L, bcType)
 
 % Check for 2 inputs:
 if ( nargin < 2 )
-    error('CHEBFUN:LINOP:adjoint:inputs', 'ADJOINT requires two inputs.')
+    error('CHEBFUN:LINOP:linopAdjoint:inputs', ...
+       'LINOPADJOINT requires two inputs.')
 end
 
-% Check to so if we can compute an adjoint for this operator!
+% Check to see if we can compute an adjoint for this operator!
 parseInputs(L, bcType);
 
 % Formal adjoint:
@@ -53,24 +54,24 @@ function parseInputs(L, bcType)
 if ( min(min(L.diffOrder)) < 0 )
     % Check for integral operators:
     error('CHEBFUN:LINOP:adjoint:difforder', ...
-        'ADJOINT doesn''t support integral operators for the moment.')
+        'LINOPADJOINT doesn''t support integral operators for the moment.')
 elseif ( size(L.domain, 2) > 2 )
     % [TODO]: Support piecewise domains.
     error('CHEBFUN:LINOP:adjoint:domain', ...
-        'ADJOINT doesn''t support piecewise domains for the moment.');
+        'LINOPADJOINT doesn''t support piecewise domains for the moment.');
 elseif ( ~any(strcmp(bcType, {'periodic', 'bvp', 'ivp', 'fvp'})) )
     error('CHEBFUN:LINOP:adjoint:boundaryconditions', ...
-        ['ADJOINT doesn''t support this type of boundary conditions', ...
+        ['LINOPADJOINT doesn''t support this type of boundary conditions', ...
          'for the moment.']);
 elseif ( m ~= n )
     % [TODO]: Support nonsquare systems.
     error('CHEBFUN:LINOP:adjoint:systems', ...
-        'ADJOINT doesn''t support nonsquare systems at the moment.');
+        'LINOPADJOINT doesn''t support nonsquare systems at the moment.');
 elseif ( n > 1 && any(diff(max(L.diffOrder)) ~= 0) )
     % [TODO]: Support block systems with arbitrary differential order in 
     %         each variable.
     error('CHEBFUN:LINOP:adjoint:systems', ...
-        ['ADJOINT doesn''t support systems with arbitrary ', ...
+        ['LINOPADJOINT doesn''t support systems with arbitrary ', ...
          'differential order in each variable at the moment.']);
 end
 
@@ -97,7 +98,7 @@ function [Lstar, op] = adjointFormal(L, pref)
 % Check for 2 inputs:
 if ( nargin < 2 )
     error('CHEBFUN:LINOP:adjointFormal:inputs', ...
-        'ADJOINT requires two inputs.')
+        'LINOPADJOINT requires two inputs.')
 end
 
 % Initialize Lstar and op to have correct dimensions:

--- a/tests/linop/test_linopAdjoint.m
+++ b/tests/linop/test_linopAdjoint.m
@@ -1,4 +1,4 @@
-function pass = test_adjoint(pref)
+function pass = test_linopAdjoint(pref)
 
 % Get preferences:
 if ( nargin < 1 )
@@ -26,7 +26,7 @@ nrm = norm(u);
 L = linop(-D^2+C);
 L = addbc(L,El,0);
 L = addbc(L,Er,0);
-[Ls,op,bcOpL,bcOpR,bcOpM] = adjoint(L,'bvp');
+[Ls,op,bcOpL,bcOpR,bcOpM] = linopAdjoint(L,'bvp');
 % test action of operator and function handle
 pass(1) = norm(-diff(u,2)+c.*u - Ls*u) < nrm*tol;
 pass(2) = norm(-diff(u,2)+c.*u - op(x,u)) < nrm*tol;
@@ -45,7 +45,7 @@ pass(8) = abs(u'*(L*u) - (Ls*u)'*u) < nrm*tol;
 u = (x-dom(1)).*(x-dom(end)).*exp(x); % function that satisfies BCs
 nrm = norm(u);
 L = linop(-D^2+C);
-[Ls,op,bcOpL,bcOpR,bcOpM] = adjoint(L,'periodic');
+[Ls,op,bcOpL,bcOpR,bcOpM] = linopAdjoint(L,'periodic');
 % test action of operator and function handle
 pass(9) = norm(-diff(u,2)+c.*u - Ls*u) < nrm*tol;
 pass(10) = norm(-diff(u,2)+c.*u - op(x,u)) < nrm*tol;
@@ -65,7 +65,7 @@ u = exp(x); % test function for L
 v = (x-dom(1)).*(x-dom(end)).*exp(x); % test function for Ls
 nrm = norm(u)+norm(v);
 L = linop(D);
-[Ls,op,bcOpL,bcOpR,bcOpM] = adjoint(L,'bvp');
+[Ls,op,bcOpL,bcOpR,bcOpM] = linopAdjoint(L,'bvp');
 % test action of operator and function handle
 pass(17) = norm(-diff(v) - Ls*v) < nrm*tol;
 pass(18) = norm(-diff(v) - op(x,v)) < nrm*tol;
@@ -87,7 +87,7 @@ nrm = norm(u1)+norm(u2)+norm(v1)+norm(v2);
 L = linop([D,I;I,D]);
 L = addbc(L,[El,z],0);
 L = addbc(L,[z,El],0);
-[Ls,op,bcOpL,bcOpR,bcOpM] = adjoint(L,'bvp');
+[Ls,op,bcOpL,bcOpR,bcOpM] = linopAdjoint(L,'bvp');
 % test action of operator and function handle
 pass(25) = norm([-diff(v1)+v2;v1-diff(v2)] - Ls*[v1;v2]) < nrm*tol;
 pass(26) = norm([-diff(v1)+v2;v1-diff(v2)] - op(x,v1,v2)) < nrm*tol;
@@ -109,7 +109,7 @@ nrm = norm(u1)+norm(u2)+norm(v1)+norm(v2);
 L = linop([D,-D;I,D]);
 L = addbc(L,[Er,z],0);
 L = addbc(L,[z,Er],0);
-[Ls,op,bcOpL,bcOpR,bcOpM] = adjoint(L,'bvp');
+[Ls,op,bcOpL,bcOpR,bcOpM] = linopAdjoint(L,'bvp');
 % test action of operator and function handle
 pass(33) = norm([-diff(v1)+v2;diff(v1)-diff(v2)] - Ls*[v1;v2]) < nrm*tol;
 pass(34) = norm([-diff(v1)+v2;diff(v1)-diff(v2)] - op(x,v1,v2)) < nrm*tol;


### PR DESCRIPTION
…ples.  The reason we changed the name of linop/adjoint was so that users typing `help adjoint` would get the chebop variety.  We also added a couple of examples in the `chebop/adjoint` help text.  This goes part way to addressing #2037, without yet introducing a new Chebfun Example.