### PR TITLE
Fixes a bug in the evaluation of an even length, array-valued trigtech

### DIFF
--- a/@trigtech/horner.m
+++ b/@trigtech/horner.m
@@ -122,7 +122,7 @@ else
     if mod(N, 2) == 1
         q = exp(-1i*pi*(N-1)/2*x)*(z.*q + c(1,:));
     else
-        q = exp(-1i*pi*(N/2-1)*x)*q + cos(N/2*pi*z)*c(1,:);
+        q = exp(-1i*pi*(N/2-1)*x)*q + cos(N/2*pi*x)*c(1,:);
     end
 end
 

--- a/tests/trigtech/test_feval.m
+++ b/tests/trigtech/test_feval.m
@@ -92,4 +92,11 @@ f_exact = [0 0 0 -1 1 -1 exp(-1i*pi) 1 exp(1i*pi)
     [1 sqrt(2) 1 1 0 -1]/sqrt(2) exp(1i*pi.*[.25 .5 .75])];
 pass(12) = all(all(abs(fx - f_exact) < 10*max(vscale(f)*eps)));
 
+% Even expansion of an array-valued complex trigfun evaluated at scalar
+% argument.
+f_exact = @(t) [exp(pi*1i*t) exp(2*pi*1i*t)];
+f = chebfun(f_exact,'trig','trunc',4);
+t = 1/2;
+pass(13) = ( norm(f(t)-f_exact(t), inf) < 10*vscale(f)*eps );
+
 end


### PR DESCRIPTION
Small bug in the Horner algorithm for evaluating array-valued, complex trigtechs that are of even length.  Included a test for this rare case.  Here's an example of the bug:
```
f = chebfun(@(t) [exp(pi*1i*t) exp(2*pi*1i*t)],'trig','trunc',4)
f(1/2)
ans =
   1.0e+02 *
 -0.000000000000000 + 0.010000000000000i  2.677467614837482 - 0.000000000000001i
```
