### PR TITLE
Feature trigpade

### DIFF
--- a/@chebfun/trigpade.m
+++ b/@chebfun/trigpade.m
@@ -25,7 +25,7 @@ function varargout = trigpade(f, m, n, varargin)
 %     [p, q, r] = trigpade(f, 1, 3);
 %     plotcoeffs(f-p./q, '.')
 %   
-%   Compute a type (2, 2) trgonometric Pade approximation of
+%   Compute a type (2, 2) trigonometric Pade approximation of
 %   exp(-80*(x-.5).^2) on [-1, 1]:
 % 
 %     f = chebfun(@(t) exp(-80*(t-.5).^2), 'trig')
@@ -113,12 +113,12 @@ end
 %% Construct the four trigonometric polynomials of Fourier Pade approximaiton
 
 % _d is for denominator, _n is for numerator
-% Denonminator and numerator for the +ve part
+% Denominator and numerator for the +ve part
 tn_p = chebfun(ap, dom, 'coeffs', 'trig' );
 td_p = chebfun(bp, dom, 'coeffs', 'trig' );
 
 
-% denonminator and numerator for the -ve part
+% denominator and numerator for the -ve part
 tn_m = chebfun(am, dom, 'coeffs', 'trig' );
 td_m = chebfun(bm, dom, 'coeffs', 'trig' );
 
@@ -168,7 +168,7 @@ function [ap, bp, am, bm] = laurent_pade(c, m, n, tol)
 %   Compute the Laurent-Pade approximation from the 
 %   given Laurent coefficients in c. 
 %   Inputs: It is assumed that c has the form 
-%   [c{-N}, ..., c_{-1}, c0, c_1, ..., c_{N}].'
+%   [c_{-N}, ..., c_{-1}, c_0, c_1, ..., c_{N}].'
 %   In particular, c has odd length 2N+1
 %   m and n are non-negative integers and tol is 
 %   a tolerance.
@@ -178,7 +178,7 @@ function [ap, bp, am, bm] = laurent_pade(c, m, n, tol)
 %   a_m/b_m form p-/q-
 %   The output vectors are ready to be used by 
 %   the chebfun trig constructor, for example
-%   ap is of the form [..., 0, 0, a_0, a1, a_2, ...]
+%   ap is of the form [..., 0, 0, a_0, a_1, a_2, ...]
 %   while am has the form 
 %   [ ..., a_{-2}, a_{-1}, a_0, 0, 0, ...]. 
 %   Zero padding is also done on each side of the
@@ -193,7 +193,7 @@ end
 % make sure c is a column vector
 c = c(:);
 
-% Middle of the laurent series, location of c_{-1}
+% Middle of the Laurent series, location of c_{-1}
 N = (length(c)-1)/2;
 
 % Handle the special case:
@@ -215,7 +215,7 @@ c_rev = flipud(c);
 
 if ( norm(c-conj(c_rev), inf) < 10*tol )
     % Function is real, don't solve the 
-    % same problem again:
+    % same problem again
     am = conj(ap);
     bm = conj(bp);
 else
@@ -223,7 +223,7 @@ else
     [am, bm] = laurent_approx(c_rev, m, n, N, tol);
 end
 
-% Pad coefficients with zeros:
+% Pad coefficients with zeros
 ap = [zeros(length(ap)-1, 1); ap];
 bp = [zeros(length(bp)-1, 1); bp];
 
@@ -238,11 +238,11 @@ end
 
 function [a, b] = laurent_approx(c, m, n, N, tol)
 
-% Input: It is assumed that the laurent
+% Input: It is assumed that the Laurent
 % coefficients are stored in an array 
 % [c_{-N}, ..., c_{-1}, c_0, c_1, ..., c{N}]
 % and the length of the array is 2N + 1.
-% To convert a laurent index to matlab index
+% To convert a Laurent index to matlab index
 % an offset of N+1 is needed.
 % c_0 is indexed at N + 1
 % c_k is indexed at k + N + 1
