### PR TITLE
Chebfun2 roots again

### DIFF
--- a/@separableApprox/roots.m
+++ b/@separableApprox/roots.m
@@ -83,16 +83,11 @@ if ( nargin == 1 )  % Seek zero curves of scalar function
         % of the curves component by component, using complex arithmetic
         % for convenience.
         j = 1; r = chebfun;
-%sizeC = size(C)
         while ( j < length(C) )
             k = j + C(2, j);
             D = C(:, j+1:k);
             data = ( D(1, :) + 1i*(D(2, :)+realmin) ).';            
             npts = length(data);
-%plot(data,'.'), hold on
-%data([1 end])
-data = snap(data);
-%data([1 end])
             err = 999; errnew = 1e-2;
             stepno = 0;
             curvenew = chebfun(data);
@@ -100,28 +95,21 @@ data = snap(data);
                 stepno = stepno+1;
                 err = errnew;
                 curve = curvenew;
-%data([1 end])
                 s = [0; cumsum(abs(diff(data)))];    % empirical arclength
                 s = 2*s/s(end) - 1;                  % normalize to [-1,1]
                 data = interp1(s, data, chebpts ...  % interpolate
                     (length(data)), 'spline');
-data = snap(data);
                 curvenew = chebfun(data);            % make chebfun
-                curvenew = simplify(curvenew);       % simplify it
                 data = curvenew(chebpts(npts));      % sample finely
-data = snap(data);   
+                data = snap(data);                   % snap to boundary
                 ff = fval(data);                     % function values
                 g = gradf(data);                     % gradient values
                 errnew = norm(ff,inf)/vscale(f);     % max rel error
-%disp(errnew), % pause
                 data = data - ff.*( g./abs(g).^2 );  % Newton step
                 curvenew = chebfun(data);            % make chebfun
                 curvenew = simplify(curvenew);       % simplify it
-data = snap(data);
             end
             j = k + 1;
-%disp('adding a component')
-%pause
             r = [ r , curve ];
         end
 
@@ -138,7 +126,7 @@ elseif ( isa(g, 'separableApprox') )  % seek zero points of vector function
     
 end
 
-function d = snap(d);      % adjust endpoints to snap to boundary of domain
+function d = snap(d);   % adjust endpoints to snap to boundary of domain
     n = length(d);
     scl = norm(dom,inf);
     dr = real(d); di = imag(d);

--- a/@separableApprox/roots.m
+++ b/@separableApprox/roots.m
@@ -76,11 +76,11 @@ if ( nargin == 1 )  % Seek zero curves of scalar function
         vals = feval( f, xx, yy );
         C = contourc( x, y, vals, 0*[1 1] );
         [fx, fy] = grad(f);        
-        gradf = @(data) feval( fx, real(data), imag(data)) ...;
+        gradf = @(data) feval( fx, real(data), imag(data)) ...
                    + 1i*feval( fy, real(data), imag(data));
         fval = @(data) feval( f, real(data), imag(data));
         
-        % The contruction of chebfuns proceeds by improving the accuracy
+        % The construction of chebfuns proceeds by improving the accuracy
         % of the curves component by component, using complex arithmetic
         % for convenience.
         j = 1; r = chebfun;
@@ -129,7 +129,7 @@ elseif ( isa(g, 'separableApprox') )  % seek zero points of vector function
     
 end
 
-function d = snap(d);   % adjust endpoints to snap to boundary of domain
+function d = snap(d)   % adjust endpoints to snap to boundary of domain
     n = length(d);
 
     if abs(real(d(1))-dom(2)) < .02*scl                 % snap to right bndry

--- a/@separableApprox/roots.m
+++ b/@separableApprox/roots.m
@@ -91,7 +91,7 @@ if ( nargin == 1 )  % Seek zero curves of scalar function
             err = 999; errnew = 1e-2;
             stepno = 0;
             curvenew = chebfun(data);
-            while (errnew < err) && (stepno < 8)
+            while (errnew < err) && (stepno < 6)
                 stepno = stepno+1;
                 err = errnew;
                 curve = curvenew;
@@ -129,16 +129,43 @@ end
 function d = snap(d);   % adjust endpoints to snap to boundary of domain
     n = length(d);
     scl = norm(dom,inf);
