### PR TITLE
Fix equiflag

### DIFF
--- a/@chebfun/chebfun.m
+++ b/@chebfun/chebfun.m
@@ -550,7 +550,7 @@ function [op, dom, data, pref, flags] = parseInputs(op, varargin)
             args(1) = [];
             if ( ~isnumeric(op) && (isempty(args) || ~isscalar(args{1})) )
                 error('CHEBFUN:CHEBFUN:parseInputs:equi', ...
-                'Cannot construct CHEBFUN adaptively from equispaced data.');
+                '''equi'' flag requires the number of points to be specified.');
             end
         elseif ( strcmpi(args{1}, 'vectorize') || ...
                  strcmpi(args{1}, 'vectorise') )

--- a/@chebfun/chebfun.m
+++ b/@chebfun/chebfun.m
@@ -532,7 +532,6 @@ function [op, dom, data, pref, flags] = parseInputs(op, varargin)
     isPeriodic = false;
     vectorize = false;
     doVectorCheck = true;
-    isFixedLength = false;
     
     while ( ~isempty(args) )
         if ( isstruct(args{1}) || isa(args{1}, 'chebfunpref') )
@@ -550,11 +549,6 @@ function [op, dom, data, pref, flags] = parseInputs(op, varargin)
             % Enable FUNQUI when dealing with equispaced data.
             keywordPrefs.enableFunqui = true;
             args(1) = [];
-            if ( ~isnumeric(op) && ~isFixedLength && ...
-                    (isempty(args) || ~isscalar(args{1})) )
-                error('CHEBFUN:CHEBFUN:parseInputs:equi', ...
-                '''equi'' flag requires the number of points to be specified.');
-            end
         elseif ( strcmpi(args{1}, 'vectorize') || ...
                  strcmpi(args{1}, 'vectorise') )
             % Vectorize flag for function_handles.
@@ -594,7 +588,6 @@ function [op, dom, data, pref, flags] = parseInputs(op, varargin)
             keywordPrefs.splitting = true;
         elseif ( isnumeric(args{1}) && isscalar(args{1}) )
             % g = chebfun(@(x) f(x), N)
-            isFixedLength = true;
             keywordPrefs.techPrefs.fixedLength = args{1};
             args(1) = [];
         elseif ( strcmpi(args{1}, 'splitting') )
@@ -703,6 +696,16 @@ function [op, dom, data, pref, flags] = parseInputs(op, varargin)
                     'Could not parse input argument sequence.');
             end
         end
