### PR TITLE
feature-transpose-is-adjoint

### DIFF
--- a/@chebop/ctranspose.m
+++ b/@chebop/ctranspose.m
@@ -4,7 +4,12 @@ function Nstar = ctranspose(N)
 %   endpoint boundary conditions. If N is nonlinear then N is first
 %   linearized around U = 0 and NSTAR is the adjoint of the linearization.
 %
-%   ADJOINT(N) is called for the syntax N'.
+%   N' is calculated by a call to ADJOINT(N).  To linearize about
+%   a nonzero function U, use ADJOINT(N, U).
+%
+%  Example:
+%   L = chebop(-1,1); L.op = @(x,u) diff(u,2) + diff(u,1) + u;
+%   L.lbc = 0; L.rbc = 1, Ls = L'
 %
 % See also CHEBOP/ADJOINT.
 

--- a/@chebop/ctranspose.m
+++ b/@chebop/ctranspose.m
@@ -1,0 +1,17 @@
+function Nstar = ctranspose(N)
+%'   Compute the adjoint of a CHEBOP.
+%   NSTAR = N' returns the adjoint of a CHEBOP that has either periodic or
+%   endpoint boundary conditions. If N is nonlinear then N is first
+%   linearized around U = 0 and NSTAR is the adjoint of the linearization.
+%
+%   ADJOINT(N) is called for the syntax N'.
+%
+% See also CHEBOP/ADJOINT.
+
+% Copyright 2017 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+% This is just a wrapper for adjoint().
+Nstar = adjoint(N);
+
+end

--- a/tests/chebop/test_adjoint.m
+++ b/tests/chebop/test_adjoint.m
@@ -92,4 +92,10 @@ pass(16) = min(feval(Ls.lbc(o,o),dom(1)));
 % check commutator
 pass(17) = abs([v1;v2]'*(L*[u1;u2]) - (Ls*[v1;v2])'*[u1;u2]) < nrm*tol;
 
+%% Test L' syntax
+
+Ls1 = adjoint(L);
+Ls2 = L';
+pass(18) = norm((Ls1*[v1;v2]) - (Ls2*[v1;v2])) < nrm*tol;
+
 end


### PR DESCRIPTION
Add `ctranspose` method for CHEBOP class so that `A'` is a wrapper for `adjoint(A)`.