### PR TITLE
modifications to allow normalized random functions

### DIFF
--- a/randnfun.m
+++ b/randnfun.m
@@ -10,9 +10,12 @@ function f = randnfun(varargin)
 %
 %   F = RANDNFUN(DX, N) returns a quasimatrix with N independent columns.
 %
-%   Combinations RANDNFUN(DX, N, DOM) or RANDNFUN(DX, DOM, N) are
-%   also allowed.  Commands RANDNFUN() or RANDNFUN(DOM) use the
-%   default value DX = 1.
+%   F = RANDNFUN(DX, 'norm') normalizes the output by dividing it
+%   by SQRT(DX), so that white noise is approached in the limit DX -> 0.
+%
+%   F = RANDNFUN() uses the default value DX = 1.  Combinations such
+%   as RANDNFUN(DOM), RANDNFUN('norm', DX) are allowed so long as
+%   DX, if present, precedes N, if present.
 %
 % Examples:
 %
@@ -21,34 +24,41 @@ function f = randnfun(varargin)
 %
 %   X = randnfun(.01,2); cov(X)
 %
-%   f = randnfun([0 100]); plot(cumsum(f))
+%   f = randnfun(0.1,'norm',[0 10]); plot(cumsum(f))
 %
 % See also RANDNFUNTRIG.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.
 
-[dx, n, dom] = parseInputs(varargin{:});
+[dx, n, dom, normalize] = parseInputs(varargin{:});
 
 % Call RANDNFUNTRIG on interval of approximately double length.
 % and then restrict the result to the prescribed interval.
 
 m = 2*round(diff(dom)/dx)+1;
 dom2 = dom(1) + [0 m*dx];
-f = randnfuntrig(dx, n, dom2);
+if normalize
+    f = randnfuntrig(dx, n, dom2, 'norm');
+else
+    f = randnfuntrig(dx, n, dom2);
+end
 f = f{dom(1),dom(2)};
 
 end
 
-function [dx, n, dom] = parseInputs(varargin)
+function [dx, n, dom, normalize] = parseInputs(varargin)
 
 dx = NaN;
 n = NaN;
 dom = NaN;
+normalize = 0;
 
 for j = 1:nargin
     v = varargin{j};
-    if ~isscalar(v)
+    if ischar(v)
+        normalize = 1;
+    elseif ~isscalar(v)
         dom = v;
     elseif isnan(dx)
         dx = v;

--- a/randnfuntrig.m
+++ b/randnfuntrig.m
@@ -11,9 +11,12 @@ function f = randnfuntrig(varargin)
 %
 %   F = RANDNFUNTRIG(DX, N) returns a quasimatrix with N independent columns.
 %
-%   Combinations RANDNFUNTRIG(DX, N, DOM) or RANDNFUNTRIG(DX, DOM, N) are
-%   also allowed.  Commands RANDNFUNTRIG() or RANDNFUNTRIG(DOM) use
-%   the default value DX = 1.
+%   F = RANDNFUNTRIG(DX, 'norm') normalizes the output by dividing it
+%   by SQRT(DX), so that white noise is approached in the limit DX -> 0.
+%
+%   F = RANDNFUNTRIG() uses the default value DX = 1.  Combinations such
+%   as RANDNFUNTRIG(DOM), RANDNFUNTRIG('norm', DX) are allowed so long as
+%   DX, if present, precedes N, if present.
 %
 % Examples:
 %
@@ -22,14 +25,14 @@ function f = randnfuntrig(varargin)
 %
 %   X = randnfuntrig(.01,2); cov(X)
 %
-%   f = randnfuntrig([0 100]); plot(cumsum(f))
+%   f = randnfuntrig(0.1,'norm',[0 10]); plot(cumsum(f))
 %
 % See also RANDNFUN.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.
 
-[dx, n, dom] = parseInputs(varargin{:});
+[dx, n, dom, normalize] = parseInputs(varargin{:});
 
 % Although the output is real, complex arithmetic is used for the
 % construction since the 'trig', 'coeffs' mode is only documented
@@ -39,18 +42,24 @@ m = round(diff(dom)/dx);
 c = randn(2*m+1, n) + 1i*randn(2*m+1, n);
 c = (c + flipud(conj(c)))/2;
 f = chebfun(c/sqrt(2*m+1), dom, 'trig', 'coeffs');
+if normalize
+    f = f/sqrt(dx);
+end
 
 end
 
-function [dx, n, dom] = parseInputs(varargin)
+function [dx, n, dom, normalize] = parseInputs(varargin)
 
 dx = NaN;  
 n = NaN;  
 dom = NaN;
+normalize = 0;
 
 for j = 1:nargin
     v = varargin{j};
-    if ~isscalar(v)
+    if ischar(v)
+        normalize = 1;
+    elseif ~isscalar(v)
         dom = v;
     elseif isnan(dx) 
         dx = v;

--- a/tests/misc/test_randnfun.m
+++ b/tests/misc/test_randnfun.m
@@ -17,4 +17,9 @@ A = randnfun(1,10,[0 10]);
 X = cov(A);
 pass(4) = (norm(X-X') == 0);
 
+rng(0), f1 = randnfun('norm',1/64,[0 3]);
+rng(0), f2 = 8*randnfun(1/64, 1, [0 3]);
+pass(5) = norm(f1-f2) == 0;
+
+
 end

--- a/tests/misc/test_randnfuntrig.m
+++ b/tests/misc/test_randnfuntrig.m
@@ -20,4 +20,8 @@ pass(4) = (norm(X-X') == 0);
 f = randnfuntrig(1) + 1i*randnfuntrig(1);
 pass(5) = (abs(f(-.999)-f(.999)) < .1);
 
+rng(0), f1 = randnfuntrig(1/16,'norm')/4;
+rng(0), f2 = randnfuntrig(1/16);
+pass(6) = norm(f1-f2) == 0;
+
 end


### PR DESCRIPTION
For random ODE (and other) applications involving `randnfun` and `randnfuntrig` we want two possibilities: variance 1 at each point (easy to remember, very simple) or variance 1/dt at each point (so that we approach white noise as dt -> 0).  I've added the option `'norm'` to `randnfun` and `randnfuntrig` to make this possible.