### PR TITLE
improve accuracy in Chebfun2/roots

### DIFF
--- a/@separableApprox/roots.m
+++ b/@separableApprox/roots.m
@@ -3,11 +3,11 @@ function r = roots( f, g, varargin )
 %   R = ROOTS(F), returns the zero contours of F as a quasimatrix of chebfuns.
 %   Each column of R is one zero contour. This command only finds contours when
 %   there is a change of sign and it can also group intersecting contours in a
-%   non-optimal way. Contours are computed to, roughly, four digits of
+%   non-optimal way. Contours are computed to, roughly, eight digits of
 %   precision. In particular, this command cannot reliably compute isolated real
 %   roots of F or zero curves lying close to the boundary of the domain. 
 %
-%   In the special case when F is of length 1 then the zero contours are found
+%   In the special case when F is of length 1, the zero contours are found
 %   to full precision.
 %
 %   R = ROOTS(F, G) returns the isolated points of F and G.
@@ -31,13 +31,13 @@ if ( isempty( f ) )
     return
 end 
 
-tol = 1e-7; % Go for seven digits.
+tol = 1e-10; % Go for ten digits. 
 dom = f.domain;
 
 if ( nargin == 1 )
     
     if ( length( f ) == 1 )  
-        % The SEPARABLEAPPROX is rank 1:
+        % The SEPARABLEAPPROX is of rank 1:
         
         cols = f.cols;
         rows = f.rows;
@@ -63,9 +63,9 @@ if ( nargin == 1 )
         % Function is real-valued.
         
         % Use Matlab's contourc function (Marching Squares). Note n = 502 is
-        % chosen so that use a grid that does not involve the boundary of the
+        % chosen to use a grid that does not involve the boundary of the
         % domain.
-        n = 502; % disc size.
+        n = 502; % discretization size.
         x = linspace( dom(1), dom(2), n );
         x(1) = []; x(end) = []; 
         y = linspace( dom(3), dom(4), n );
@@ -73,21 +73,35 @@ if ( nargin == 1 )
         [xx, yy] = meshgrid( x, y );
         vals = feval( f, xx, yy );
         C = contourc( x, y, vals, 0*[1 1] );
+        [fx, fy] = grad(f);        
         
         % Store solution in complex-valued CHEBFUNs:
         j = 1; r = chebfun;
         while ( j < length(C) )
             k = j + C(2, j);
             D = C(:, j+1:k);
-            Dc = ( D(1, :) + 1i*(D(2, :)+realmin) ).';
-	    s = [0; cumsum(abs(diff(Dc)))];   % empirical arc length
-	    s = 2*s/s(end) - 1;               % for better interpolation
-	    chebgrid = chebpts(length(Dc));
+            Dc = ( D(1, :) + 1i*(D(2, :)+realmin) ).';            
+            
+        % Take one Newton step to improve curve data
+            fxval = feval( fx, D(1,:), D(2,:) );
+            fyval = feval( fy, D(1,:), D(2,:) );        
+            gradf = fxval + 1i*fyval; 
+            fval = feval( f, D(1,:), D(2,:) );                                                
+            Dcnew = Dc - fval.*( gradf./abs(gradf).^2 );
+            fvalnew = feval( f, real(Dcnew), imag(Dcnew) );  
+            failures = find(abs(fval) < abs(fvalnew));
+            Dcnew(failures) = Dc(failures);
+            Dc = Dcnew; 
+            
+        % Empirical arc length for better interpolation
+    	    s = [0; cumsum(abs(diff(Dc)))];   
+    	    s = 2*s/s(end) - 1;               
+    	    chebgrid = chebpts(length(Dc));
             newdata = interp1(s, Dc, chebgrid, 'spline');
-            f = chebfun( newdata );
-            f = simplify( f, tol, 'globaltol' );
+            fnew = chebfun( newdata );            
+            fnew = simplify( fnew, tol, 'globaltol' );
             j = k + 1;
-            r = [ r , f ];
+            r = [ r , fnew ];
         end
     else
         % Function is complex-valued.

--- a/@separableApprox/roots.m
+++ b/@separableApprox/roots.m
@@ -25,14 +25,13 @@ function r = roots( f, g, varargin )
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-
 % Check for empty:
 if ( isempty( f ) )
     r = []; 
     return
 end 
 
-tol = 1e-5; % Go for five digits.
+tol = 1e-7; % Go for seven digits.
 dom = f.domain;
 
 if ( nargin == 1 )