@@ -262,7 +262,7 @@ col = c((m+1)+(N+1):(m+n)+(N+1));
 % Each row has n+1 columns
 row = c((m+1)+(N+1):-1:(m+1-n)+(N+1));
 
-% C is of size n x (n+1):
+% C is of size n x (n+1)
 C = toeplitz(col, row);
 
 % It has at least one null vector, which 
@@ -273,7 +273,7 @@ if ( size(b, 2) > 1)
 end
 
 % Normalize b, the derivation following Baker and Graves-Morris
-% requires this nomraliztion 
+% requires this normalization 
 if ( abs(b(1)) < tol )
     error('CHEBFUN:TRIGPADE:laurent_approx', 'denominator zero at the origin detected')
 else
@@ -285,7 +285,7 @@ M = max([m, n]);
 col = c(0+(N+1):M+(N+1));
 col(1) = col(1)/2;
 % C is an (M+1) X (M+1) square matrix
-% Note: it is curcial to say toeplitz(col, col) to 
+% Note: it is crucial to say toeplitz(col, col) to 
 % avoid hermitian formation of the following matrix
 C = toeplitz(col, col);
 C = tril(C);
@@ -299,7 +299,7 @@ end
 function a = chop_coeffs(c, tol)
 % Discard small coeffs from either 
 % end of c using tol, preserving 
-% the maximum fourier mode if asymmetric
+% the maximum Fourier mode if asymmetric
 mid = (length(c)+1)/2;
 nm = mid - find(abs(c)>tol, 1, 'first');
 np = find(abs(c)>tol, 1, 'last') - mid;

--- a/@chebfun/trigpade.m
+++ b/@chebfun/trigpade.m
@@ -44,31 +44,20 @@ dom = f.domain([1, end]);
 
 % Extract the Fourier coefficients of F:
 coeffs  = trigcoeffs(f);
-
-% Index of the middle coefficint:
-c = (length(coeffs)-1)/2;
-
-% Separate the +ve and -ve coefficients
-% _p is for 'plus' and _m is for minus
-coeffs_p = coeffs(c+1:end);
-coeffs_m = coeffs(c+1:-1:1);
-
-% Half the zeroth order coefficient
-coeffs_p(1) = 1/2*coeffs_p(1);
-coeffs_m(1) = 1/2*coeffs_m(1);
-
-% Solve the two Pade approximation problems
-[~, a_p, b_p] = padeapprox(coeffs_p, m, n);
-if ( isreal(f) )
-    % If f is real then the second Pade approximant 
-    % is the conjugate of the first.
-    a_m = conj(a_p);
-    b_m = conj(b_p);    
-else 
-    % If f is not real, then solve the second Pade problem
-    % explicitly
-    [~, a_m, b_m] = padeapprox(coeffs_m, m, n);           
+N = (length(coeffs)-1)/2;
+if ( N ~= round(N) )
+    error('c must have odd length')
 end
+
+% Make sure that we have sufficiently long
+% Laurent series to avoid indexing issues.
+d = 2*max([m, n]) - N;
+if ( d > 0 )
+    % Pad with zeros if this is not the case:
+    coeffs = [zeros(d, 1); coeffs; zeros(d, 1)];    
+end
+
+[a_p, b_p, a_m, b_m] = laurent_pade(coeffs, m, n);
 
 %% Construct the four trigonometric polynomials of Fourier Pade approximaiton
 
@@ -78,8 +67,8 @@ bb_p = [zeros(length(b_p)-1, 1); b_p];
 
 % _d is for denominator, _n is for numerator
 % Denonminator and numerator for the +ve part
-tn_p = chebfun(aa_p, 'coeffs', 'trig' );
-td_p = chebfun(bb_p, 'coeffs', 'trig' );
+tn_p = chebfun(aa_p, dom, 'coeffs', 'trig' );
+td_p = chebfun(bb_p, dom, 'coeffs', 'trig' );
 
 % Pad coefficients with zeros
 aa_m = [zeros(length(a_m)-1, 1); a_m];