+    end
+    
+    % Construction from equispaced data requires the number of points to be
+    % specified
+    if ( ~isnumeric(op) && isfield(keywordPrefs, 'enableFunqui') && ...
+            (~isfield(keywordPrefs, 'techPrefs') || ...
+            (isfield(keywordPrefs, 'techPrefs') && ...
+            ~isfield(keywordPrefs.techPrefs,'fixedLength'))) )
+        error('CHEBFUN:CHEBFUN:parseInputs:equi', ...
+            '''equi'' flag requires the number of points to be specified.');
     end
     
     % It doesn't make sense to construct from values and coeffs at the same

--- a/@chebfun/chebfun.m
+++ b/@chebfun/chebfun.m
@@ -533,6 +533,7 @@ function [op, dom, data, pref, flags] = parseInputs(op, varargin)
     vectorize = false;
     doVectorCheck = true;
     isFixedLength = false;
+    
     while ( ~isempty(args) )
         if ( isstruct(args{1}) || isa(args{1}, 'chebfunpref') )
             % Preference object input.  (Struct inputs not tied to a keyword

--- a/@chebfun/chebfun.m
+++ b/@chebfun/chebfun.m
@@ -532,6 +532,7 @@ function [op, dom, data, pref, flags] = parseInputs(op, varargin)
     isPeriodic = false;
     vectorize = false;
     doVectorCheck = true;
+    isFixedLength = false;
     while ( ~isempty(args) )
         if ( isstruct(args{1}) || isa(args{1}, 'chebfunpref') )
             % Preference object input.  (Struct inputs not tied to a keyword
@@ -548,7 +549,8 @@ function [op, dom, data, pref, flags] = parseInputs(op, varargin)
             % Enable FUNQUI when dealing with equispaced data.
             keywordPrefs.enableFunqui = true;
             args(1) = [];
-            if ( ~isnumeric(op) && (isempty(args) || ~isscalar(args{1})) )
+            if ( ~isnumeric(op) && ~isFixedLength && ...
+                    (isempty(args) || ~isscalar(args{1})) )
                 error('CHEBFUN:CHEBFUN:parseInputs:equi', ...
                 '''equi'' flag requires the number of points to be specified.');
             end
@@ -591,6 +593,7 @@ function [op, dom, data, pref, flags] = parseInputs(op, varargin)
             keywordPrefs.splitting = true;
         elseif ( isnumeric(args{1}) && isscalar(args{1}) )
             % g = chebfun(@(x) f(x), N)
+            isFixedLength = true;
             keywordPrefs.techPrefs.fixedLength = args{1};
             args(1) = [];
         elseif ( strcmpi(args{1}, 'splitting') )

--- a/@chebfun/chebfun.m
+++ b/@chebfun/chebfun.m
@@ -548,6 +548,10 @@ function [op, dom, data, pref, flags] = parseInputs(op, varargin)
             % Enable FUNQUI when dealing with equispaced data.
             keywordPrefs.enableFunqui = true;
             args(1) = [];
+            if ( ~isnumeric(op) && (isempty(args) || ~isscalar(args{1})) )
+                error('CHEBFUN:CHEBFUN:parseInputs:equi', ...
+                'Cannot construct CHEBFUN adaptively from equispaced data.');
+            end
         elseif ( strcmpi(args{1}, 'vectorize') || ...
                  strcmpi(args{1}, 'vectorise') )
             % Vectorize flag for function_handles.

--- a/@chebfun2/constructor.m
+++ b/@chebfun2/constructor.m
@@ -57,6 +57,11 @@ if ( isa(op, 'chebfun2') )  % CHEBFUN2( CHEBFUN2 )
     return
 end
 
+% The 'equi' flag can be used only with numeric data:
+if ( isEqui && ~isa(op, 'double') )
+    error('CHEBFUN:CHEBFUN2:constructor:equi', ...
+        'The EQUI flag is valid only when constructing from numeric data');
+end
 % Deal with constructions from numeric data:
 if ( isa(op, 'double') )    % CHEBFUN2( DOUBLE )
     g = constructFromDouble(op, dom, pref, isEqui);

--- a/@chebfun3/constructor.m
+++ b/@chebfun3/constructor.m
@@ -43,6 +43,12 @@ maxRank = prefStruct.maxRank;
 pseudoLevel = prefStruct.chebfun3eps;
 passSampleTest = prefStruct.sampleTest;
 
+% The 'equi' flag can be used only with numeric data:
+if ( isEqui && ~isa(op, 'double') )
+    error('CHEBFUN:CHEBFUN3:constructor:equi', ...
+        'The EQUI flag is valid only when constructing from numeric data');
+end
+
 if ( isa(op, 'chebfun3') )     % CHEBFUN3( CHEBFUN3 )
     f = op;
     return

--- a/tests/chebfun/test_constructor_equi.m
+++ b/tests/chebfun/test_constructor_equi.m
@@ -54,4 +54,12 @@ u = xx(end);
 g = chebfun( u, 'equi');
 pass(10) = norm(g - u) < 10*vscale(g)*eps;
 
+% Equi should throw an error when trying to use it in an adaptive way:
+try
+    g = chebfun('exp(x)','equi');
+    pass(11) = false;
+catch ME
+    pass(11) = strcmp(ME.identifier, 'CHEBFUN:CHEBFUN:parseInputs:equi');
+end
+
 end

--- a/tests/chebfun/test_mtimes.m
+++ b/tests/chebfun/test_mtimes.m
@@ -100,7 +100,6 @@ try
     h = f*'X';
     pass(18) = false;
 catch ME
-    ME
     pass(18) = strcmp(ME.identifier, 'CHEBFUN:CHEBFUN:mtimes:unknown');
 end
 
@@ -108,7 +107,6 @@ try
     h = f*f1;
     pass(19) = true;
 catch ME
-    ME
     pass(19) = strcmp(ME.identifier, 'CHEBFUN:CHEBFUN:dimCheck:dim');
 end
 

--- a/tests/chebfun2/test_constructor2.m
+++ b/tests/chebfun2/test_constructor2.m
@@ -114,4 +114,13 @@ f = chebfun2( @(x,y) exp(cos(x.*y)), dom, [m n] );
 [mF, nF] = length(f);
 pass(23) = ( all( f.domain == dom ) && mF == m && nF == n );
 
+% Test that the 'equi' flag outputs an error message if used for
+% adaptive construction of a chebfun2.
+try
+    f = chebfun2(@(x,y) sin(x).*sin(y), 'equi');
+    pass(24) = false;
+catch ME
+    pass(24) = strcmp(ME.identifier, 'CHEBFUN:CHEBFUN2:constructor:equi');
+end
+
 end

--- a/tests/chebfun3/test_constructor2.m
+++ b/tests/chebfun3/test_constructor2.m
@@ -82,4 +82,13 @@ pass(17) = f(0.25,0.5,0) - 0.75 < tol;
 f = chebfun3('cos(x+y+z)');
 pass(18) = f(0.25,0.5,-0.3) - cos(0.25+0.5-0.3) < tol;
 
+% Test that the 'equi' flag outputs an error message if used for
+% adaptive construction of a chebfun3.
+try
+    f = chebfun3(@(x, y, z) z.*x.^2.*exp(sin(x + y)), 'equi');
+    pass(19) = false;
+catch ME
+    pass(19) = strcmp(ME.identifier, 'CHEBFUN:CHEBFUN3:constructor:equi');
+end
+
 end


### PR DESCRIPTION
This pull request addresses issue #2052. An appropriate error message is now displayed when a user tries to adaptively construct a chebfun/chebfun2/chebfun3 object from equispaced data.