### PR TITLE
changed DT to LAMBDA everywhere

### DIFF
--- a/randnfun.m
+++ b/randnfun.m
@@ -1,25 +1,25 @@
 function f = randnfun(varargin)
 %RANDNFUN   Random smooth function
-%   F = RANDNFUN(DT) returns a smooth CHEBFUN on [-1,1] with maximum
-%   frequency about 2pi/DT and standard normal distribution N(0,1)
+%   F = RANDNFUN(LAMBDA) returns a smooth CHEBFUN on [-1,1] with maximum
+%   frequency about 2pi/LAMBDA and standard normal distribution N(0,1)
 %   at each point.  F can be regarded as one sample path of a Gaussian
-%   process.  It is obtained by calling RANDNFUN(DT, 'trig') on an interval
-%   of length about 20% longer and restricting the result to [-1,1].
+%   process.  It is obtained by calling RANDNFUN(LAMBDA, 'trig') on an
+%   interval about 20% longer and restricting the result to [-1,1].
 %
-%   RANDNFUN(DT, DOM) returns a result with domain DOM = [A, B].
+%   RANDNFUN(LAMBDA, DOM) returns a result with domain DOM = [A, B].
 %
-%   RANDNFUN(DT, N) returns a quasimatrix with N independent columns.
+%   RANDNFUN(LAMBDA, N) returns a quasimatrix with N independent columns.
 %
-%   RANDNFUN(DT, 'norm') normalizes the output by dividing it
-%   by SQRT(DT), so that white noise is approached in the limit DT -> 0.
+%   RANDNFUN(LAMBDA, 'norm') normalizes the output by dividing it by
+%   SQRT(LAMBDA), so white noise is approached in the limit LAMBDA -> 0.
 %
-%   RANDNFUN(DT, 'trig') returns a random periodic function.  This
-%   is defined by a a finite Fourier series with independent normally
+%   RANDNFUN(LAMBDA, 'trig') returns a random periodic function.  This
+%   is defined by a finite Fourier series with independent normally
 %   distributed coefficients of equal variance.
 %
-%   RANDNFUN() uses the default value DT = 1.  Combinations such
-%   as RANDNFUN(DOM), RANDNFUN('norm', DT) are allowed so long as
-%   DT, if present, precedes N, if present.
+%   RANDNFUN() uses the default value LAMBDA = 1.  Combinations such
+%   as RANDNFUN(DOM), RANDNFUN('norm', LAMBDA) are allowed so long as
+%   LAMBDA, if present, precedes N, if present.
 %
 % Examples:
 %
@@ -35,34 +35,34 @@ function f = randnfun(varargin)
 % Copyright 2017 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.
 
-[dt, n, dom, normalize, trig] = parseInputs(varargin{:});
+[lambda, n, dom, normalize, trig] = parseInputs(varargin{:});
 
 if trig    % periodic case: random Fourier series
 
-    m = round(diff(dom)/dt);
+    m = round(diff(dom)/lambda);
     c = randn(2*m+1, n) + 1i*randn(2*m+1, n);
     c = (c + flipud(conj(c)))/2;
     f = chebfun(c/sqrt(2*m+1), dom, 'trig', 'coeffs');
     if normalize
-        f = f/sqrt(dt);
+        f = f/sqrt(lambda);
     end
 
 else       % nonperiodic case: call periodic case and restrict
 
-    if dt == inf
-        f = chebfun(randn, dom);    % random constant function
+    if lambda == inf    
+        f = chebfun(randn, dom);        % random constant function
         if normalize
-            f = f/sqrt(dt);         % zero function
+            f = f/sqrt(lambda);         % zero function
         end
         return
     end
 
-    m = round(1.2*diff(dom)/dt+2);
-    dom2 = dom(1) + [0 m*dt];
+    m = round(1.2*diff(dom)/lambda+2);
+    dom2 = dom(1) + [0 m*lambda];
     if normalize
-        f = randnfun(dt, n, dom2, 'norm', 'trig');
+        f = randnfun(lambda, n, dom2, 'norm', 'trig');
     else
-        f = randnfun(dt, n, dom2, 'trig');
+        f = randnfun(lambda, n, dom2, 'trig');
     end
 
            % restrict the result to the prescribed interval
@@ -74,9 +74,9 @@ else       % nonperiodic case: call periodic case and restrict
 end
 end
 
-function [dt, n, dom, normalize, trig] = parseInputs(varargin)
+function [lambda, n, dom, normalize, trig] = parseInputs(varargin)
 
-dt = NaN;
+lambda = NaN;
 n = NaN;
 dom = NaN;
 normalize = 0;
@@ -94,15 +94,15 @@ for j = 1:nargin
         end
     elseif ~isscalar(v)
         dom = v;
-    elseif isnan(dt)
-        dt = v;
+    elseif isnan(lambda)
+        lambda = v;
     else
         n = v;
     end
 end
 
