### PR TITLE
Even faster spherefun rotate

### DIFF
--- a/@spherefun/fastSphereEval.m
+++ b/@spherefun/fastSphereEval.m
@@ -133,12 +133,13 @@ X = X(c(:,2));
 breaks = find(diff(srt_ic)); 
 breaks(end+1) = numel(idic); % Include the endpoint
 cnt = 1;
+ov = ones(size(YY,2),1);
 vals = zeros(M, N); % Allocate storage for output.
 for idx = 1:size(c,1)
     % Get the (ii,jj) values that use the same X and Y.
     kk = idic(cnt:breaks(idx));
     % Do the inner product:
-    vals(kk) = sum((U1(kk,:)*Y{idx}).*(U2(kk,:)*X{idx}), 2);
+    vals(kk) = ((U1(kk,:)*Y{idx}).*(U2(kk,:)*X{idx}))*ov;
     cnt = breaks(idx)+1;
 end
 end

--- a/@spherefun/fastSphereEval.m
+++ b/@spherefun/fastSphereEval.m
@@ -86,31 +86,25 @@ U2 = real( chebT(K2-1,er/gam) * besselCoeffs(K2, gam) * Dx );
 V2 = chebT(K2-1, 2*nn'/n) * invDx;
 
 % Business end of the transform. (Everything above could be considered
-% precomputation.)
+% precomputation.) Note that since we know the final result is going to be
+% real, as all spherefun objects are real-valued, we can remove the
+% imaginary components of FFT_rows and FFT_cols:
 FFT_cols = zeros(m,rk,K1);
 for s = 1:K1
     % Transform in the "col" variable:
     CV1 = bsxfun(@times, C, V1(:,s));
-    FFT_cols(:,:,s) = fft( ifftshift(CV1, 1) );
+    FFT_cols(:,:,s) = real( fft( ifftshift(CV1, 1) ) );
 end
 FFT_rows = zeros(rk,n,K2);
 for r = 1:K2
     % Transform in the "row" variable:
     RV2 = bsxfun(@times, R, V2(:,r)).';
-    FFT_rows(:,:,r) = D*fft( ifftshift(RV2,2), [], 2 );
+    FFT_rows(:,:,r) = real( D*fft( ifftshift(RV2,2), [], 2 ) );
 end
-
-% Since we know the final result is going to be real, as all spherefun 
-% objects are real-valued, we can remove the imaginary components of 
-% FFT_rows and FFT_cols: 
-FFT_rows = real(FFT_rows); 
-FFT_cols = real(FFT_cols); 
 
 % Permute:
 XX = permute(FFT_rows, [1 3 2]);
 YY = permute(FFT_cols, [3 2 1]);
-% XX = permute(FFT_rows,[1 3 2]);
-% YY = permute(FFT_cols,[3 2 1]);
 % Convert to cell for speed:
 X = cell(n,1);
 for k = 1:n
@@ -142,7 +136,7 @@ for idx = 1:size(c,1)
     kk = idic(cnt:breaks(idx));
     % Do the inner product:
     A = U1(kk,:)*Y{idx};
-    vals(kk) = (U2(kk,:).*(A*X{idx}))*ov;
+    vals(kk) = (U2(kk,:).*(A*X{idx}))*ov;  % This is faster than sum2
     cnt = breaks(idx)+1;
 end
 end

--- a/@spherefun/fastSphereEval.m
+++ b/@spherefun/fastSphereEval.m
@@ -114,7 +114,7 @@ YY = permute(FFT_cols, [3 2 1]);
 % Convert to cell for speed:
 X = cell(n,1);
 for k = 1:n
-    X{k} = XX(:,:,k).';
+    X{k} = XX(:,:,k);
 end
 Y = cell(size(YY,3),1);
 for k = 1:m
@@ -135,13 +135,14 @@ X = X(c(:,2));
 breaks = find(diff(srt_ic)); 
 breaks(end+1) = numel(idic); % Include the endpoint
 cnt = 1;
-ov = ones(size(YY,2),1);
+ov = ones(K2,1);
 vals = zeros(M, N); % Allocate storage for output.
 for idx = 1:size(c,1)
     % Get the (ii,jj) values that use the same X and Y.
     kk = idic(cnt:breaks(idx));
     % Do the inner product:
-    vals(kk) = ((U1(kk,:)*Y{idx}).*(U2(kk,:)*X{idx}))*ov;
+    A = U1(kk,:)*Y{idx};
+    vals(kk) = (U2(kk,:).*(A*X{idx}))*ov;
     cnt = breaks(idx)+1;
 end
 end

--- a/@spherefun/fastSphereEval.m
+++ b/@spherefun/fastSphereEval.m
@@ -64,8 +64,9 @@ K1 = ceil(5*gam*exp(lw));
 
 % Low rank factors for Ay: 
 Dy = diag((1i).^(0:K1-1));
+invDy = diag((1./1i).^(0:K1-1));
 U1 = real( chebT(K1-1,er/gam) * besselCoeffs(K1, gam) * Dy );
-V1 = chebT(K1-1, 2*mm'/m) / Dy;
+V1 = chebT(K1-1, 2*mm'/m) * invDy;
 
 % Ax = exp(-2*pi*1i*n*(x(:)-xj(:))*nn/n);
 % Find low rank approximation to Ax = U2*V2.':
@@ -80,8 +81,9 @@ K2 = ceil(5*gam*exp(lw));
 
 % Low rank factors for Ax:
 Dx = diag((1i).^(0:K2-1));
+invDx = diag((1./1i).^(0:K2-1));
 U2 = real( chebT(K2-1,er/gam) * besselCoeffs(K2, gam) * Dx );
-V2 = chebT(K2-1, 2*nn'/n) / Dx;
+V2 = chebT(K2-1, 2*nn'/n) * invDx;
 
 % Business end of the transform. (Everything above could be considered
 % precomputation.)

--- a/@spherefun/rotate.m
+++ b/@spherefun/rotate.m
@@ -27,13 +27,8 @@ end
 
 [m, n] = length( f );
 if ( nargin == 4 )
-    % Use the fast transform only when the number lengths of both columns
-    % are greater than 64 and the rank of f is greater than 2.
-    if ( min(m,n) > 64 && numel(cdr(f)) > 2) 
-        method = 'nufft';
-    else
-        method = 'feval';
-    end
+    % Use the fast transform, unless the user tells us otherwise.
+    method = 'nufft'; 
 end
 
 % f is bandlimited of degree (n,m) so its rotation will be bandlimited will


### PR DESCRIPTION
Slightly modify the low-rank representation of the internal matrices `Ay` and `Ax` so that the most expensive line can be done in real arithmetic.  This gives us another x2 speed up in `spherefun.rotate`! 

Now, we have 
```
f = randnfunsphere(0.03); 
tic
g = rotate(f, 0.1, 0.1, 0.1); 
toc
Elapsed time is 0.388473 seconds.
```

We never use the `feval` method now, the `nufft` is almost always faster, and usually by orders of magnitude. 

...We need to start finding out what the world-record is... 👍 