@@ -97,14 +86,20 @@ q = td_p.*td_m;
 r_h = @(t) p(t)./q(t);
 
 % Discard the imaginary rounding errors:
-if ( isreal(f) && (norm(imag(p)) + norm(imag(q)) > 100*norm(f)* eps ) )
-	warning('CHEBFUN:CHEBFUN:trigpade:imag', 'imaginary part not negligible.');
-else
-	p = real(p);
-    q = real(q);
-    r_h = @(t) p(t)./q(t);
+tol = 1e-13;
+if ( norm(coeffs - conj(flipud(coeffs)), inf) < tol ) 
+    % The input function is real, check the imaginary part
+    % of the approximation
+    if ( norm(imag(p./q)) > tol )        
+        warning('CHEBFUN:CHEBFUN:trigpade:imag', 'imaginary part not negligible.');
+    else
+        p = real(p);
+        q = real(q);
+        r_h = @(t) p(t)./q(t);
+    end
 end
 
+% Form the outputs
 outArgs = {p, q, r_h, tn_p, td_p, tn_m, td_m};
 if ( nargout <= 1 )
     varargout{1} = r_h;
@@ -115,5 +110,103 @@ else
         'Incorrect number of output arguments.'); 
 end
     
+
+end
+
+%%
+function [a_p, b_p, a_m, b_m] = laurent_pade(c, m, n)
+%   Compute the Laurent-Pade approximation from the 
+%   given Laurent coefficients in c. 
+%   Inputs: It is assumed that c has the form 
+%   [c{-N}, ..., c_{-1}, c0, c_1, ..., c_{N}].'
+%   In particular, c has odd length 2N+1
+%   m and n are non-negative integers
+%
+%   Outputs are the coefficients of Laurent fractions
+%   The coefficients for a_p/b_p form p+/q+
+%   a_m/b_m form p-/q-
+%   The output vectors correspond to polynomials
+%   a(1) + a(2)z + ... + a(m) z^m, etc. The ordering
+%   is sucht that the lowest order coeff is at the 
+%   top of each output vector
+       
+% make sure c is a column vector
+c = c(:);
+
+% Middle of the laurent series, location of c_{-1}
+N = (length(c)-1)/2;
+
+% Handle the special case:
+if ( n == 0 )
+    b_p = 1;
+    b_m = 1;
+    a_p = c(N+1:N+1+m);
+    a_m = c(N+1:-1:N+1-m);
+    a_p(1) = a_p(1)/2;
+    a_m(1) = a_m(1)/2;
+    return
+end
+
+% Compute one sided Laurent approximation
+[a_m, b_m] = laurent_approx(c, m, n, N);
+c_rev = flipud(c);
+
+if ( norm(c-conj(c_rev), inf) < 1e-13 )
+    % Function is real, don't solve the 
+    % same problem again:
+    a_p = conj(a_m);
+    b_p = conj(b_m);
+else
+    % Compute the second Laurent approximation
+    [a_p, b_p] = laurent_approx(c_rev, m, n, N);
+end
+
+end
+
+function [a, b] = laurent_approx(c, m, n, N)
+
+% Input: It is assumed that the laurent
+% coefficients are stored in an array 
+% [c_{-N}, ..., c_{-1}, c_0, c_1, ..., c{N}]
+% and the length of the array is 2N + 1.
+% To convert a laurent index to matlab index
+% an offset of N+1 is needed.
+% c_0 is indexed at N + 1
+% c_k is indexed at k + N + 1
+% c_{-N} is indexed 1
+% c_{N} is indexed at 2N+1
+% 
+% m, n are non-negative integers
+%
+% Output: a and b are vectors with coefficents 
+% for a Pade approximation of the negative 
+% coefficients within c
+
+% Each column has n rows
+col = c((m+1)+(N+1):(m+n)+(N+1));
+
+% Each row has n+1 columns
+row = c((m+1)+(N+1):-1:(m+1-n)+(N+1));
+
+% C is of size n x (n+1):
+C = toeplitz(col, row);
+
+% It has at least one null vector, which 
+% forms the coefficents of the denominator
+b = null(C);
+if ( size(b, 2) > 1)
+    b = b(:, 1);
+end
+
+% Compute the coefficients of the numerator
+M = max([m, n]);
+col = c(0+(N+1):M+(N+1));
+col(1) = col(1)/2;
+% C is an (M+1) X (M+1) square matrix
+C = toeplitz(col);
+C = tril(C);
+% Make sure bb has length M+1
+bb = [b; zeros(M+1-length(b), 1)];
+a = C*bb;
 
 end