-    dr = real(d); di = imag(d);
-    if abs(dr(1)-dom(1))<.02*scl, dr(1) = dom(1); end  % snap to left bndry
-    if abs(dr(n)-dom(1))<.02*scl, dr(n) = dom(1); end
-    if abs(dr(1)-dom(2))<.02*scl, dr(1) = dom(2); end  % snap to right bndry
-    if abs(dr(n)-dom(2))<.02*scl, dr(n) = dom(2); end
-    if abs(di(1)-dom(3))<.02*scl, di(1) = dom(3); end  % snap to bottom bndry
-    if abs(di(n)-dom(3))<.02*scl, di(n) = dom(3); end
-    if abs(di(1)-dom(4))<.02*scl, di(1) = dom(4); end  % snap to top bndry
-    if abs(di(n)-dom(4))<.02*scl, di(n) = dom(4); end
-    d = complex(dr,di);
+
+    if abs(real(d(1))-dom(2)) < .02*scl                 % snap to right bndry
+        dx0 = dom(2)-real(d(2)); dx = real(d(1)-d(2));
+        d(1) = d(2) + (dx0/dx)*(d(1)-d(2));
+    end
+    if abs(real(d(n))-dom(2)) < .02*scl
+        dx0 = dom(2)-real(d(n-1)); dx = real(d(n)-d(n-1));
+        d(n) = d(n-1) + (dx0/dx)*(d(n)-d(n-1));
+    end
+
+    if abs(real(d(1))-dom(1)) < .02*scl                 % snap to left bndry
+        dx0 = dom(1)-real(d(2)); dx = real(d(1)-d(2));
+        d(1) = d(2) + (dx0/dx)*(d(1)-d(2));
+    end
+    if abs(real(d(n))-dom(1)) < .02*scl
+        dx0 = dom(1)-real(d(n-1)); dx = real(d(n)-d(n-1));
+        d(n) = d(n-1) + (dx0/dx)*(d(n)-d(n-1));
+    end
+
+    if abs(imag(d(1))-dom(4)) < .02*scl                 % snap to top bndry
+        dy0 = dom(4)-imag(d(2)); dy = imag(d(1)-d(2));
+        d(1) = d(2) + (dy0/dy)*(d(1)-d(2));
+    end
+    if abs(imag(d(n))-dom(4)) < .02*scl
+        dy0 = dom(4)-imag(d(n-1)); dy = imag(d(n)-d(n-1));
+        d(n) = d(n-1) + (dy0/dy)*(d(n)-d(n-1));
+    end
+
+    if abs(imag(d(1))-dom(3)) < .02*scl                 % snap to bottom bndry
+        dy0 = dom(3)-imag(d(2)); dy = imag(d(1)-d(2));
+        d(1) = d(2) + (dy0/dy)*(d(1)-d(2));
+    end
+    if abs(imag(d(n))-dom(3)) < .02*scl
+        dy0 = dom(3)-imag(d(n-1)); dy = imag(d(n)-d(n-1));
+        d(n) = d(n-1) + (dy0/dy)*(d(n)-d(n-1));
+    end
+
 end
 
 end

--- a/@separableApprox/roots.m
+++ b/@separableApprox/roots.m
@@ -35,6 +35,7 @@ if ( isempty( f ) )
 end 
 
 dom = f.domain;
+scl = norm(dom,inf);
 
 if ( nargin == 1 )  % Seek zero curves of scalar function
     
@@ -87,6 +88,8 @@ if ( nargin == 1 )  % Seek zero curves of scalar function
             k = j + C(2, j);
             D = C(:, j+1:k);
             data = ( D(1, :) + 1i*(D(2, :)+realmin) ).';            
+            ii = find(abs(diff(data)) < 1e-8*scl);
+            data(ii) = [];                           % eliminate repetitions
             npts = length(data);
             err = 999; errnew = 1e-2;
             stepno = 0;
@@ -128,7 +131,6 @@ end
 
 function d = snap(d);   % adjust endpoints to snap to boundary of domain
     n = length(d);
-    scl = norm(dom,inf);
 
     if abs(real(d(1))-dom(2)) < .02*scl                 % snap to right bndry
         dx0 = dom(2)-real(d(2)); dx = real(d(1)-d(2));

