### PR TITLE
changing ends to domain

### DIFF
--- a/@chebfun/chebpade.m
+++ b/@chebfun/chebpade.m
@@ -113,7 +113,7 @@ l = max(m, n);
 
 % Limit to fixed number of coefficients if specified.
 if ( M >= 0 )
-    F = chebfun(@(x) feval(F, x), F.ends([1 end]), M + 1);
+    F = chebfun(@(x) feval(F, x), F.domain([1 end]), M + 1);
 elseif ( numel(F.funs) > 1 )
     error('CHEBFUN:CHEBFUN:chebpade:chebpadeClenshawLord:multipleFuns', ...
         ['For a function with multiple funs, the number of coefficients ' ...

--- a/tests/chebfun/test_chebpade.m
+++ b/tests/chebfun/test_chebpade.m
@@ -40,6 +40,11 @@ ratio1 = p2(.3)/p(.3);
 ratio2 = r2(-.4)/r(-.4);
 pass(5) = norm([ratio1 ratio2] - [1i 1i], inf) < 1e-13;
 
+% Try a call with an explicit number of coefficients in
+% the Chebyshev expansion of f.
+[p,q,r] = chebpade(f,2,2,10);
+pass(6) = norm(f - p./q) < 2e-4;
+
 % Restore the warning state.
 warning(warnState);
 


### PR DESCRIPTION
This small change fixes bug #1992 inside chebpade when specifying the number of terms to use in the Chebyshev expansion of the function to approximate.