--- a/@chebfun/trigpade.m
+++ b/@chebfun/trigpade.m
@@ -1,0 +1,114 @@
+function varargout = trigpade(f, m, n, varargin)
+%TRIGPADE   Trigonometric (Fourier) Pade approximation.
+%   [P, Q, R_HANDLE] = TRIGPADE(F, M, N) computes trigonometric polynomials 
+%   P and Q of degree M and N, respectively, such that the trigonometric 
+%   rational function P/Q is the type (M,N) Fourier-Pade approximation of 
+%   the CHEBFUN F. That is, the Fourier series of P/Q coincides with that 
+%   for the CHEBFUN F up to the maximum possible order for the polynomial 
+%   degrees permitted. R_HANDLE is a function handle for evaluating the 
+%   trigonometric rational function.
+% 
+%   [P, Q, R_HANDLE, TN_P, TD_P, TN_M, TD_M] = TRIGPADE(F, M, N) also
+%   returns the four trigonometric polynomials TN_P, TD_P, TN_M and TD_M
+%   such that P/Q = TN_P./TD_P + TN_M./TD_M.
+
+%   In both of the above cases, if only one output argument is specified
+%   then R_HANDLE is returned, while P and Q are returned if two or more 
+%   output arguments are specified. 
+%
+%   References:
+%
+%   [1] G. A. Baker and P. R. Graves-Morris. Pade Approximants. 
+%   Cambridge University Press, second edition, 1996.
+%
+%   [2] M. Javed. Algorithms for trigonometric polynomial and rational 
+%   approximation. DPhil thesis, Oxford.
+%
+% See also PADEAPPROX and CHEBPADE
+
+% Copyright 2017 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+
+if ( isempty(f) )
+    varargout{1} = f;
+    return
+end
+
+dom = f.domain([1, end]);
+
+% Extract the Fourier coefficients of F:
+coeffs  = trigcoeffs(f);
+
+% Index of the middle coefficint:
+c = (length(coeffs)-1)/2;
+
+% Separate the +ve and -ve coefficients
+% _p is for 'plus' and _m is for minus
+coeffs_p = coeffs(c+1:end);
+coeffs_m = coeffs(c+1:-1:1);
+
+% Half the zeroth order coefficient
+coeffs_p(1) = 1/2*coeffs_p(1);
+coeffs_m(1) = 1/2*coeffs_m(1);
+
+% Solve the two Pade approximation problems
+[~, a_p, b_p] = padeapprox(coeffs_p, m, n);
+if ( isreal(f) )
+    % If f is real then the second Pade approximant 
+    % is the conjugate of the first.
+    a_m = conj(a_p);
+    b_m = conj(b_p);    
+else 
+    % If f is not real, then solve the second Pade problem
+    % explicitly
+    [~, a_m, b_m] = padeapprox(coeffs_m, m, n);           
+end
+
+%% Construct the four trigonometric polynomials of Fourier Pade approximaiton
+
+% Pad coefficients with zeros:
+aa_p = [zeros(length(a_p)-1, 1); a_p];
+bb_p = [zeros(length(b_p)-1, 1); b_p];
+
+% _d is for denominator, _n is for numerator
+% Denonminator and numerator for the +ve part
+td_p = chebfun(aa_p, 'coeffs', 'trig' );
+tn_p = chebfun(bb_p, 'coeffs', 'trig' );
+
+% Pad coefficients with zeros
+aa_m = [zeros(length(a_m)-1, 1); a_m];
+aa_m = flipud(aa_m);
+bb_m = [zeros(length(b_m)-1, 1); b_m];
+bb_m = flipud(bb_m);
+
+% denonminator and numerator for the -ve part
+td_m = chebfun(aa_m, dom, 'coeffs', 'trig' );
+tn_m = chebfun(bb_m, dom, 'coeffs', 'trig' );
+
+% Construct the full approximation:
+p = td_p.*tn_m + td_m.*tn_p; 
+q = tn_p.*tn_m;
+r_h = @(t) p(t)./q(t);
+
+% Discard the imaginary rounding errors:
+if ( isreal(f) && (norm(imag(p)) + norm(imag(q)) > 100*norm(f)* eps ) )
+	warning('Chebfun:trigpade:imag', 'imaginary part not negligible.');
+else
+	p = real(p);
+    q = real(q);
+    r_h = @(t) p(t)./q(t);
+end
+
+outArgs = {p, q, r_h, tn_p, td_p, tn_m, td_m};
+if ( nargout <= 1 )
+    varargout{1} = r_h;
+elseif ( nargout <= 7 )
+    [varargout{1:nargout}] = outArgs{1:nargout};
+else
+    error('CHEBFUN:CHEBFUN:trigpade:nargout', ...
+        'Incorrect number of output arguments.'); 
+end
+    
+
+end