--- a/@separableApprox/roots.m
+++ b/@separableApprox/roots.m
@@ -88,22 +88,28 @@ if ( nargin == 1 )  % Seek zero curves of scalar function
             k = j + C(2, j);
             D = C(:, j+1:k);
             data = ( D(1, :) + 1i*(D(2, :)+realmin) ).';            
-            data = snap2boundary(data);
+data([1 end])
+data = snap(data);
+data([1 end])
             err = 999; errnew = 1e-2;
             while errnew < err                           
                 err = errnew;
                 curve = chebfun(data);               % make chebfun
+data([1 end])
                 s = [0; cumsum(abs(diff(data)))];    % empirical arclength
                 s = 2*s/s(end) - 1;                  % normalize to [-1,1]
                 data = interp1(s, data, chebpts ...  % interpolate
                     (length(data)), 'spline');
+%data = snap(data);
                 curve = chebfun(data);               % make chebfun
                 curve = simplify(curve);             % simplify it
                 data = curve(chebpts(1000));         % sample finely
+%data = snap(data);   
                 ff = fval(data);                     % function values
                 g = gradf(data);                     % gradient values
-                errnew = norm(ff,inf);               % max error
+                errnew = norm(ff,inf), pause         % max error
                 data = data - ff.*( g./abs(g).^2 );  % Newton step
+%data = snap(data);
             end
             j = k + 1;
             r = [ r , curve ];
@@ -122,7 +128,7 @@ elseif ( isa(g, 'separableApprox') )  % seek zero points of vector function
     
 end
 
-function d = snap2boundary(d);
+function d = snap(d);      % adjust endpoints to snap to boundary of domain
     n = length(d);
     dr = real(d); di = imag(d);
     if abs(dr(1)-dom(1))<.02, dr(1) = dom(1); end  % snap to left boundary

--- a/@separableApprox/roots.m
+++ b/@separableApprox/roots.m
@@ -1,44 +1,45 @@
 function r = roots( f, g, varargin )
-%ROOTS   Zero contours of a SEPARABLEAPPROX.
-%   R = ROOTS(F), returns the zero contours of F as a quasimatrix of chebfuns.
-%   Each column of R is one zero contour. This command only finds contours when
-%   there is a change of sign and it can also group intersecting contours in a
-%   non-optimal way. Contours are computed to, roughly, eight digits of
-%   precision. In particular, this command cannot reliably compute isolated real
-%   roots of F or zero curves lying close to the boundary of the domain. 
+%ROOTS   Zeros of a SEPARABLEAPPROX.
+%   R = ROOTS(F) returns the zero contours of F as a quasimatrix of chebfuns.
+%   Each column of R is one zero contour.  This command only finds contours when
+%   there is a change of sign, and it can also group intersecting contours in a
+%   non-optimal way.  It may be inaccurate for components near the boundary
+%   of the domain.
 %
-%   In the special case when F is of length 1, the zero contours are found
-%   to full precision.
+%   R = ROOTS(F, G) returns the isolated mutual roots of F and G.
 %
-%   R = ROOTS(F, G) returns the isolated points of F and G.
-%
-%   R = ROOTS(F, G, METHOD) the underlying rootfinding algorithm can be
-%   supplied. If METHOD = 'ms' or METHOD = 'marchingsquares', then the Marching
-%   Squares algorithm is employed. The Marching Squares algorithm is fast but
-%   not particularly robust. If METHOD = 'resultant', then a hidden variable
-%   resultant method based on Bezout resultants is employed. The Resultant
-%   method is slower but far more robust. See the CHEBFUN2V/ROOTS()
-%   documentation to see which algorithm is used when no METHOD is passed.
+%   R = ROOTS(F, G, METHOD) allows the underlying rootfinding algorithm to
+%   be specified.  If METHOD = 'ms' or 'marchingsquares', the Marching
+%   Squares algorithm is employed, which is fast but not very robust.
+%   If METHOD = 'resultant', a hidden variable resultant method
+%   based on Bezout resultants is employed, slower but more robust.
+%   See the CHEBFUN2V/ROOTS documentation to see which algorithm is used
+%   when no METHOD is passed.
 %  