-if isnan(dt)
-   dt = 1;          % default space scale
+if isnan(lambda)
+   lambda = 1;      % default space scale
 end
 if isnan(n)
    n = 1;           % default number of columns

--- a/randnfun2.m
+++ b/randnfun2.m
@@ -1,22 +1,22 @@
 function f = randnfun2(varargin)
 %RANDNFUN2   Random smooth 2D function 
-%   F = RANDNFUN2(DT) returns a smooth CHEBFUN2 on [-1,1,-1,1] with
-%   maximum frequency about 2pi/DT in both the X and Y directions
+%   F = RANDNFUN2(LAMBDA) returns a smooth CHEBFUN2 on [-1,1,-1,1] with
+%   maximum frequency about 2pi/LAMBDA in both the X and Y directions
 %   and standard normal distribution N(0,1) at each point.  F is obtained
 %   by calling RANDNFUN2(T, 'trig') on a domain of dimensions about 20%
 %   greater and restricting the result to [-1,1,-1,1].    
 %
-%   F = RANDNFUN2(DT, DOM) returns a result with domain DOM = [A,B,C,D].
+%   F = RANDNFUN2(LAMBDA, DOM) returns a result with domain DOM = [A,B,C,D].
 %
-%   F = RANDNFUN2(DT, 'norm') normalizes the output by dividing it
-%   by SQRT(DT).  (This may change.)
+%   F = RANDNFUN2(LAMBDA, 'norm') normalizes the output by dividing it
+%   by SQRT(LAMBDA).  (This may change.)
 %
-%   RANDNFUN(DT, 'trig') returns a random doubly periodic function.
+%   RANDNFUN(LAMBDA, 'trig') returns a random doubly periodic function.
 %   This is defined by a finite bivariate Fourier series with independent
 %   normally distributed coefficients of equal variance.
 %
-%   F = RANDNFUN2() uses the default value DT = 1.  Combinations such
-%   as RANDNFUN2(DOM), RANDNFUN2('norm', DT) are allowed.
+%   F = RANDNFUN2() uses the default value LAMBDA = 1.  Combinations such
+%   as RANDNFUN2(DOM), RANDNFUN2('norm', LAMBDA) are allowed.
 %
 % Examples:
 %
@@ -28,13 +28,13 @@ function f = randnfun2(varargin)
 % Copyright 2017 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.
 
-[dt, dom, normalize, trig] = parseInputs(varargin{:});
+[lambda, dom, normalize, trig] = parseInputs(varargin{:});
 
 if trig    % periodic case: random bivariate Fourier series
 
-    m = round(diff(dom(1:2))/dt);
+    m = round(diff(dom(1:2))/lambda);
     m2 = 2*m+1;
-    n = round(diff(dom(3:4))/dt);
+    n = round(diff(dom(3:4))/lambda);
     n2 = 2*n+1;
     c = randn(n2, m2) + 1i*randn(n2, m2);   % random coefficients on a square
     [x,y] = meshgrid(-m:m,-n:n);
@@ -45,27 +45,27 @@ if trig    % periodic case: random bivariate Fourier series
     f = chebfun2(c, dom, 'coeffs', 'trig');
     f = real(f);
     if normalize
-        f = f/sqrt(dt);                     % normalize for 2D white noise
+        f = f/sqrt(lambda);                     % normalize for 2D white noise
     end
 
 else       % nonperiodic case: call periodic case and restrict
 
-    if dt == inf
+    if lambda == inf
         f = chebfun2(randn, dom);    % random constant function
         if normalize
-            f = f/sqrt(dt);          % zero function
+            f = f/sqrt(lambda);          % zero function
         end
         return
     end
     
-    m = round(1.2*(dom(2)-dom(1))/dt+2);
-    n = round(1.2*(dom(4)-dom(3))/dt+2);
-    dom2 = [ dom(1) dom(1)+m*dt dom(3) dom(3)+n*dt ];
+    m = round(1.2*(dom(2)-dom(1))/lambda+2);
+    n = round(1.2*(dom(4)-dom(3))/lambda+2);
+    dom2 = [ dom(1) dom(1)+m*lambda dom(3) dom(3)+n*lambda ];
 
     if normalize
-        f = randnfun2(dt, dom2, 'norm', 'trig');
+        f = randnfun2(lambda, dom2, 'norm', 'trig');
     else
-        f = randnfun2(dt, dom2, 'trig');
+        f = randnfun2(lambda, dom2, 'trig');
     end
     
            % restrict the result to the prescribed domain
@@ -75,9 +75,9 @@ else       % nonperiodic case: call periodic case and restrict
 end
 end
 
-function [dt, dom, normalize, trig] = parseInputs(varargin)
+function [lambda, dom, normalize, trig] = parseInputs(varargin)
 
-dt = NaN;  
+lambda = NaN;  
 dom = NaN;
 normalize = 0;
 trig = 0;
@@ -95,12 +95,12 @@ for j = 1:nargin
     elseif ~isscalar(v)
         dom = v;
     else