--- a/@chebfun/trigpade.m
+++ b/@chebfun/trigpade.m
@@ -135,6 +135,10 @@ end
 
 pk = conv(ap, bm) + conv(am, bp);
 qk = conv(bm, bp);
+% discard small coeffs:
+pk = chop_coeffs(pk, tol);
+qk = chop_coeffs(qk, tol);
+
 p = chebfun(pk, dom, 'coeffs', 'trig');
 q = chebfun(qk, dom, 'coeffs', 'trig');
 p = simplify(p);
@@ -158,8 +162,6 @@ if ( norm(coeffs - conj(flipud(coeffs)), inf) < tol )
 end
 
 end
-
-
 
 %%
 function [ap, bp, am, bm] = laurent_pade(c, m, n, tol)
@@ -218,7 +220,7 @@ if ( norm(c-conj(c_rev), inf) < 10*tol )
     bm = conj(bp);
 else
     % Compute the second Laurent approximation
-    [am, bm] = laurent_approx(c_rev, m, n, N);
+    [am, bm] = laurent_approx(c_rev, m, n, N, tol);
 end
 
 % Pad coefficients with zeros:
@@ -291,4 +293,16 @@ C = tril(C);
 bb = [b; zeros(M+1-length(b), 1)];
 a = C*bb;
 
+end
+
+
+function a = chop_coeffs(c, tol)
+% Discard small coeffs from either 
+% end of c using tol, preserving 
+% the maximum fourier mode if asymmetric
+mid = (length(c)+1)/2;
+nm = mid - find(abs(c)>tol, 1, 'first');
+np = find(abs(c)>tol, 1, 'last') - mid;
+nn = max([nm, np]);
+a = c(mid-nn:mid+nn);
 end

--- a/tests/chebfun/test_trigpade.m
+++ b/tests/chebfun/test_trigpade.m
@@ -93,7 +93,34 @@ pass(24) = length(p) <= 2*m + 1;
 pass(25) = length(q) <= 2*n + 1;
 
 
