### PR TITLE
Fix trigpts end points

### DIFF
--- a/@trigtech/refine.m
+++ b/@trigtech/refine.m
@@ -56,16 +56,19 @@ function [values, giveUp] = refineResampling(op, values, pref)
     end
    
     % [TODO]: Allow "first-kind" trigonometric points.
-    x = trigpts(n);    
+    % Do the evaluation with the right end point included so that we can
+    % get the average value of the function at its two ends to redefine
+    % f(-1) as f(-1) = 0.5*(f(1) + f(-1)).  This approach is preferred
+    % since f may not make sense to evaluate pointwise if, for example, it
+    % is the result of an integral equation.
+    x = [trigpts(n);1];
 
     % Evaluate the operator:
     values = feval(op, x);
     
-    % Force the value at -1 to be equal to the value at 1, thus
-    % enforcing symmetry.
-    valRightBoundary = feval(op,1);
-    
-    values(1,:) = 0.5*(values(1,:) + valRightBoundary);
+    % Compute the average value of f at -/+ 1 and then remove the +1 value.
+    values(1,:) = 0.5*(values(1,:) + values(end,:));
+    values = values(1:end-1,:);
 end
 
 function [values, giveUp] = refineNested(op, values, pref)

--- a/@trigtech/trigtech.m
+++ b/@trigtech/trigtech.m
@@ -138,8 +138,8 @@ classdef trigtech < smoothfun % (Abstract)
                     ~isempty(pref.fixedLength) && ~isnan(pref.fixedLength) )
                 % Evaluate op on the equi-spaced grid of given size. Include
                 % the right end point and use this to get the average value
-                % of the function at it's two ends to redefine f(-1) as
-                % f(-1) = 0.5*(f(1) + f(-1)).  This approach is prefered
+                % of the function at its two ends to redefine f(-1) as
+                % f(-1) = 0.5*(f(1) + f(-1)).  This approach is preferred
                 % since f may not make sense to evaluate pointwise if, for
                 % example, it is the result of an integral equation.
                 vals = feval(op, [trigtech.trigpts(pref.fixedLength);1]);

--- a/@trigtech/trigtech.m
+++ b/@trigtech/trigtech.m
@@ -136,9 +136,15 @@ classdef trigtech < smoothfun % (Abstract)
             % Force nonadaptive construction if PREF.FIXEDLENGTH is numeric:
             if ( ~(isnumeric(op) || iscell(op)) && ...
                     ~isempty(pref.fixedLength) && ~isnan(pref.fixedLength) )
-                % Evaluate op on the equi-spaced grid of given size:
-                vals = feval(op, trigtech.trigpts(pref.fixedLength));
-                vals(1,:) = 0.5*(vals(1,:) + feval(op, 1));
+                % Evaluate op on the equi-spaced grid of given size. Include
+                % the right end point and use this to get the average value
+                % of the function at it's two ends to redefine f(-1) as
+                % f(-1) = 0.5*(f(1) + f(-1)).  This approach is prefered
+                % since f may not make sense to evaluate pointwise if, for
+                % example, it is the result of an integral equation.
+                vals = feval(op, [trigtech.trigpts(pref.fixedLength);1]);
+                vals(1,:) = 0.5*(vals(1,:) + vals(end,:));
+                vals = vals(1:end-1,:);
                 op = vals;
             end
 


### PR DESCRIPTION
Fixes the `trigtech` constructor so that it does not include a separate evaluation of the right end point to determine the average value of the function at the left end point.  Now evaluations are done over `[-1,1]` all at once and the value `f(-1)` is redefined to `f(-1) = 0.5*(f(1) + f(-1))`.