+% Example:
+%   cheb.xy;
+%   f = x.^2 + y.^2 - 1/4;
+%   roots(x,f)                               % [0 -.5; 0 .5]
+%   c = roots(f);
+%   arclength = sum(abs(diff(c)))            % pi
+%   area = abs(sum(real(c).*diff(imag(c))))  % pi/4
+%
 % See also CHEBFUN2V/ROOTS.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-% Check for empty:
+% Check for empty chebfun input:
 if ( isempty( f ) )
     r = []; 
     return
 end 
 
-tol = 1e-10; % Go for ten digits. 
 dom = f.domain;
 
-if ( nargin == 1 )
+if ( nargin == 1 )  % Seek zero curves of scalar function
     
-    if ( length( f ) == 1 )  
-        % The SEPARABLEAPPROX is of rank 1:
-        
+    if ( length( f ) == 1 )  % Special case: f has rank 1:
         cols = f.cols;
         rows = f.rows;
         yrts = 1i*(roots( cols )+realmin);  
@@ -59,13 +60,14 @@ if ( nargin == 1 )
             r = [r f];
         end
         
-    elseif ( isreal( f ) )
-        % Function is real-valued.
-        
-        % Use Matlab's contourc function (Marching Squares). Note n = 502 is
-        % chosen to use a grid that does not involve the boundary of the
-        % domain.
-        n = 502; % discretization size.
+    elseif ( isreal( f ) )  % Main case: zero curves for real function 
+        % We seek accurate chebfun representations of each component
+        % of the zero curve.  First we call Matlab's contourc function
+        % to get initial data points, which typically will lie on the zero
+        % curve to 5-6 digit accuracy and will be smoothly spaced along 
+        % it to 2-3 digit accuracy.  The choice n = 502 is used to get a
+        % grid that does not involve the boundary of the domain.
+        n = 502;
         x = linspace( dom(1), dom(2), n );
         x(1) = []; x(end) = []; 
         y = linspace( dom(3), dom(4), n );
@@ -74,50 +76,64 @@ if ( nargin == 1 )
         vals = feval( f, xx, yy );
         C = contourc( x, y, vals, 0*[1 1] );
         [fx, fy] = grad(f);        
+        gradf = @(data) feval( fx, real(data), imag(data)) ...;
+                   + 1i*feval( fy, real(data), imag(data));
+        fval = @(data) feval( f, real(data), imag(data));
         
-        % Store solution in complex-valued CHEBFUNs:
+        % The contruction of chebfuns proceeds by improving the accuracy
+        % of the curves component by component, using complex arithmetic
+        % for convenience.
         j = 1; r = chebfun;
         while ( j < length(C) )
             k = j + C(2, j);
             D = C(:, j+1:k);
-            Dc = ( D(1, :) + 1i*(D(2, :)+realmin) ).';            
-            
-        % Take one Newton step to improve curve data
-            fxval = feval( fx, D(1,:), D(2,:) );
-            fyval = feval( fy, D(1,:), D(2,:) );        
-            gradf = fxval + 1i*fyval; 
-            fval = feval( f, D(1,:), D(2,:) );                                                
-            Dcnew = Dc - fval.*( gradf./abs(gradf).^2 );
-            fvalnew = feval( f, real(Dcnew), imag(Dcnew) );  
-            failures = find(abs(fval) < abs(fvalnew));
-            Dcnew(failures) = Dc(failures);
-            Dc = Dcnew; 
-            
-        % Empirical arc length for better interpolation
-    	    s = [0; cumsum(abs(diff(Dc)))];   
-    	    s = 2*s/s(end) - 1;               
-    	    chebgrid = chebpts(length(Dc));
-            newdata = interp1(s, Dc, chebgrid, 'spline');
-            fnew = chebfun( newdata );            
-            fnew = simplify( fnew, tol, 'globaltol' );
+            data = ( D(1, :) + 1i*(D(2, :)+realmin) ).';            
+            data = snap2boundary(data);
+            err = 999; errnew = 1e-2;
+            while errnew < err                           
+                err = errnew;
+                curve = chebfun(data);               % make chebfun
+                s = [0; cumsum(abs(diff(data)))];    % empirical arclength
+                s = 2*s/s(end) - 1;                  % normalize to [-1,1]
+                data = interp1(s, data, chebpts ...  % interpolate
+                    (length(data)), 'spline');
+                curve = chebfun(data);               % make chebfun
+                curve = simplify(curve);             % simplify it
+                data = curve(chebpts(1000));         % sample finely
+                ff = fval(data);                     % function values
+                g = gradf(data);                     % gradient values
+                errnew = norm(ff,inf);               % max error
+                data = data - ff.*( g./abs(g).^2 );  % Newton step
+            end
             j = k + 1;