-        dt = v;
+        lambda = v;
     end
 end
 
-if isnan(dt)
-   dt = 1;               % default space scale
+if isnan(lambda)
+   lambda = 1;               % default space scale
 end
 if isnan(dom)
    dom = [-1 1 -1 1];    % default domain

--- a/randnfundisk.m
+++ b/randnfundisk.m
@@ -1,11 +1,11 @@
-function f = randnfundisk(dt)
+function f = randnfundisk(lambda)
 %RANDNFUNDISK   Random smooth function on the unit disk
-%   F = RANDNFUNDISK(DT) returns a smooth DISKFUN of maximum
-%   frequency about 2pi/DT and standard normal distribution N(0,1)
-%   at each point.  F is obtained by restricting the output of
-%   RANDNFUN2 to the unit disk.
+%   F = RANDNFUNDISK(LAMBDA) returns a smooth DISKFUN of maximum
+%   frequency about 2pi/LAMBDA and standard normal distribution N(0,1)
+%   at each point.  F is obtained by restricting output of RANDNFUN2
+%   to the unit disk.
 %
-%   RANDNFUNDISK() uses the default value DT = 1.
+%   RANDNFUNDISK() uses the default value LAMBDA = 1.
 %
 % Examples:
 %
@@ -18,13 +18,13 @@ function f = randnfundisk(dt)
 % See http://www.chebfun.org/ for Chebfun information.
 
 if nargin == 0
-    dt = 1;
+    lambda = 1;
 end
 
-if dt > 1
-    fsquare = randnfun2(dt,1.25*[-1 1 -1 1]);         % correct in principle
+if lambda > 1
+    fsquare = randnfun2(lambda,1.25*[-1 1 -1 1]);         % correct in principle
 else
-    fsquare = randnfun2(dt,1.25*[-1 1 -1 1],'trig');  % much faster
+    fsquare = randnfun2(lambda,1.25*[-1 1 -1 1],'trig');  % much faster
 end
 
 % Sample fsquare over a polar tensor product grid that is dense enough to

--- a/randnfunsphere.m
+++ b/randnfunsphere.m
@@ -1,15 +1,15 @@
-function f = randnfunsphere(dt,type)
+function f = randnfunsphere(lambda, type)
 %RANDNFUNSPHERE   Random smooth function on the unit sphere
-%   F = RANDNFUNSPHERE(DT) returns a smooth SPHEREFUN of maximum
-%   frequency about 2pi/DT and standard normal distribution N(0,1)
+%   F = RANDNFUNSPHERE(LAMBDA) returns a smooth SPHEREFUN of maximum
+%   frequency about 2pi/LAMBDA and standard normal distribution N(0,1)
 %   at each point.  F is obtained from a combination of spherical
 %   harmonics with random coefficients.
 %
-%   RANDNFUNSPHERE(DT, 'monochrome') is similar, but uses a
+%   RANDNFUNSPHERE(LAMBDA, 'monochrome') is similar, but uses a
 %   fixed-degree expansion so that all components have wave number
-%   about equal to 2pi/DT.
+%   about equal to 2pi/LAMBDA.
 %
-%   RANDNFUNSPHERE() uses the default value DT = 1.
+%   RANDNFUNSPHERE() uses the default value LAMBDA = 1.
 %
 % Examples:
 %
@@ -26,21 +26,21 @@ function f = randnfunsphere(dt,type)
 
 % Parse the inputs
 if nargin == 0
-    dt = 1;
+    lambda = 1;
     type = 'white';
 elseif nargin == 1
-    % User either called randnspherefun(dt) or randnspherefun('monochromatic')
-    if isnumeric( dt )
+    % User either called randnspherefun(lambda) or randnspherefun('monochromatic')
+    if isnumeric( lambda )
         type = 'white';
-    elseif ( ischar( dt ) && strncmpi(dt,'m',1) )
-        dt = 1;
+    elseif ( ischar( lambda ) && strncmpi(lambda,'m',1) )
+        lambda = 1;
         type = 'monochromatic';
     else
         error('CHEBFUN:SPHEREFUN:randnspherefun:inputUnknown', ...
             'Input argument unknown, options are a positive number or the string ''monochromatic''.');
     end
 elseif nargin == 2
-    if ~isnumeric( dt )
+    if ~isnumeric( lambda )
         error('CHEBFUN:SPHEREFUN:randnspherefun:inputUnknown', ...
             'First input argument must be a positive number.');
     end
@@ -53,7 +53,7 @@ elseif nargin == 2
     end
 end
  
-deg = round(pi/dt);
+deg = round(pi/lambda);
 
 % We do not use adaptive construction, but just sample the function on a
 % fine enough grid to exactly resolve it then pass this to the constructor.


### PR DESCRIPTION
We've had endless confusion in randnfun caused by the parameter dt looking like a differential in an integral.  Accordingly I have renamed it lambda in all the randnfun/2/disk/sphere functions.  This name makes sense since the parameter is equal to a typical wavelength of the functions generated.