### PR TITLE
Feature randnfun

### DIFF
--- a/randnfun.m
+++ b/randnfun.m
@@ -1,26 +1,33 @@
-function f = randnfun(dt, dom)
+function f = randnfun(dt, n, dom)
 %RANDNFUN   Random smooth function
-%   F = RANDNFUN(DT) returns a smooth chebfun on [-1,1] with space
-%   scale DT and standard normal distribution N(0,1) at each point.
-%   It can be regarded as a sample path of a Gaussian process.
-%   F is obtained by calling RANDNFUNTRIG on an interval of about
-%   twice the length and restricting the result to [-1,1].
+%   F = RANDNFUN(DT) returns a smooth chebfun on [-1,1] with maximum
+%   wave number about 2pi/DT and standard normal distribution N(0,1)
+%   at each point.  F can be regarded as one sample path of a Gaussian
+%   process.  F is obtained by calling RANDNFUNTRIG on an interval
+%   of about twice the length and restricting the result to [-1,1].
 %
-%   F = RANDNFUN(DT, DOM) returns a random chebfun on DOM = [A, B].
+%   F = RANDNFUN(DT, N) returns a quasimatrix with N independent columns.
 %
-% Example:
-%   f = randnfun(0.1);
-%   std(f)
-%   plot(f)
+%   F = RANDNFUN(DT, N, DOM) returns a result with domain DOM = [A, B].
+%
+% Examples:
+%
+%   f = randnfun(0.1); std(f), plot(f)
 %   plotcoeffs(f, '.'), xlim([0 200])
+%
+%   X = randnfun(.01,2); cov(X)
 %
 % See also RANDNFUNTRIG.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.
 
-if nargin == 1
-    dom = [-1 1];
+if nargin < 3
+    dom = [-1 1];     % default domain
+end
+
+if nargin < 2
+    n = 1;            % default number of columns
 end
 
 % Call RANDNFUNTRIG on interval of approximately double length.
@@ -28,5 +35,5 @@ end
 
 m = 2*round(diff(dom)/dt)+1;
 dom2 = dom(1) + [0 m*dt];
-f = randnfuntrig(dt, dom2);
+f = randnfuntrig(dt, n, dom2);
 f = f{dom(1),dom(2)};

--- a/randnfun.m
+++ b/randnfun.m
@@ -1,0 +1,32 @@
+function f = randnfun(dt, dom)
+%RANDNFUN   Random smooth function
+%   F = RANDNFUN(DT) returns a smooth chebfun on [-1,1] with space
+%   scale DT and standard normal distribution N(0,1) at each point.
+%   It can be regarded as a sample path of a Gaussian process.
+%   F is obtained by calling RANDNFUNTRIG on an interval of about
+%   twice the length and restricting the result to [-1,1].
+%
+%   F = RANDNFUN(DT, DOM) returns a random chebfun on DOM = [A, B].
+%
+% Example:
+%   f = randnfun(0.1);
+%   std(f)
+%   plot(f)
+%   plotcoeffs(f, '.'), xlim([0 200])
+%
+% See also RANDNFUNTRIG.
+
+% Copyright 2017 by The University of Oxford and The Chebfun Developers. 
+% See http://www.chebfun.org/ for Chebfun information.
+
+if nargin == 1
+    dom = [-1 1];
+end
+
+% Call RANDNFUNTRIG on interval of approximately double length.
+% and then restrict the result to the prescribed interval.
+
+m = 2*round(diff(dom)/dt)+1;
+dom2 = dom(1) + [0 m*dt];
+f = randnfuntrig(dt, dom2);
+f = f{dom(1),dom(2)};

--- a/randnfuntrig.m
+++ b/randnfuntrig.m
@@ -1,27 +1,34 @@
-function f = randnfuntrig(dt, dom)
+function f = randnfuntrig(dt, n, dom)
 %RANDNFUNTRIG   Random smooth periodic function
 %   F = RANDNFUNTRIG(DT) returns a smooth periodic chebfun (trigfun)
-%   on [-1,1] with space scale DT and standard normal distribution
-%   N(0,1) at each point.  It can be regarded as a sample path of a
-%   Gaussian process.  F is obtained from a finite Fourier series with
-%   independent normally distributed coefficients of equal variance.
+%   on [-1,1] with maximum wave number about 2pi/DT and standard normal
+%   distribution N(0,1) at each point.  F can be regarded as one sample
+%   path of a Gaussian process.  It is obtained from a finite Fourier series
+%   with independent normally distributed coefficients of equal variance.
+%   (This code is preliminary and the definition may change in the future.)
 %
-%   F = RANDNFUNTRIG(DT, DOM) returns a random periodic chebfun on
-%   the interval DOM = [A, B].
+%   F = RANDNFUNTRIG(DT, N) returns a quasimatrix with N independent columns.
 %
-% Example:
-%   f = randnfuntrig(0.1);
-%   std(f)
-%   plot(f)
+%   F = RANDNFUNTRIG(DT, N, DOM) returns a result with domain DOM = [A, B].
+%
+% Examples:
+%
+%   f = randnfuntrig(0.1); std(f), plot(f)
 %   plotcoeffs(f, '.'), xlim([-100 100])