@@ -43,7 +42,7 @@ if ( nargin == 1 )
         cols = f.cols;
         rows = f.rows;
         yrts = 1i*(roots( cols )+realmin);  
-        xrts = roots( rows ) + realmin*1i; % Add complex to ensure its not real
+        xrts = roots( rows ) + realmin*1i; % Add complex to ensure it's not real
         r = chebfun; 
         % Go though col(yrts) = 0, make into a horizontal line: 
         dom = rows.domain;
@@ -80,7 +79,12 @@ if ( nargin == 1 )
         while ( j < length(C) )
             k = j + C(2, j);
             D = C(:, j+1:k);
-            f = chebfun( (D(1,:) +  1i*(D(2,:)+realmin)).' );
+            Dc = ( D(1, :) + 1i*(D(2, :)+realmin) ).';
+	    s = [0; cumsum(abs(diff(Dc)))];   % empirical arc length
+	    s = 2*s/s(end) - 1;               % for better interpolation
+	    chebgrid = chebpts(length(Dc));
+            newdata = interp1(s, Dc, chebgrid, 'spline');
+            f = chebfun( newdata );
             f = simplify( f, tol, 'globaltol' );
             j = k + 1;
             r = [ r , f ];

--- a/tests/chebfun2/test_roots.m
+++ b/tests/chebfun2/test_roots.m
@@ -45,7 +45,7 @@ pass(6) = abs(area - pi/4) < 1e-3;
 f = chebfun2( @(x,y) x.^2 + (10*y).^2 - 1/4 );
 c = roots(f);
 arclength = sum(abs(diff(c)));
-pass(7) = abs(arclength - 2.03199) < 1e-2;
+pass(7) = abs(arclength -   2.031987090050447) < 1e-3;
 
 area = abs(sum(real(c).*diff(imag(c))));
 pass(8) = abs(area - pi/40) < 1e-3;

--- a/tests/chebfun2/test_roots.m
+++ b/tests/chebfun2/test_roots.m
@@ -15,12 +15,10 @@ r = roots( f );
 exact = chebfun( @(x) 1i*x + 1/2 );
 pass(2) = ( norm( r - exact ) < tol );
 
-
 f = chebfun2( @(x,y) x.*y);
 r = roots( f );
 exact = chebfun( @(x) [x, 1i*x]  );
 pass(3) = ( norm( r - exact ) < tol );
-
 
 f = chebfun2( @(x,y) cos(5*pi*x));
 s = roots( squeeze( f ) );
@@ -35,5 +33,21 @@ f = chebfun2( @(x,y) x.*(y-1/2), [-2 2 -3 5]);
 r = roots( f );
 exact = [chebfun( @(x) 2*x + 1i/2 ) chebfun(@(x) 1i*(4*(x+1)-3) )];
 pass(5) = ( norm( r - exact ) < tol );
+
+f = chebfun2( @(x,y) x.^2 + y.^2 - 1/4 );
+c = roots(f);
+arclength = sum(abs(diff(c)));
+pass(6) = abs(arclength - pi) < 1e-3;
+
+area = abs(sum(real(c).*diff(imag(c))));
+pass(6) = abs(area - pi/4) < 1e-3;
+
+f = chebfun2( @(x,y) x.^2 + (10*y).^2 - 1/4 );
+c = roots(f);
+arclength = sum(abs(diff(c)));
+pass(7) = abs(arclength - 2.03199) < 1e-2;
+
+area = abs(sum(real(c).*diff(imag(c))));
+pass(8) = abs(area - pi/40) < 1e-3;
 
 end


### PR DESCRIPTION
I've just changed half a dozen lines in separableApprox/roots to compute an empirical arc length before interpolating to the Chebyshev grid, to handle non-smoothly spaced data.  This seems to improve accuracy of arc length and area coefficients by several digits.  For example (see `tests/chebfun2/test_roots`), the sequence
```
f = chebfun2( @(x,y) x.^2 + y.^2 - 1/4 );
c = roots(f);
arclength = sum(abs(diff(c)));
area = abs(sum(real(c).*diff(imag(c))));
```
used to give 2 digits of accuracy and now it is 5 digits.  A discussion of this mathematics can be found in the Chebfun team dropbox folder as Chebfun2Roots.pdf.

It would be nice if somebody could review this quickly as it's short and kathryn.gillow@maths.ox.ac.uk would like to take advantage of this feature.
