### PR TITLE
fix-integral-limits

### DIFF
--- a/@chebfun/integral.m
+++ b/@chebfun/integral.m
@@ -23,6 +23,10 @@ end
 if ( nargin == 1 )
     I = sum(f);
 else
+    if ( (a > f.domain(end)) || (b < f.domain(1)) )
+        error('CHEBFUN:CHEBFUN:integral:domain', ['In integral(f,a,b) ', ...
+            'the interval [a,b] must be a subset of the domain of f.']);
+    end
     I = sum(f, a, b);
 end
 


### PR DESCRIPTION
Integral should only accept a subdomain of the given chebfun.

Closes #2149.