+%
+%   X = randnfuntrig(.01,2); cov(X)
 %
 % See also RANDNFUN.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.
 
-if nargin == 1
-    dom = [-1 1];
+if nargin < 3
+    dom = [-1 1];     % default domain
+end
+
+if nargin < 2
+    n = 1;            % default number of columns
 end
 
 % Although the output is real, complex arithmetic is used for the
@@ -29,6 +36,6 @@ end
 % in this case.
 
 m = round(diff(dom)/dt);
-c = randn(2*m+1, 1) + 1i*randn(2*m+1, 1);
+c = randn(2*m+1, n) + 1i*randn(2*m+1, n);
 c = (c + flipud(conj(c)))/2;
 f = chebfun(c/sqrt(2*m+1), dom, 'trig', 'coeffs');

--- a/randnfuntrig.m
+++ b/randnfuntrig.m
@@ -1,0 +1,34 @@
+function f = randnfuntrig(dt, dom)
+%RANDNFUNTRIG   Random smooth periodic function
+%   F = RANDNFUNTRIG(DT) returns a smooth periodic chebfun (trigfun)
+%   on [-1,1] with space scale DT and standard normal distribution
+%   N(0,1) at each point.  It can be regarded as a sample path of a
+%   Gaussian process.  F is obtained from a finite Fourier series with
+%   independent normally distributed coefficients of equal variance.
+%
+%   F = RANDNFUNTRIG(DT, DOM) returns a random periodic chebfun on
+%   the interval DOM = [A, B].
+%
+% Example:
+%   f = randnfuntrig(0.1);
+%   std(f)
+%   plot(f)
+%   plotcoeffs(f, '.'), xlim([-100 100])
+%
+% See also RANDNFUN.
+
+% Copyright 2017 by The University of Oxford and The Chebfun Developers. 
+% See http://www.chebfun.org/ for Chebfun information.
+
+if nargin == 1
+    dom = [-1 1];
+end
+
+% Although the output is real, complex arithmetic is used for the
+% construction since the 'trig', 'coeffs' mode is only documented
+% in this case.
+
+m = round(diff(dom)/dt);
+c = randn(2*m+1, 1) + 1i*randn(2*m+1, 1);
+c = (c + flipud(conj(c)))/2;
+f = chebfun(c/sqrt(2*m+1), dom, 'trig', 'coeffs');

--- a/tests/misc/test_randnfun.m
+++ b/tests/misc/test_randnfun.m
@@ -1,0 +1,20 @@
+function pass = test_randnfun( pref )
+
+if ( nargin == 0 ) 
+    pref = chebfunpref();
+end
+
+rng(0)
+f = randnfun(.01);
+pass(1) = (abs(std(f)-1) < .1);
+pass(2) = (abs(mean(f)) < .1);
+
+rng(0)
+g = randnfun(.01,1,[5,7]);
+pass(3) = (abs((sum(f)-sum(g))) < 1e-3);
+
+A = randnfun(1,10,[0 10]);
+X = cov(A);
+pass(4) = (norm(X-X') == 0);
+
+end

--- a/tests/misc/test_randnfuntrig.m
+++ b/tests/misc/test_randnfuntrig.m
@@ -1,0 +1,23 @@
+function pass = test_randnfuntrig( pref )
+
+if ( nargin == 0 ) 
+    pref = chebfunpref();
+end
+
+rng(0)
+f = randnfuntrig(.01);
+pass(1) = (abs(std(f)-1) < .1);
+pass(2) = (abs(mean(f)) < .1);
+
+rng(0)
+g = randnfuntrig(.01,1,[5,7]);
+pass(3) = ((sum(f)-sum(g)) < 1e-3);
+
+A = randnfuntrig(1,10,[0 10]);
+X = cov(A);
+pass(4) = (norm(X-X') == 0);
+
+f = randnfuntrig(1) + 1i*randnfuntrig(1);
+pass(5) = (abs(f(-.999)-f(.999)) < .1);
+
+end


### PR DESCRIPTION
With discussion with abdullateef.hajiali@maths.ox.ac.uk, I've added new codes 'randn' and 'randfun' in our root directory.  This are continuous analogues of 'randn', producing smooth random functions (periodic or not) with a specified spatial scale DT and domain.  The underlying mathematical ideas may evolve but I am eager to get some of this material into Chebfun to help our explorations and also to help in researching associated questions of stochastic ODEs driven by smooth data and in writing Chapter 12 of _Exploring ODEs_.

These codes are short and should be easy to review.

Questions:

(1) Is this "rectangular window" of Fourier coefficients right, or would Gaussian be better?  (I am speaking here of the covariance function when 'randnfun' is regarded as generating a sample from a Gaussian process.)

(2) Is our method of getting nonperiodic functions by restricting periodic ones good?  Can the unwanted correlations across boundaries that it introduces be quantified?

(3) What are the right rectangle, box, disk, and sphere analogues?  (belyaev@maths.ox.ac.uk) is a local expert at Oxford.)

(4) What literature is there on related methods?