### PR TITLE
Loosening singleSignTest tolerance in Chebfun3

### DIFF
--- a/@chebfun3/private/singleSignTest.m
+++ b/@chebfun3/private/singleSignTest.m
@@ -15,7 +15,7 @@ function [ss, wzero, ispos] = singleSignTest(F)
 % Copyright 2016 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-tol = chebfun3eps;
+tol = 2*chebfun3eps;
 ss = false;                  % Assume false
 ispos = false;
 


### PR DESCRIPTION
Adjusting the tolerance in ```@chebfun3/private/singleSignTest.m```. This makes sure that example approx3/ChangeVar3D passes on ALL machines.

At the moment, on the maths machine, when a certain (positive) jacobian is computed at line 43 in the example approx3/ChangeVar3D the minimum returned is -eps, which causes the singleSignTest to fail on the maths machine and consequently a nightly test also fails. 