-            r = [ r , fnew ];
+            r = [ r , curve ];
         end
-    else
-        % Function is complex-valued.
-        
-        % Call CHEBFUN2V/ROOTS():
+
+    else  % Function is complex-valued: reduce to real case
         r = roots( [ real(f) ; imag(f) ] );
-        % Make them complex again.
         if ( ~isempty( r ) )
             r = r(:, 1) + 1i*r(:, 2);
         end
     end
     
-elseif ( isa(g, 'separableApprox') )
+elseif ( isa(g, 'separableApprox') )  % seek zero points of vector function
     % TODO: This should not call chebfun2v directly.
     r = roots( chebfun2v( f, g ), varargin{:} );
     
+end
+
+function d = snap2boundary(d);
+    n = length(d);
+    dr = real(d); di = imag(d);
+    if abs(dr(1)-dom(1))<.02, dr(1) = dom(1); end  % snap to left boundary
+    if abs(dr(n)-dom(1))<.02, dr(n) = dom(1); end
+    if abs(dr(1)-dom(2))<.02, dr(1) = dom(2); end  % snap to right boundary
+    if abs(dr(n)-dom(2))<.02, dr(n) = dom(2); end
+    if abs(di(1)-dom(3))<.02, di(1) = dom(3); end  % snap to bottom boundary
+    if abs(di(n)-dom(3))<.02, di(n) = dom(3); end
+    if abs(di(1)-dom(4))<.02, di(1) = dom(4); end  % snap to top boundary
+    if abs(di(n)-dom(4))<.02, di(n) = dom(4); end
+    d = complex(dr,di);
 end
 
 end

--- a/tests/chebfun2/test_roots.m
+++ b/tests/chebfun2/test_roots.m
@@ -164,4 +164,16 @@ arclength = sum(abs(diff(c)));
 err = arclength - 2.957885715089195;
 pass(23) = abs(err) < tol2;
 
+f = chebfun2( @(x,y) y.^2-x.^2-.1,[-1 1 -1.5 1.5]);  % hyperbola
+c = roots(f);
+arclength = sum(abs(diff(c)));
+err = arclength - [1 1]*2.51829399795912;
+pass(24) = norm(err,inf) < tol2;
+
+f = chebfun2( @(x,y) y.^2-x.^2);  % cross
+c = roots(f);
+arclength = sum(abs(diff(c)));
+err = arclength - [1 1]*sqrt(8);
+pass(25) = norm(err,inf) < tol4;
+
 end

--- a/tests/chebfun2/test_roots.m
+++ b/tests/chebfun2/test_roots.m
@@ -146,7 +146,22 @@ err = area - pi/4;
 pass(20) = abs(err) < tol2;
 %disp([int2str(pass(20)) '  vertical scaling 2  ' int2str(length(c))])
 
-f = chebfun2( @(x,y) x.^2 + (10*y).^2 - 1/4 );
+f = chebfun2( @(x,y) y-sin(x),[-pi pi,-1.1 1.3]);
 c = roots(f);
+arclength = sum(abs(diff(c)));
+err = arclength - 7.640395578055424035;
+pass(21) = abs(err) < tol2;
+
+f = chebfun2( @(x,y) x-tanh(y));
+c = roots(f);
+arclength = sum(abs(diff(c)));
+err = arclength - 2.53182746833076;
+pass(22) = abs(err) < tol2;
+
+f = chebfun2( @(x,y) y-x.^2);
+c = roots(f);
+arclength = sum(abs(diff(c)));
+err = arclength - 2.957885715089195;
+pass(23) = abs(err) < tol2;
 
 end

--- a/tests/chebfun2/test_roots.m
+++ b/tests/chebfun2/test_roots.m
@@ -1,9 +1,12 @@
 function pass = test_roots( )
 % Test the chebfun2/roots command.
 
