### PR TITLE
New randnfun syntax

### DIFF
--- a/randnfun.m
+++ b/randnfun.m
@@ -1,14 +1,18 @@
-function f = randnfun(dx, n, dom)
+function f = randnfun(varargin)
 %RANDNFUN   Random smooth function
 %   F = RANDNFUN(DX) returns a smooth chebfun on [-1,1] with maximum
 %   wave number about 2pi/DX and standard normal distribution N(0,1)
 %   at each point.  F can be regarded as one sample path of a Gaussian
-%   process.  F is obtained by calling RANDNFUNTRIG on an interval
+%   process.  It is obtained by calling RANDNFUNTRIG on an interval
 %   of about twice the length and restricting the result to [-1,1].
+%
+%   F = RANDNFUN(DX, DOM) returns a result with domain DOM = [A, B].
 %
 %   F = RANDNFUN(DX, N) returns a quasimatrix with N independent columns.
 %
-%   F = RANDNFUN(DX, N, DOM) returns a result with domain DOM = [A, B].
+%   Combinations RANDNFUN(DX, N, DOM) or RANDNFUN(DX, DOM, N) are
+%   also allowed.  Commands RANDNFUN() or RANDNFUN(DOM) use the
+%   default value DX = 1.
 %
 % Examples:
 %
@@ -17,18 +21,14 @@ function f = randnfun(dx, n, dom)
 %
 %   X = randnfun(.01,2); cov(X)
 %
+%   f = randnfun([0 100]); plot(cumsum(f))
+%
 % See also RANDNFUNTRIG.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.
 
-if nargin < 3
-    dom = [-1 1];     % default domain
-end
-
-if nargin < 2
-    n = 1;            % default number of columns
-end
+[dx, n, dom] = parseInputs(varargin{:});
 
 % Call RANDNFUNTRIG on interval of approximately double length.
 % and then restrict the result to the prescribed interval.
@@ -37,3 +37,35 @@ m = 2*round(diff(dom)/dx)+1;
 dom2 = dom(1) + [0 m*dx];
 f = randnfuntrig(dx, n, dom2);
 f = f{dom(1),dom(2)};
+
+end
+
+function [dx, n, dom] = parseInputs(varargin)
+
+dx = NaN;
+n = NaN;
+dom = NaN;
+
+for j = 1:nargin
+    v = varargin{j};
+    if ~isscalar(v)
+        dom = v;
+    elseif isnan(dx)
+        dx = v;
+    else
+        n = v;
+    end
+end
+
+if isnan(dx)
+   dx = 1;          % default space scale
+end
+if isnan(n)
+   n = 1;           % default number of columns
+end
+if isnan(dom)
+   dom = [-1 1];    % default domain
+end
+
+end
+

--- a/randnfuntrig.m
+++ b/randnfuntrig.m
@@ -1,4 +1,4 @@
-function f = randnfuntrig(dx, n, dom)
+function f = randnfuntrig(varargin)
 %RANDNFUNTRIG   Random smooth periodic function
 %   F = RANDNFUNTRIG(DX) returns a smooth periodic chebfun (trigfun)
 %   on [-1,1] with maximum wave number about 2pi/DX and standard normal
@@ -7,9 +7,13 @@ function f = randnfuntrig(dx, n, dom)
 %   with independent normally distributed coefficients of equal variance.
 %   (This code is preliminary and the definition may change in the future.)
 %
+%   F = RANDNFUNTRIG(DX, DOM) returns a result with domain DOM = [A, B].
+%
 %   F = RANDNFUNTRIG(DX, N) returns a quasimatrix with N independent columns.
 %
-%   F = RANDNFUNTRIG(DX, N, DOM) returns a result with domain DOM = [A, B].
+%   Combinations RANDNFUNTRIG(DX, N, DOM) or RANDNFUNTRIG(DX, DOM, N) are
+%   also allowed.  Commands RANDNFUNTRIG() or RANDNFUNTRIG(DOM) use
+%   the default value DX = 1.
 %
 % Examples:
 %
@@ -18,18 +22,14 @@ function f = randnfuntrig(dx, n, dom)
 %
 %   X = randnfuntrig(.01,2); cov(X)
 %
+%   f = randnfuntrig([0 100]); plot(cumsum(f))
+%
 % See also RANDNFUN.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.
 
-if nargin < 3
-    dom = [-1 1];     % default domain
-end
-
-if nargin < 2
-    n = 1;            % default number of columns
-end
+[dx, n, dom] = parseInputs(varargin{:});
 
 % Although the output is real, complex arithmetic is used for the
 % construction since the 'trig', 'coeffs' mode is only documented
@@ -39,3 +39,34 @@ m = round(diff(dom)/dx);
 c = randn(2*m+1, n) + 1i*randn(2*m+1, n);
 c = (c + flipud(conj(c)))/2;
 f = chebfun(c/sqrt(2*m+1), dom, 'trig', 'coeffs');
+
+end
+
+function [dx, n, dom] = parseInputs(varargin)
+
+dx = NaN;  
+n = NaN;  
+dom = NaN;
+
+for j = 1:nargin
+    v = varargin{j};
+    if ~isscalar(v)
+        dom = v;
+    elseif isnan(dx) 
+        dx = v;
+    else
+        n = v;
+    end
+end
+
+if isnan(dx)
+   dx = 1;          % default space scale
+end
+if isnan(n)
+   n = 1;           % default number of columns
+end
+if isnan(dom)
+   dom = [-1 1];    % default domain
+end
+
+end


### PR DESCRIPTION
I've made the input arguments to `randfun` and `randnfuntrig` more flexible.  Now there can be any number of arguments 0, 1, 2, or 3:
```
f = randnfun(dx, n, dom)
```
where `dom` is an interval `[a, b]`.  By default dx = 1, n = 1, and dom = [-1 1].  The arguments can appear in any order except that the first scalar, if any, is taken to be `dx` (the space scale) and the second scalar, if any, is taken to be `n` (the number of columns).

Thus for example, for a plot of a random walk on [0, 100] we used to have to type
```
plot(cumsum(randnfun(1,1,[0 100]))
```
but now we can get away with
```
plot(cumsum(randnfun([0 100])))