### PR TITLE
improved functionality of mean(chebfun)

### DIFF
--- a/@chebfun/mean.m
+++ b/@chebfun/mean.m
@@ -1,16 +1,29 @@
 function h = mean(f, g)
 %MEAN    Average or mean value of a CHEBFUN.
-%   MEAN(F) is the mean value of the CHEBFUN F in its continuous dimension.
-%   MEAN(F, G) is the average CHEBFUN between CHEBFUN objects F and G.
+%   MEAN(F) is the mean of the CHEBFUN F.
+%   If F is a quasimatrix, the mean is along the continuous dimension.
+%   MEAN(F, DIM), where DIM = 1 or 2, is the mean in dimension DIM.
+%   MEAN(F, G), where G is a CHEBFUN, is the mean of F and G.
 %
 % See also SUM.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-if ( nargin == 1 )
+if ( f(1).isTransposed )
+    if nargin == 1
+        g = 2;
+    end
 
-    if ( ~f(1).isTransposed )
+    if isscalar(g) && (g==1 | g==2)
+        h = mean(f.', 3-g).';
+    else
+        h = mean(f.', g.').';
+    end
+
+else    % f is not transposed
+
+    if (nargin == 1)
 
         % Check to see if the domain is unbounded:
         dom = domain(f);
@@ -38,21 +51,21 @@ if ( nargin == 1 )
                 % Or return a NaN if they are different:
                 h = NaN;
             end
+       end
+
+    else  % case of 2 inputs
+
+        if isscalar(g) && g == 2    
+            h = sum(f,2)/size(f,2);
+
+        elseif isscalar(g) && g == 1
+            h = mean(f);
+
+        else
+        % Take the mean of two inputs:
+            h = 0.5*(f + g);
+    
         end
-
-    else
-
-        % Deal with the transposed case:
-        h = transpose(mean(transpose(f)));
-        % [TODO]: Is this right?
-
     end
-
-else
-
-    % Take the mean of two inputs:
-    h = 0.5*(f + g);
-
-end
 
 end

--- a/@chebfun/mean.m
+++ b/@chebfun/mean.m
@@ -15,7 +15,7 @@ if ( f(1).isTransposed )
         g = 2;
     end
 
-    if isscalar(g) && (g==1 | g==2)
+    if isscalar(g) && (g==1 || g==2)
         h = mean(f.', 3-g).';
     else
         h = mean(f.', g.').';
@@ -64,7 +64,6 @@ else    % f is not transposed
         else
         % Take the mean of two inputs:
             h = 0.5*(f + g);
-    
         end
     end
 

--- a/tests/chebfun/test_mean.m
+++ b/tests/chebfun/test_mean.m
@@ -83,6 +83,18 @@ f = chebfun(op, dom, 'splitting', 'on');
 M = mean(f);
 pass(13) = abs(M - 0.75) < 1e2*eps*vscale(f);
 
+x = chebfun('x');
+f = mean([x 3*x], 2)
+pass(14) = norm(f-2*x) < 1e2*eps;
+
+f = mean([x 3*x], 1);
+pass(15) = norm( f - mean([x 3*x]) ) == 0;
+
+pass(16) = (norm(mean(x,1) - mean(x.',2)) == 0);
+
+pass(17) = (norm(mean(x') - 0) < 1e2*eps);
+
+pass(18) = (norm(mean(x',1) - x') == 0);
 
 end
 
@@ -97,5 +109,4 @@ else
 end
 
 out = norm(feval(f, x), inf);
-
 end

--- a/tests/chebfun/test_mean.m
+++ b/tests/chebfun/test_mean.m
@@ -84,7 +84,7 @@ M = mean(f);
 pass(13) = abs(M - 0.75) < 1e2*eps*vscale(f);
 
 x = chebfun('x');
-f = mean([x 3*x], 2)
+f = mean([x 3*x], 2);
 pass(14) = norm(f-2*x) < 1e2*eps;
 
 f = mean([x 3*x], 1);


### PR DESCRIPTION
Until now, Chebfun lacked the functionality of `mean(f,2)` to compute the mean of a Chebfun quasimatrix in the horizontal direction.  We (@sfilip and I) have now implemented that, along with the appropriate (we hope) capabilities for taking means if `f` happens to be transposed.  

A key motivation here is exploration of random functions.  For example, `f = randnfun(.1,10)` gives a quasimatrix whose 10 columns are independent random functions.  What is the mean of these functions?  We want to be able to compute this with `mean(f,2)`.