+%% Ex 1 p. 381, Baker 1996 Pade Approximant
+N = 16;
+h = 1/9;k = 1/h+1;
+b = 2; c = 1;
+c_p = h.^(1:N).';
+c_m = k.^(-N:-1).';
+c_k = [c_m; b+c; c_p];
+f = chebfun(c_k, 'coeffs', 'trig');
+m = 1;
+n = 2;
+[p, q] = trigpade(f, m, n);
+r = p./q;
+pass(26) = norm(f-r, inf) < tol;
+% degree of q should be reduced
+pass(27) = length(q) == 2*(n-1)+1; 
+pass(28) = length(p) == 2*m+1;
 
+
+%% Test a complex valued function
+f = chebfun(@(t) 1i./(1+25*sin(pi*(t+.5)/2).^2) + exp(sin(3*pi*t)+cos(pi*t)), 'trig');
+m = 1; n = 3;
+[p, q] = trigpade(f, m, n);
+r = p./q;
+pass(29) = compare_coeffs(f, r, m+n, tol);
+m = 5; n = 2;
+[p, q] = trigpade(f, m, n);
+r = p./q;
+pass(30) = compare_coeffs(f, r, m+n, tol);
 end
 
 

--- a/tests/chebfun/test_trigpade.m
+++ b/tests/chebfun/test_trigpade.m
@@ -6,12 +6,13 @@ if ( nargin < 1 )
 end
 
 % Set an error tolerance.
-tol = 1.0e-12;
+tol = 1.0e-13;
 
 %% check for emptiness:
 p = trigpade(chebfun);
 pass(1) = isempty(p);
 
+%%
 f = chebfun(@(t) sin(pi*t), 'trig');
 [p, q, r] = trigpade(f, 1, 0);
 pass(2) = length(p) == 3;
@@ -45,10 +46,11 @@ pass(10) = length(q) == 3;
 r = p./q;
 pass(11) = norm(f-r, inf) < tol;
 
-%% Check another periodic function
+%% Check another periodic function 
 f = chebfun(@(t) exp(sin(pi*t)), 'trig');
 m = 15;
 n = 3;
 [p, q, r_h] = trigpade(f, m, n);
 pass(12) = norm(f-p./q, inf) < tol;
+
 end

--- a/tests/chebfun/test_trigpade.m
+++ b/tests/chebfun/test_trigpade.m
@@ -14,15 +14,19 @@ pass(1) = isempty(p);
 
 %%
 f = chebfun(@(t) sin(pi*t), 'trig');
-[p, q, r] = trigpade(f, 1, 0);
-pass(2) = length(p) == 3;
-pass(3) = length(q) == 1;
+m = 1; n = 0;
+[p, q, r] = trigpade(f, m, n);
+tt = -1+2*rand(100,1);
+pass(2) = length(p) <= 2*m+1;
+pass(3) = length(q) <= 2*n+1;
 pass(4) = norm(p./q - f, inf) < tol;
-[p, q, r, s, t, u, v] = trigpade(f, 1, 0);
-pass(5) = length(p) == 3 && length(q) == 1;
-pass(6) = length(s) == 3 && length(t) == 1;
-pass(7) = length(u) == 3 && length(v) == 1;
-pass(8) = norm(p./q - (s./t + u./v), inf) < tol; 
+pass(5) = norm(f(tt) - r(tt), inf) < tol;
+[p, q, r, s, t, u, v] = trigpade(f, m, n);
+pass(6) = length(p) <= 2*m+1 && length(q) <= 2*n+1;
+pass(7) = length(s) <= 2*m+1 && length(t) <= 2*n+1;
+pass(8) = length(u) <= 2*m+1 && length(v) <= 2*n+1;
+pass(9) = norm(p./q - (s./t + u./v), inf) < tol; 
+pass(10) = norm(f(tt) - r(tt), inf) < tol;
 
 %%
 % Ex 1 p. 381, Baker 1996 Pade Approximant
@@ -37,20 +41,89 @@ coeffs = [c_m; b+c; c_p];
 f = chebfun(coeffs, 'coeffs', 'trig');
 m = 1;
 n = 2;
-[p, q, rh] = trigpade(f, m, n);
+[p, q] = trigpade(f, m, n);
 % approximation has defect, make sure this 
 % is detected:
-pass(9) = length(p) == 3;
-pass(10) = length(q) == 3;
+pass(11) = length(p) == 3;
+pass(12) = length(q) == 3;
 % We should reproduce f:
 r = p./q;
-pass(11) = norm(f-r, inf) < tol;
+pass(13) = norm(f-r, inf) < tol;
 
 %% Check another periodic function 
 f = chebfun(@(t) exp(sin(pi*t)), 'trig');
-m = 15;
-n = 3;
+m = 8;
+n = 8;
 [p, q, r_h] = trigpade(f, m, n);
-pass(12) = norm(f-p./q, inf) < tol;
+pass(14) = norm(f-p./q, inf) < tol;
+pass(15) = norm(f(tt)-r_h(tt), inf) < tol;
+
+
+%% Explicitly test the case when m < n
+f = chebfun(@(t) 1./(1+sin(pi*(t-.8)/2).^2), 'trig');
+m = 0; n = 1;
+[p, q] = trigpade(f, m, n);
+pass(16) = length(p) == 1;
+pass(17) = length(q) == 3;
+pass(18) = norm(f-p./q, inf) < tol;
+
+%% Test another function
+f = chebfun(@(t) exp(sin(3*pi*t)+cos(pi*t)), 'trig');
+m = 5; n = 15;
+[p, q] = trigpade(f, m, n);
+r = p./q;
+pass(19) = compare_coeffs(f, r, m+n, tol);
+
+%% And another function
+fh = @(x) (-x+0.7)/(1+0.7).*(x<0.7) + (x-0.7)/(1-0.7).*(x>=0.7);
+f = chebfun(fh, 1001, 'trig');
+m = 5; n = 5;
+[p, q] = trigpade(f, m, n);
+r = p./q;
+pass(20) = compare_coeffs(f, r, m + n, 100*tol);
+pass(21) = length(p) <= 2*m + 1;
+pass(22) = length(q) <= 2*n + 1;
+
+%% test m < n again
+m = 2; n = 7;
+[p, q] = trigpade(f, m, n);
+r = p./q;
+pass(23) = compare_coeffs(f, r, m + n, 100*tol);
+pass(24) = length(p) <= 2*m + 1;
+pass(25) = length(q) <= 2*n + 1;
+
+
 
 end
+
+
+function out = compare_coeffs(f, g, n, tol)
+% Compare 2n+1 coeffs from the middle in
+% periodic chebfuns f and g upto a tolerance tol
+c1 = f.coeffs;
+c2 = g.coeffs;
+
+l1 = (length(c1)-1)/2;
+l2 = (length(c2)-1)/2;
+
+% pad with zeros and make them of equal lengths
+if ( l1 > l2 )
+    c2 = [zeros(l1-l2, 1); c2; zeros(l1-l2, 1)];
+else
+    c1 = [zeros(l2-l1, 1); c1; zeros(l2-l1, 1)];
+end
+
+if ( length(c1) ~= length(c2) )
+    error( 'must have same length')
+end
+
+% test the coefficients
+l = (length(c1)+1)/2;
+if (n > l-1)
+    out = norm(c1-c2, inf) < tol;
+else
+    out = norm(c1(l-n:l+n) - c2(l-n:l+n), inf) < tol;
+end
+
+end
+