-tol = 1e-14;
+tol = 1e-12;  % rank 1 curves
+tol2 = 1e-8;  % rank >1 curves, disjoint
+tol3 = 1e-4;  % rank >1 curves, noncircular
+tol4 = 1e-2;  % intersecting curves, not properly disentangled
 
-% Here, we check that the roots command is working for separable functions. 
+% First we check separable functions, i.e., rank 1:
 
 f = chebfun2( @(x,y) 1/2-y);
 r = roots( f );
@@ -34,30 +37,116 @@ r = roots( f );
 exact = [chebfun( @(x) 2*x + 1i/2 ) chebfun(@(x) 1i*(4*(x+1)-3) )];
 pass(5) = ( norm( r - exact ) < tol );
 
+% Next we move to functions of rank > 1
+
 f = chebfun2( @(x,y) x.^2 + y.^2 - 1/4 );
 c = roots(f);
 arclength = sum(abs(diff(c)));
-pass(6) = abs(arclength - pi) < 1e-3;
+err = arclength - pi;
+pass(6) = abs(err) < tol2;
+%disp([int2str(pass(6)) '  circle  ' int2str(length(c))])
 
 area = abs(sum(real(c).*diff(imag(c))));
-pass(6) = abs(area - pi/4) < 1e-3;
+err = area - pi/4;
+pass(7) = abs(err) < tol2;
+%disp([int2str(pass(7)) '  area of circle  ' int2str(length(c))])
 
 f = chebfun2( @(x,y) x.^2 + (10*y).^2 - 1/4 );
 c = roots(f);
 arclength = sum(abs(diff(c)));
-pass(7) = abs(arclength - 2.031987090050447) < 1e-3;
+err = arclength - 2.031987090050447;
+pass(8) = abs(err) < tol3;
+%disp([int2str(pass(8)) '  ellipse  ' int2str(length(c))])
 
 area = abs(sum(real(c).*diff(imag(c))));
-pass(8) = abs(area - pi/40) < 1e-3;
+err = area - pi/40;
+pass(9) = abs(err) < tol3;
+%disp([int2str(pass(9)) '  area of ellipse  ' int2str(length(c))])
 
 f = chebfun2( @(x,y) (x-1).^2 + y.^2 - 1/4 );
 c = roots(f);
 arclength = sum(abs(diff(c)));
-pass(9) = abs(arclength - pi/2) < 1e-3;
+err = arclength - pi/2;
+pass(10) = abs(err) < tol2;
+%disp([int2str(pass(10)) '  semicircle at boundary  ' int2str(length(c))])
 
 f = chebfun2( @(x,y) (x-1).^2 + (y+1).^2 - 1/4 );
 c = roots(f);
 arclength = sum(abs(diff(c)));
