### PR TITLE
Use NaN data for the dummy plot in chebfun.plot().

### DIFF
--- a/@chebfun/plot.m
+++ b/@chebfun/plot.m
@@ -370,8 +370,18 @@ if ( ~verLessThan('matlab', '8.4') )
     set(gca, 'ColorOrderIndex', originalColorOrder);
 end
 
+% Generate data for the dummy plot for the legend.  dummyData is the same as
+% lineData but with the numeric entries replaced by NaNs of suitable dimension
+% so that they don't show up on the plot but are still "active" for the legend.
+dummyData = lineData;
+for i = 1:1:length(dummyData)
+    if ( isnumeric(lineData{i}) )
+        dummyData{i} = NaN(1, size(dummyData{i}, 2));
+    end
+end
+
 % Plot the dummy data, which includes both line and point style:
-hDummy = plot(lineData{:});
+hDummy = plot(dummyData{:});
 if ( ~isempty(lineStyle) || ~isempty(pointStyle) )
     set(hDummy, lineStyle{:}, pointStyle{:});
 end
@@ -416,8 +426,13 @@ set(h1, 'handlevis', 'off');
 set(h2, 'handlevis', 'off');
 set(h3, 'handlevis', 'off');
 set(h4, 'handlevis', 'off');
-% The dummy plot is invisible, but its handle is visible (for LEGEND).
-set(hDummy, 'handlevis', 'on', 'visible', 'off');     %  ¯\_(o.O)_/¯
+
+% Ensure that the both the handle for the dummy plot and the dummy plot itself
+% are visible for LEGEND().  The dummy plot could in theory have its 'Visible'
+% property set to 'off', but the data is NaN, so it doesn't draw anything
+% anyway.  Moreover, if 'Visible' is 'off', the entries in the legend will be
+% grayed out in R2016b and later.
+set(hDummy, 'handlevis', 'on', 'visible', 'on');     %  ¯\_(o.O)_/¯
 
 % Give an output to the plot handles if requested:
 if ( nargout > 0 )


### PR DESCRIPTION
Previously, we just replotted the existing line data and set the plot's
"Visible" property to 'off'.  This doesn't work properly anymore in
R2016b, since MATLAB grays out the legend entries for graphics items
marked invisible.

The fix is easy enough:  we plot NaN data for the dummy plot (but set
the line and point styles appropriately) and leave "Visible" set to
'on'.  MATLAB doesn't draw anything on the plot for NaN data, so we're
good.  A little ugly, but we already use this trick elsewhere for other
things.

Closes #2061.