--- a/tests/chebfun/test_trigpade.m
+++ b/tests/chebfun/test_trigpade.m
@@ -1,0 +1,54 @@
+% Test for trigpade.m.
+function pass = test_trigpade(pref)
+
+if ( nargin < 1 )
+    pref = chebfunpref();
+end
+
+% Set an error tolerance.
+tol = 1.0e-12;
+
+%% check for emptiness:
+p = trigpade(chebfun);
+pass(1) = isempty(p);
+
+f = chebfun(@(t) sin(pi*t), 'trig');
+[p, q, r] = trigpade(f, 1, 0);
+pass(2) = length(p) == 3;
+pass(3) = length(q) == 1;
+pass(4) = norm(p./q - f, inf) < tol;
+[p, q, r, s, t, u, v] = trigpade(f, 1, 0);
+pass(5) = length(p) == 3 && length(q) == 1;
+pass(6) = length(s) == 3 && length(t) == 1;
+pass(7) = length(u) == 3 && length(v) == 1;
+pass(8) = norm(p./q - (s./t + u./v), inf) < tol; 
+
+%%
+% Ex 1 p. 381, Baker 1996 Pade Approximant
+h = 1/9;
+k = 1/h;
+b = 2;
+c = 1;
+N = 16;
+c_p = h.^(1:N).';
+c_m = k.^(-N:-1).';
+coeffs = [c_m; b+c; c_p];
+f = chebfun(coeffs, 'coeffs', 'trig');
+m = 1;
+n = 2;
+[p, q, rh] = trigpade(f, m, n);
+% approximation has defect, make sure this 
+% is detected:
+pass(9) = length(p) == 3;
+pass(10) = length(q) == 3;
+% We should reproduce f:
+r = p./q;
+pass(11) = norm(f-r, inf) < tol;
+
+%% Check another periodic function
+f = chebfun(@(t) exp(sin(pi*t)), 'trig');
+m = 15;
+n = 3;
+[p, q, r_h] = trigpade(f, m, n);
+pass(12) = norm(f-p./q, inf) < tol;
+end

--- a/trigratinterp.m
+++ b/trigratinterp.m
@@ -79,6 +79,12 @@ nu = (length(bc) - 1)/2;
 % function handle for evaluating the rational approximation.
 [p, q, r] = constructTrigRatApprox(ac, bc, dom, ts);
 
+% Normalize q to 1 if a type (m, 0) approximation is computed
+if ( n == 0 || nu == 0 )
+    p = p./q;
+    q = q./q;
+end
+
 % Compute poles and residues if requested.
 poles = [];
 residues = [];


### PR DESCRIPTION
This branch implements trigonometric Pade approximation of a periodic Chebfun.

Try the following code for fun, which compares the best trigonometric type (2,2) approximation of abs(x) with its type(2,2) trigonometric Pade approximation.

```
LW = 'linewidth';
FS = 'fontsize';
t = chebfun('t');
f = abs(t);
fh = @(t) abs(t);
ft = chebfun(fh, 'trunc', 21, 'trig');
m = 2;
n = 2;
[p, q, ~] = trigpade(ft, m, n);
[p_r, q_r, ~, e] = trigremez(f, m, n);
r_p = p./q;
r_r = p_r./q_r;
subplot(2, 1, 1)
plot(f, 'k', LW, 1.2)
hold on
plot(r_p, 'r', LW, 1.2)
plot(r_r, 'b', LW, 1.2)
legend('|\theta|', 'trigpade(f,2,2)', 'trigremez(f,2,2)')
hold off
grid on
str = '$f(x) = |\theta|$, \verb|trigpade(f,2,2)| and \verb|trigremez(f,2,2)|';
h = title(str, FS, 11);
set(h, 'interpreter', 'latex')
h = xlabel('$\theta$', FS, 11);
set(h, 'interpreter', 'latex');

subplot(2, 1, 2)
e_p = f-r_p;
plot(e_p, 'r', LW, 1.2)
hold on
e_r = f-r_r;
plot(e_r, 'b', LW, 1.2)
legend('trigpade', 'trigremez')
str = sprintf('\\verb|trigpade| error: $%.5e$, \\verb|trigremez| error: $%.5e$', norm(e_p, inf), norm(e_r, inf));
h = title(str, FS, 11);
set(h, 'interpreter', 'latex')
h = xlabel('$\theta$', FS, 11);
set(h, 'interpreter', 'latex');
hold off
grid on
```
![pade](https://cloud.githubusercontent.com/assets/890964/21650468/f73401b2-d29c-11e6-8bc6-3f13dffaf57b.jpg)