-pass(10) = abs(arclength - pi/4) < 1e-3;
+err = arclength - pi/4;
+pass(11) = abs(err) < tol2;
+%disp([int2str(pass(11)) '  quarter-circle at corner  ' int2str(length(c))])
+
+r = 1/pi;  % this radius gives circumference 2
+x = chebfun2(@(x,y) x);
+y = chebfun2(@(x,y) y);
+
+%% One circle
+f = x.^2 + y.^2 - r^2;      
+c = roots(f); arclength = sum(abs(diff(c)));
+err = arclength - 2;
+pass(12) = abs(err) < tol2;
+%disp([int2str(pass(12)) '  another circle  ' int2str(length(c))])
+
+%% Two circles
+f = x.^2 + y.^2 - r^2;      
+g = (x-.6).^2 + (y-.5).^2 - r^2;      
+c = roots(f.*g); arclength = sum(abs(diff(c)));
+err = arclength - [2 2];
+pass(13) = norm(err,inf) < tol2;
+%disp([int2str(pass(13)) '  two circles  ' int2str(length(c))])
+
+%% Intersecting circles
+f = x.^2 + y.^2 - r^2;      
+g = (x-.2).^2 + (y-.5).^2 - r^2;      
+c = roots(f.*g); arclength = sum(abs(diff(c)));
+err = sum(arclength) - 4;
+pass(14) = abs(err) < tol4;
+%disp([int2str(pass(14)) '  intersecting circles  ' int2str(length(c))])
+
+%% A circle and a line
+f = x.^2 + y.^2 - r^2;      
+w = exp(x)-1.2;
+c = roots(f.*w); arclength = sum(abs(diff(c)));
+err = sum(arclength) - 4;
+pass(15) = abs(err) < tol4;
+%disp([int2str(pass(15)) '  intersecting circle and line  ' int2str(length(c))])
+
+%% Concentric circles (well separated)
+f = chebfun2(@(x,y) (x.^2 + y.^2 - .25).*(x.^2+y.^2-0.300));
+c = roots(f); arclength = sum(abs(diff(c)));
+err = arclength - pi*[sqrt(.300/.250) 1];
+pass(16) = norm(err,inf) < tol2;
+%disp([int2str(pass(16)) '  concentric circles  ' int2str(length(c))])
+
+%% Concentric circles (less well separated)
+f = chebfun2(@(x,y) (x.^2 + y.^2 - .25).*(x.^2+y.^2-0.260));
+c = roots(f); arclength = sum(abs(diff(c)));
+err = arclength - pi*[sqrt(.260/.250) 1];
+pass(17) = norm(err,inf) < tol2;
+%disp([int2str(pass(17)) '  close concentric circles  ' int2str(length(c))])
+
+f = chebfun2( @(x,y) (x.^2+y.^2-1/4).*((x-1.1).^2+(y-3).^2-1/4),[-1.3 1.1 -.9 3]);
+c = roots(f);
+arclength = sum(abs(diff(c)));
+err = sum(arclength) - 1.25*pi;
+pass(18) = abs(err) < tol2;
+%disp([int2str(pass(18)) '  different domain  ' int2str(length(c))])
+
+f = chebfun2( @(x,y) 1e100*(x.^2 + y.^2 - 1/4) );
+c = roots(f);
+arclength = sum(abs(diff(c)));
+err = arclength - pi;
+pass(19) = abs(err) < tol2;
+%disp([int2str(pass(19)) '  vertical scaling 1  ' int2str(length(c))])
+
+f = chebfun2( @(x,y) 1e100*(x.^2 + y.^2 - 1/4) );
+area = abs(sum(real(c).*diff(imag(c))));
+err = area - pi/4;
+pass(20) = abs(err) < tol2;
+%disp([int2str(pass(20)) '  vertical scaling 2  ' int2str(length(c))])
+
+f = chebfun2( @(x,y) x.^2 + (10*y).^2 - 1/4 );
+c = roots(f);
 
 end

--- a/tests/chebfun2/test_roots.m
+++ b/tests/chebfun2/test_roots.m
@@ -45,9 +45,19 @@ pass(6) = abs(area - pi/4) < 1e-3;
 f = chebfun2( @(x,y) x.^2 + (10*y).^2 - 1/4 );
 c = roots(f);
 arclength = sum(abs(diff(c)));
-pass(7) = abs(arclength -   2.031987090050447) < 1e-3;
+pass(7) = abs(arclength - 2.031987090050447) < 1e-3;
 
 area = abs(sum(real(c).*diff(imag(c))));
 pass(8) = abs(area - pi/40) < 1e-3;
+
+f = chebfun2( @(x,y) (x-1).^2 + y.^2 - 1/4 );
+c = roots(f);
+arclength = sum(abs(diff(c)));
+pass(9) = abs(arclength - pi/2) < 1e-3;
+
+f = chebfun2( @(x,y) (x-1).^2 + (y+1).^2 - 1/4 );
+c = roots(f);
+arclength = sum(abs(diff(c)));
+pass(10) = abs(arclength - pi/4) < 1e-3;
 
 end


### PR DESCRIPTION
I've made various improvements to Chebfun2 roots so that in simple cases at least, it gets very good accuracy.  Since @sfilip reviewed the last round of improvements to roots, perhaps he might take a look at this one too?

Here's an example of the arc length of a parabola.  All digits displayed are correct.
```
>> f = chebfun2(@(x,y) y-x.^2);
>> sum(abs(diff(roots(f))))
ans = 2.957885715089195
```

Roots is still not perfect, especially when there are intersecting or near-intersecting curves.   