### PR TITLE
Feature Chebyshev Convolution

### DIFF
--- a/@bndfun/conv.m
+++ b/@bndfun/conv.m
@@ -1,4 +1,4 @@
-function h = conv(f, g)
+function h = conv(f, g, pt)
 %CONV   Convolution of BNDFUN objects.
 %   H = CONV(F, G) produces the convolution of BNDFUN objects F and G:
 %                     - 
@@ -17,6 +17,7 @@ function h = conv(f, g)
 % See http://www.chebfun.org/ for Chebfun information.
 %
 % Nick Hale and Alex Townsend, 2014
+% Kuan Xu, 2017
 
 %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % DEVELOPER NOTE:
@@ -24,6 +25,13 @@ function h = conv(f, g)
 % For further details, see Hale and Townsend, "An algorithm for the convolution
 % of Legendre series", SIAM Journal on Scientific Computing, Vol. 36, No. 3,
 % pages A1207-A1220, 2014.
+% 
+% For convolution based on all classic orthogonal polynomials, including 
+% Chebyshev polynomials, Gegenbauer polynomials, Jacobi polynomials, and 
+% Laguerre polynomials, see
+%
+% [1]. Xu and Loureiro, "Spectral approximation of convolution operator" (2017).
+% [2]. Loureiro and Xu, "convolution of Chebyshev polynomials" (2017).
 % 
 % In the following, it is assumed that the length of the domain of g is greater
 % than the length of the domain of f. If this is not the case, then simply
@@ -43,7 +51,7 @@ function h = conv(f, g)
 % The triangular pieces at end are dealt with using a convolution theorem for
 % Legendre polynomials, which leads to a convenient recurrence relation. The
 % cost of this is O(m*n) and results in a polynomial of degree m+n. See
-% EASYCONV() for details.
+% legConv() for details.
 %
 % Similarly one can show the interior rectangle results in a polynomial of
 % degree n. This can be computed by patching with R = floor[(d-c) / (b-a)]
@@ -73,7 +81,7 @@ function h = conv(f, g)
 % size, which turns out to be far more efficient. 
 %
 % Total complexity: O( R*(m*n + n*n) + m*m )
-
+%
 % [TODO]: It's possible this should be pushed further to the chebtech level.
 %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -94,8 +102,17 @@ d = domG(2);
 
 % Ensure that g is the signal (i.e., on the larger domain) and f is the filter:
 if ( (b - a) > (d - c) )
-    h = conv(g, f);
+    h = conv(g, f, pt);
     return
+end
+
+% Method options:
+if ( strcmpi(pt, 'cheb') )
+    pt = 1;
+elseif ( strcmpi(pt, 'leg') )
+    pt = 2;
+else
+    error('CHEBFUN:BNDFUN:conv:validFlag', 'Unrecognizable flag.')
 end
     
 % Useful things:
@@ -104,7 +121,11 @@ numPatches = floor((d - c) / (b - a));       % Number of patches required
 x = chebpts(N, [b+c, a+d], 1);               % Chebyshev grid for interior piece
 y = 0*x;                                     % Initialise values in interior
 map = @(x, a, b) (x-a)/(b-a) - (b-x)/(b-a);  % Map from [a, b] --> [-1, 1]
-f_leg = cheb2leg(get(f, 'coeffs'));  % Legendre coefficients of f
+
+fc = get(f, 'coeffs');
+if ( pt == 2 )
+    fc = cheb2leg(fc);  % Legendre coefficients of f
+end
 
 if ( numPatches > 100 )
     error('CHEBFUN:BNDFUN:conv:tooManyPatches', ...
@@ -129,18 +150,33 @@ for k = 1:numPatches
     dk_right = b + dk(2); %  dkl  dkm   dkr
     gk = g_restricted{k};                          % g on this subdomain
     gk = simplify(gk);                             % Simplify for efficiency
-    gk_leg = cheb2leg(get(gk, 'coeffs'));  % Legendre coefficients
-    [hLegL, hLegR] = easyConv(f_leg, gk_leg);      % Convolution on this domain
+    
+    gkc = get(gk, 'coeffs');
+    
+    if ( pt == 1 )
+        hLc = chebConv(fc, gkc, 1);      % Convolution on this domain
+        hRc = chebConv(fc, gkc, 0);
+    elseif ( pt == 2 )
+        gkc = cheb2leg(gkc);  % Legendre coefficients
+        [hLc, hRc] = legConv(fc, gkc);      % Convolution on this domain
+    end
+    
     
     % The left triangle for the kth patch:
     ind = (dk_left <= x) & (x < dk_mid); % Locate the grid values in [dkl, dkr]:
     if ( k == 1 ) % First piece:
-        hLegL = leg2cheb(hLegL);           % Cheb. coeffs of left tri.
+        if ( pt == 2 )
+            hLc = leg2cheb(hLc);           % Cheb. coeffs of left tri.
+        end
         data.domain = [dk_left, dk_mid];
-        h_left = bndfun({[], hLegL}, data);        % Make BNDFUN from coeffs
+        h_left = bndfun({[], hLc}, data);        % Make BNDFUN from coeffs
     else          % Subsequent left pieces
         z = map(x(ind), dk_left, dk_mid);          % Map grid points to [-1, 1]
-        tmp = clenshawLegendre(z, hLegL);          % Evaluate via recurrence
+        if ( pt == 1 )
+            tmp = clenshawCheb(z, hLc);          % Evaluate via recurrence
+        elseif ( pt == 2 )
+            tmp = clenshawLeg(z, hLc);          % Evaluate via recurrence
+        end
         y(ind) = y(ind) + tmp;                     % Append
     end
     
@@ -149,16 +185,23 @@ for k = 1:numPatches
         % Locate the grid values in [dkl, dkr]:
         ind = (dk_mid <= x) & (x < dk_right);
         z = map(x(ind), dk_mid, dk_right);
-        tmp = clenshawLegendre(z, hLegR);
+        if ( pt == 1 )
+            tmp = clenshawCheb(z, hRc);          
+        elseif ( pt == 2 )
+            tmp = clenshawLeg(z, hRc);
+        end
         y(ind) = y(ind) + tmp;
     end
 end
 
 if ( abs((b-a)-(d-c)) < 10*eps(norm([a b c d], inf)) )
     % If there's only one patch, then we already have all the information reqd.
-    hLegR = leg2cheb(hLegR);       % Cheb coeffs of right tri.
+    
+    if ( pt == 2)
+        hRc = leg2cheb(hRc);       % Cheb coeffs of right tri.
+    end
     data.domain = d + [a b];
-    h_right = bndfun({[], hLegR}, data);   % Make BNDFUN from coeffs
+    h_right = bndfun({[], hRc}, data);   % Make BNDFUN from coeffs
     h_mid = bndfun();
     
 else  
@@ -173,11 +216,19 @@ else
     finishLocation = a + c + numPatches*(b - a);    % Where patches got to. (fl) 
     gk = restrict(g, d-[(b-a) 0]);                  % g on appropriate domain   
     gk = simplify(gk);                              % Simplify for efficiency
-    gk_leg = cheb2leg(get(gk, 'coeffs'));           % Legendre coeffs
-    [hLegL, hLegR] = easyConv(f_leg, gk_leg);       % Conv on A and B
-    hLegR = leg2cheb(hLegR);                % Cheb coeffs on A
+    
+    gkc = get(gk, 'coeffs');
+    if ( pt == 1 )
+        hLc = chebConv(fc, gkc, 1);       % Conv on A and B
+        hRc = chebConv(fc, gkc, 0);       % Conv on A and B
+    elseif ( pt == 2 )
+        gkc = cheb2leg(gkc);           % Legendre coeffs
+        [hLc, hRc] = legConv(fc, gkc);       % Conv on A and B
+        hRc = leg2cheb(hRc);                % Cheb coeffs on A
+    end
+    
     data.domain = [d+a, d+b];
-    h_right = bndfun({[], hLegR}, data);            % Make BNDFUN from coeffs
+    h_right = bndfun({[], hRc}, data);            % Make BNDFUN from coeffs
     
     % Remainder piece: (between fl and a+d)
     remainderWidth = d + a - finishLocation; % b+d-fl-(b-a)
@@ -186,7 +237,11 @@ else
         
         % B: (Coeffs were computed above)
         z = map(x(ind), d - b + 2*a, d + a); % Map grid to [-1, 1]
-        tmp = clenshawLegendre(z, hLegL);    % Evaluate via recurrence
+        if ( pt == 1 )
+            tmp = clenshawCheb(z, hLc);    % Evaluate via recurrence
+        elseif ( pt == 2 )
+            tmp = clenshawLeg(z, hLc);    % Evaluate via recurrence
+        end
         y(ind) = tmp;                        % Store
         
         % C: 
@@ -195,16 +250,32 @@ else
         domfk(end) = min(domfk(end), f.domain(end));    %  valid subdomain
         fk = restrict(f, domfk);                        % Restrict f
         fk = simplify(fk);                              % Simplify f
-        fk_leg = cheb2leg(get(fk, 'coeffs'));   % Legendre coeffs
+        
+        fkc = get(fk, 'coeffs');
+        if ( pt == 2 )
+            fkc = cheb2leg(fkc);   % Legendre coeffs
+        end
+        
         domgk = [finishLocation, d + a] - b;            % Domain of gk
         domgk(1) = max(domgk(1), g.domain(1));          % Ensure domgk is a
         domgk(end) = min(domgk(end), g.domain(end));    %  valid subdomain
         gk = restrict(g, domgk);                        % Restrict g
         gk = simplify(gk);                              % Simplify g
-        gk_leg = cheb2leg(get(gk, 'coeffs'));   % Legendre coeffs
-        [ignored, hLegR] = easyConv(fk_leg, gk_leg);    % Conv 
+        
+        gkc = get(gk, 'coeffs');
+        if ( pt == 1 )
+            hRc = chebConv(fkc, gkc, 0);    % Conv
+        elseif ( pt == 2 )
+            gkc = cheb2leg(gkc);   % Legendre coeffs
+            [ignored, hRc] = legConv(fkc, gkc);    % Conv
+        end
         z = map(x(ind), finishLocation, d + a);         % Map to [-1, 1]
-        tmp = clenshawLegendre(z, hLegR);               % Eval via recurrence
+        
+        if ( pt == 1 )
+            tmp = clenshawCheb(z, hRc);               % Eval via recurrence
+        elseif ( pt == 2 )
+            tmp = clenshawLeg(z, hRc);               % Eval via recurrence
+        end
         y(ind) = y(ind) + tmp*remainderWidth/(b - a);   % Scale and append
     end
     % Convert values to coeffs (we don't want to construct a chebtech1)
@@ -253,7 +324,7 @@ end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-function [gammaL, gammaR] = easyConv(alpha, beta)
+function [gammaL, gammaR] = legConv(alpha, beta)
 % Convolution using Legendre expansions and the analoguous convolution theorem.
 % See Hale and Townsend, "An algorithm for the convolution of Legendre series",
 % SIAM Journal on Scientific Computing, Vol. 36, No. 3, pages A1207-A1220, 2014.
@@ -340,7 +411,7 @@ end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-function val = clenshawLegendre(x, alpha) 
+function val = clenshawLeg(x, alpha) 
 % Evaluate a Legendre expansion with coefficient alpha at x. 
 
 n = length(alpha); 
@@ -356,3 +427,217 @@ val = alpha(1) + x.*b_cur - .5*b_old;
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+function ch = chebConv(cf, cg, lr)
+% Convolution using Chebyshev expansions based a unified framework for all 
+% classic orthogonal polynomials.
+%
+% See [1]. Xu and Loureiro, "Spectral approximation of convolution operator" (2017),
+% and [2]. Loureiro and Xu, "Convolution of Chebyshev polynomials" (2017).
+
+% Lengths:
+M = length(cf)-1;
+N = length(cg)-1;
+
+% Better computational efficiency is achieved when g has the lower degree:
+if ( (N < M && N > 1) || (M < N && M < 2) )
+    tmp = cf;
+    cf = cg;
+    cg = tmp;
+    tmp = M;
+    M = N;
+    N = tmp;
+end
+
+ch = zeros(M+N+2, 1);
+v = ones(1, M+1);
+v(1:2:end) = -1;
+cr = zeros(2*M+5, 1);
+
+%% First three columns:
+
+c0 = int(cf, lr);
+ch(1:M+2) = cg(1)*c0;
+if ( N == 0 )
+    return
+end
+cr(1) = c0(2);
+
+c1 = timesx(c0) + (-1)^lr*[c0; 0] - int(timesx(cf), lr);
+ch(1:M+3) = ch(1:M+3) + cg(2)*c1(1:M+3);
+if ( N == 1 )
+    return
+end
+
+c0 = int(cf, 2);
+c2 = (-1)^(lr+1)*[c0; 0; 0] + 4*int(c1, 2);
+ch(3:M+4) = ch(3:M+4) + cg(3)*c2(3:M+4);
+if ( N == 2 )
+    ch(1:2) = ch(1:2) + cg(3)*c2(1:2);
+    return
+end
+
+c1 = [c1(2:M+3); 0; 0];
+c2 = [c2(3:M+4); 0; 0];
+c3 = zeros(M+4, 1);
+
+cr(2:3) = c1(1:2);
+cr(4:5) = c2(1:2);
+
+%% Recursion below the diagonal
+
+for n = 2:M-1  % n is the true order index
+    m = n + 2; % m is the matrix index
+    c3(1:M+2) = (1+2/(n-1))*c1(3:M+4) + ...
+        (n+1)*(c2(1:M+2)-c2(3:M+4))./(((n+1):(n+M+2)).');
+    c3(1:M-m+3) = c3(1:M-m+3) + (2*(-1)^(lr*n)/(n-1))*c0(m:M+2);
+    
+    ch(m:m+M+1) = ch(m:m+M+1) + cg(m)*c3(1:M+2);
+    
+    cr(2*n+2:2*n+3) = c3(1:2);
+    c1 = c2;
+    c2 = c3;
+end
+
+r = zeros(2, N+2);
+
+for n = M:M+1 % n is the true order index
+    
+    % Recursion:
+    m = n + 2; % m is the matrix index
+    c3(1:M+2) = (1+2/(n-1))*c1(3:M+4) + ...
+        (n+1)*(c2(1:M+2)-c2(3:M+4))./(((n+1):(n+M+2)).');
+    c3(1:M-m+3) = c3(1:M-m+3) + (2*(-1)^(lr*n)/(n-1))*c0(m:M+2);
+    
+    if ( n < N )
+        ch(m:m+M+1) = ch(m:m+M+1) + cg(m)*c3(1:M+2);
+    end
+    
+    cr(2*n+2:2*n+3) = c3(1:2);
+    c1 = c2;
+    c2 = c3;
+    
+    % Reflection:
+    r(M+2-n, 3:M+3) = v.*(m:m+M).*c3(2:M+2).'/(n+1);
+    ch(m) = ch(m) + sum(r(M+2-n, 3:N-n+1).'.*cg(m+1:N+1));
+    
+end
+
+cr(2*(M+2)+1) = [];
+
+r(1, 1:2) = cr(2*(M+1)+1:2*(M+2));
+r(2, 1:2) = cr(2*M+1:2*(M+1));
+
+for n = M+2:N-M-2  % n is the true order index
+    
+    % Recursion:
+    m = n + 2; % m is the matrix index
+    c3(1:M+2) = (1+2/(n-1))*c1(3:M+4) + ...
+        (n+1)*(c2(1:M+2)-c2(3:M+4))./(((n+1):(n+M+2)).');
+    ch(m:m+M+1) = ch(m:m+M+1) + cg(m)*c3(1:M+2);
+    c1 = c2;
+    c2 = c3;
+    
+    % Reflection:
+    %     m = n + 1; % m is the matrix index
+    ch(m) = ch(m) + (v.*(m:m+M).*c3(2:M+2).'/(n+1))*cg(m+1:m+M+1);
+end
+
+for n = max(M+2, N-M-1):N-1  % n is the true order index
+    
+    % Recursion:
+    m = n + 2; % m is the matrix index
+    c3(1:M+2) = (1+2/(n-1))*c1(3:M+4) + ...
+        (n+1)*(c2(1:M+2)-c2(3:M+4))./(((n+1):(n+M+2)).');
+    ch(m:m+M+1) = ch(m:m+M+1) + cg(m)*c3(1:M+2);
+    c1 = c2;
+    c2 = c3;
+    
+    % Reflection:
+    %     m = n + 1; % m is the matrix index
+    ch(m) = ch(m) + (v(1:N-n-1).*(m:N).*c3(2:N-n).'/(n+1))*cg(m+1:N+1);
+end
+
+%% Recursion for the top rows
+
+r1 = r(1, :);
+r2 = r(2, :);
+r3 = zeros(1, N+2);
+
+for m = M+1:-1:2
+    n = m:m+N-1;
+    r3(1:2) = cr(2*(m-1)-1:2*(m-1));
+    r3(3:N+2) = m*r2(1:N)./(1-n) + m*r2(3:N+2)./(n+1) + r1(1:N)...
+        -2*m*(-1).^(lr*n).*c0(m+1)./(n.^2-1);
+    
+    ch(m) = ch(m) + r3(3:N-m+3)*cg(m+1:N+1);
+    r1 = r2;
+    r2 = r3;
+end
+
+n = 2:N;
+ch(1) = ch(1) + (r2(n)./(1-n) + r2(4:N+2)./(n+1) + r1(n)...
+    -2*(-1).^(lr*n).*c0(2)./(n.^2-1))*cg(3:N+1)/2;
+
+
+%% integration:
+
+    function b = int(c, mode)
+        
+        k = length(c);
+        c = [c; 0; 0];          % Pad with zeros
+        b = zeros(k+1, 1);   % Initialize vector b = {b_r}
+        
+        % Compute b_(2) ... b_(n+1):
+        b(3:k+1) = (c(2:k)-c(4:k+2))./(2*(2:k).');
+        b(2) = c(1)-c(3)/2;        % Compute b_1
+        
+        if ( mode == 1 )
+            w = ones(1, k);
+            w(2:2:end) = -1;
+            b(1) = w*b(2:end);             % Compute b_0 (satisfies f(-1) = 0)
+        elseif ( mode == 0 )
+            b(1) = sum(b(2:end));
+            b(2:end) = -b(2:end);
+        elseif( mode == 2 )
+            b(1) = -sum(b(2:end));
+        end
+        
+    end
+
+%% product with x:
+
+    function b = timesx(c)
+        
+        j = length(c);
+        c = [c; 0; 0];       % Pad with zeros
+        b = zeros(j+1, 1);   % Initialize vector b = {b_r}
+        
+        % Compute b_(2) ... b_(j+1):
+        b(3:j+1) = (c(2:j)+c(4:j+2))/2;
+        b(2) = c(1)+c(3)/2;  % Compute b_1
+        b(1) = c(2)/2;
+        
+    end
+
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+function val = clenshawCheb(x, alpha)
+% Evaluate a Chebyshev expansion with coefficient alpha at x.
+
+bk1 = 0*x;
+bk2 = bk1;
+x = 2*x;
+n = size(alpha,1)-1;
+for k = (n+1):-2:3
+    bk2 = alpha(k) + x.*bk1 - bk2;
+    bk1 = alpha(k-1) + x.*bk2 - bk1;
+end
+if ( mod(n, 2) )
+    [bk1, bk2] = deal(alpha(2) + x.*bk1 - bk2, bk1);
+end
+val = alpha(1) + .5*x.*bk1 - bk2;
+
+end

--- a/@chebfun/conv.m
+++ b/@chebfun/conv.m
@@ -147,7 +147,7 @@ else
 
     % Ensure g is the signal (i.e., on the larger domain) and f is the filter:
     if ( (b - a) > (d - c) )
-        h = conv(g, f);
+        h = conv(g, f, varargin{:});
         return
     end
 

--- a/@chebfun/conv.m
+++ b/@chebfun/conv.m
@@ -37,6 +37,10 @@ function h = conv(f, g, varargin)
 %   [1] N. Hale and A. Townsend, "An algorithm for the convolution of Legendre
 %   series", SIAM Journal on Scientific Computing, Vol. 36, No. 3,
 %   pp. A1207-A1220, 2014.
+% 
+%   [2]. Xu and Loureiro, "Spectral approximation of convolution operator"
+%   (2017).
+%   [3]. Loureiro and Xu, "Convolution of Chebyshev polynomials" (2017).
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
@@ -90,6 +94,9 @@ if ( isempty(f) || isempty(g) )
     return
 end
 
+pt = 'cheb';
+% pt = 'leg';
+
 % Parse inputs:
 oldMethod = false;
 same = false;
@@ -99,6 +106,10 @@ for k = 1:numel(varargin)
         oldMethod = true;
     elseif ( strcmpi(vk, 'same') )
         same = true;
+    elseif ( strcmpi(vk, 'cheb') )
+        pt = 'cheb';
+    elseif ( strcmpi(vk, 'leg') )
+        pt = 'leg';
     elseif ( strcmpi(vk, 'full') )
         % Do nothing.
     elseif ( strcmpi(vk, 'valid') )
@@ -146,7 +157,7 @@ else
     for j = 1:numel(f.funs)
         for k = 1:numel(g.funs)
             % Compute the contribution of jth fun of f with kth fun of g:
-            hjk = conv(f.funs{j}, g.funs{k});  
+            hjk = conv(f.funs{j}, g.funs{k}, pt);  
             % Add this contribution:            
             h = myplus(h, chebfun(hjk));
         end

--- a/@deltafun/conv.m
+++ b/@deltafun/conv.m
@@ -1,4 +1,4 @@
-function h = conv(f, g)
+function h = conv(f, g, pt)
 %CONV   Convolution of DELTAFUN objects.
 %   H = CONV(F, G) produces the convolution of DELTAFUN objects F and G:
 %                     - 
@@ -65,7 +65,7 @@ pref = chebfunpref();
 deltaTol = pref.deltaPrefs.deltaTol;
 
 % Compute the convolution of funParts and append it to the output cell:
-h = conv(funF, funG);
+h = conv(funF, funG, pt);
 
 % Remove zero funs for simplicity:
 zeroIndices = cellfun( @(hk) iszero(hk), h);

--- a/@deltafun/conv.m
+++ b/@deltafun/conv.m
@@ -65,7 +65,7 @@ pref = chebfunpref();
 deltaTol = pref.deltaPrefs.deltaTol;
 
 % Compute the convolution of funParts and append it to the output cell:
-h = conv(funF, funG, pt);
+h = conv(funF, funG, 'cheb');
 
 % Remove zero funs for simplicity:
 zeroIndices = cellfun( @(hk) iszero(hk), h);

--- a/tests/chebfun/test_conv.m
+++ b/tests/chebfun/test_conv.m
@@ -14,150 +14,173 @@ h = chebfun(@(x) cos(2*x), [-3 1]);
 p = chebfun(@(x) sin(15*x), [-1 1]);
 q = chebfun(@(x) exp(cos(3*x)), [-1 1]);
 
-%% 1. Test the commutativity.
-H1 = conv(f, g);
-H2 = conv(g, f);
-pass(1) = norm(H1 - H2) < 100*eps;
+j = 0;
 
-%% 2. Test the associativity.
-H1 = conv(conv(f, g), h);
-H2 = conv(f, conv(g, h));
-pass(2) = norm(H1 - H2) < 100*eps;
-
-%% 3. Test the distributivity.
-H1 = conv(f, (p + q));
-H2 = conv(f, p) + conv(f, q);
-pass(3) = norm(H1 - H2) < 100*eps;
-
-%% 4. Test B-splines.
-% Generates piecewise polynomial cardinal B-splines by a process of
-% convolution, with CONV, then estimates the error compared to the exact
-% solution B, using NORM. For more on generating B-splines using convolution,
-% see e.g. http://en.wikipedia.org/wiki/B-spline
-B = (1/6)*chebfun( {@(x) (2+x).^3, ...
-    @(x)1 + 3*(1+x) + 3*(1+x).^2 - 3*(1+x).^3, ...
-    @(x)1 + 3*(1-x) + 3*(1-x).^2 - 3*(1-x).^3, ...
-    @(x)(2-x).^3}, -2:2 );
-s = chebfun(1, [-.5 .5]);
-f = s;
-for k = 1:3
-    f = conv(f, s);
-end
-pass(4) = norm(f - B) < 100*eps*vscale(f);
-
-%% 5. Test more splines.
-f = chebfun(1/2); 
-g = f;
-for j = 2:4
-    g = conv(f, g);
-end
-pass(5) = abs(feval(g, 1) - 23/96) < 100*eps;
-
-%% 6. Test the example from the HELP text:
-f = chebfun(1/2); g = f;
-for j = 2:4
-    g = conv(f, g); 
-end
-g1 = g(.1);
-for j = 1:4
-    g = diff(g); 
-end
-g2 = g(.1);
-err = abs(g1 - 0.332114583333333) + abs(g2 - 0);
-pass(6) = err < 1e-14;
+for algo = ["cheb", "leg"]
     
-%% 7. Test the example from ATAP
-a = 0.2885554757; b = 0.3549060246;
-g = chebfun(@(x) sin(1./x).*sin(1./sin(1./x)), [a,b], 80, 'chebkind', 2);
-t = 1e-7;
-f = chebfun(@(x) exp(-x.^2/(4*t))/sqrt(4*pi*t),.003*[-1 1]);
-h = conv(f, g);
-err = abs(norm(h,2) - 0.029781437647379);
-tol = 10*max(get(f, 'vscale')*eps, ...
-    eps*get(g, 'vscale'));
-pass(7) = err < tol;
-
-%% An Example due to Mohsin Javed:
-f = chebfun(@(x) x, [-1.5 0] );
-g = chebfun(@(x) sin(x), [-1 1]);
-h1 = conv(f, g);
-h2 = conv(f, g, 'old');
-tol = 10*max(get(f, 'vscale')*eps, ...
-    eps*get(g, 'vscale'));
-pass(8) = norm(h1 - h2, inf) < tol;
-
-%% Testing Delta function convolution
-% Delta funciton reproduces the function under convolution:
-f = chebfun({@(x) sin(x), @(x) cos(x), @(x) sin(4*x.^2)}, [-2, -1, 0, 1] );
-x = chebfun('x', [-2, 1] );
-d = dirac(x);
-g = conv(d, f);
-g = restrict(g, [-2, 1]);
-g.pointValues(1) = 2*g.pointValues(1);
-g.pointValues(end) = 2*g.pointValues(end);
-pass(9) = norm(f - g, inf) < tol;
-
-% Derivative of delta function differentiates the function:
-x = chebfun('x');
-f = sin(x);
-g = conv(f, diff(dirac(x)));
-g = restrict(g, [-1, 1] );
-g.pointValues(1) = 2*g.pointValues(1);
-g.pointValues(end) = 2*g.pointValues(end);
-pass(10) = norm(g - cos(x), inf ) < 10*tol;
-
-% Second order ODE via delta functions and convolutions:
-% g = f'' + f
-f = sin(x);
-g = conv(f, diff(dirac(x), 2) + dirac(x));
-g = restrict(g, [-1, 1] );
-g.pointValues(1) = 2*g.pointValues(1);
-g.pointValues(end) = 2*g.pointValues(end);
-pass(11) = norm(g , inf ) < 1e3*tol;
-
-%% Maurice's Cox examples: 
-fX1 = chebfun(@(x) exp(x), [0, log(2)]);
-fX2 = chebfun(@(x) exp(x), [log(2), log(3)]);
-fX3 = chebfun(@(x) exp(x), [log(3), log(4)]);
-g1 = conv(fX1, fX3);
-g2 = conv(g1, fX2);
-
-g3 = conv(fX1, fX2);
-g4 = conv(g3, fX3);
-pass(12) = normest( g2 - g4 ) < 1e1*tol; 
-
-g5 = conv(fX2, fX3);
-g6 = conv(g5, fX1);
-pass(13) = normest( g2 - g6 ) < 1e1*tol; 
-
-%% test 'same' option
-f = chebfun(@(x) exp(-x.^2), [-10 10]);
-g = chebfun(@(x) exp(-x.^2), [-20 20]);
-h = conv(f, f, 'same');
-pass(14) = norm(h.domain([1, end]) - [-10 10], inf) < eps*10;
-
-h = conv(f, g, 'same');
-pass(15) = norm(h.domain([1, end]) - [-10 10], inf) < eps*10;
-
-%% test quasimatrix option
-f = chebfun(@sin);
-g = chebfun(@cos);
-fg = [f g];
-gg = [g g];
-h1 = conv(fg, gg);
-h2 = [conv(f,g), conv(g,g)];
-pass(16) = norm(h1 - h2) < eps*10;
-
-ffg = conv([f f],g);
-fgg = conv(f,[g g]);
-pass(17) = norm(ffg-fgg) < 10*eps;
-
-cheb.x;
-phi = @(t) chebfun(@(x) exp(-x^2/(4*t))/sqrt(4*pi*t));
-f = 1 - 0.2*x - abs(x-0.2);
-fsmooth = conv(f,phi(1e-4),'same');
-pass(18) = norm(f-fsmooth) < .01;
-
+    %% 1. Test the commutativity.
+    H1 = conv(f, g, algo);
+    H2 = conv(g, f, algo);
+    j = j+1;
+    pass(j) = norm(H1 - H2) < 100*eps;
+    
+    %% 2. Test the associativity.
+    H1 = conv(conv(f, g, algo), h, algo);
+    H2 = conv(f, conv(g, h, algo), algo);
+    j = j+1;
+    pass(j) = norm(H1 - H2) < 100*eps;
+    
+    %% 3. Test the distributivity.
+    H1 = conv(f, (p + q), algo);
+    H2 = conv(f, p, algo) + conv(f, q, algo);
+    j = j+1;
+    pass(j) = norm(H1 - H2) < 100*eps;
+    
+    %% 4. Test B-splines.
+    % Generates piecewise polynomial cardinal B-splines by a process of
+    % convolution, with CONV, then estimates the error compared to the exact
+    % solution B, using NORM. For more on generating B-splines using convolution,
+    % see e.g. http://en.wikipedia.org/wiki/B-spline
+    B = (1/6)*chebfun( {@(x) (2+x).^3, ...
+        @(x)1 + 3*(1+x) + 3*(1+x).^2 - 3*(1+x).^3, ...
+        @(x)1 + 3*(1-x) + 3*(1-x).^2 - 3*(1-x).^3, ...
+        @(x)(2-x).^3}, -2:2 );
+    s = chebfun(1, [-.5 .5]);
+    f = s;
+    for k = 1:3
+        f = conv(f, s, algo);
+    end
+    j = j+1;
+    pass(j) = norm(f - B) < 100*eps*vscale(f);
+    
+    %% 5. Test more splines.
+    f = chebfun(1/2);
+    g = f;
+    for k = 2:4
+        g = conv(f, g, algo);
+    end
+    j = j+1;
+    pass(j) = abs(feval(g, 1) - 23/96) < 100*eps;
+    
+    %% 6. Test the example from the HELP text:
+    f = chebfun(1/2); g = f;
+    for k = 2:4
+        g = conv(f, g, algo);
+    end
+    g1 = g(.1);
+    for k = 1:4
+        g = diff(g);
+    end
+    g2 = g(.1);
+    err = abs(g1 - 0.332114583333333) + abs(g2 - 0);
+    j = j+1;
+    pass(j) = err < 1e-14;
+    
+    %% 7. Test the example from ATAP
+    a = 0.2885554757; b = 0.3549060246;
+    g = chebfun(@(x) sin(1./x).*sin(1./sin(1./x)), [a,b], 80, 'chebkind', 2);
+    t = 1e-7;
+    f = chebfun(@(x) exp(-x.^2/(4*t))/sqrt(4*pi*t),.003*[-1 1]);
+    h = conv(f, g, algo);
+    err = abs(norm(h,2) - 0.029781437647379);
+    tol = 10*max(get(f, 'vscale')*eps, ...
+        eps*get(g, 'vscale'));
+    j = j+1;
+    pass(j) = err < tol;
+    
+    %% An Example due to Mohsin Javed:
+    f = chebfun(@(x) x, [-1.5 0] );
+    g = chebfun(@(x) sin(x), [-1 1]);
+    h1 = conv(f, g, algo);
+    h2 = conv(f, g, 'old');
+    tol = 10*max(get(f, 'vscale')*eps, ...
+        eps*get(g, 'vscale'));
+    j = j+1;
+    pass(j) = norm(h1 - h2, inf) < tol;
+    
+    %% Testing Delta function convolution
+    % Delta funciton reproduces the function under convolution:
+    f = chebfun({@(x) sin(x), @(x) cos(x), @(x) sin(4*x.^2)}, [-2, -1, 0, 1] );
+    x = chebfun('x', [-2, 1] );
+    d = dirac(x);
+    g = conv(d, f, algo);
+    g = restrict(g, [-2, 1]);
+    g.pointValues(1) = 2*g.pointValues(1);
+    g.pointValues(end) = 2*g.pointValues(end);
+    j = j+1;
+    pass(j) = norm(f - g, inf) < tol;
+    
+    % Derivative of delta function differentiates the function:
+    x = chebfun('x');
+    f = sin(x);
+    g = conv(f, diff(dirac(x)), algo);
+    g = restrict(g, [-1, 1] );
+    g.pointValues(1) = 2*g.pointValues(1);
+    g.pointValues(end) = 2*g.pointValues(end);
+    j = j+1;
+    pass(j) = norm(g - cos(x), inf ) < 10*tol;
+    
+    % Second order ODE via delta functions and convolutions:
+    % g = f'' + f
+    f = sin(x);
+    g = conv(f, diff(dirac(x), 2) + dirac(x), algo);
+    g = restrict(g, [-1, 1] );
+    g.pointValues(1) = 2*g.pointValues(1);
+    g.pointValues(end) = 2*g.pointValues(end);
+    j = j+1;
+    pass(j) = norm(g , inf ) < 1e3*tol;
+    
+    %% Maurice's Cox examples:
+    fX1 = chebfun(@(x) exp(x), [0, log(2)]);
+    fX2 = chebfun(@(x) exp(x), [log(2), log(3)]);
+    fX3 = chebfun(@(x) exp(x), [log(3), log(4)]);
+    g1 = conv(fX1, fX3, algo);
+    g2 = conv(g1, fX2, algo);
+    
+    g3 = conv(fX1, fX2, algo);
+    g4 = conv(g3, fX3, algo);
+    j = j+1;
+    pass(j) = normest( g2 - g4 ) < 1e1*tol;
+    
+    g5 = conv(fX2, fX3, algo);
+    g6 = conv(g5, fX1, algo);
+    j = j+1;
+    pass(j) = normest( g2 - g6 ) < 1e1*tol;
+    
+    %% test 'same' option
+    f = chebfun(@(x) exp(-x.^2), [-10 10]);
+    g = chebfun(@(x) exp(-x.^2), [-20 20]);
+    h = conv(f, f, 'same', algo);
+    j = j+1;
+    pass(j) = norm(h.domain([1, end]) - [-10 10], inf) < eps*10;
+    
+    h = conv(f, g, 'same', algo);
+    j = j+1;
+    pass(j) = norm(h.domain([1, end]) - [-10 10], inf) < eps*10;
+    
+    %% test quasimatrix option
+    f = chebfun(@sin);
+    g = chebfun(@cos);
+    fg = [f g];
+    gg = [g g];
+    h1 = conv(fg, gg, algo);
+    h2 = [conv(f,g, algo), conv(g,g, algo)];
+    j = j+1;
+    pass(j) = norm(h1 - h2) < eps*10;
+    
+    ffg = conv([f f],g, algo);
+    fgg = conv(f,[g g], algo);
+    j = j+1;
+    pass(j) = norm(ffg-fgg) < 10*eps;
+    
+    cheb.x;
+    phi = @(t) chebfun(@(x) exp(-x^2/(4*t))/sqrt(4*pi*t));
+    f = 1 - 0.2*x - abs(x-0.2);
+    fsmooth = conv(f,phi(1e-4),'same', algo);
+    j = j+1;
+    pass(j) = norm(f-fsmooth) < .01;
+    
+end
 
 end
 


### PR DESCRIPTION
This introduces a new algorithm for convolution of `chebfuns`, which is fully based on Chebyshev polynomials. It's equally fast as the current algorithm which relies on conversion between Chebyshev and Legendre coefficients. 

The new method also offers a unified framework for approximating convolution operator in coefficient space for all classic orthogonal polynomials, including Chebyshev, Gegenbauer (Legendre as a special case), Jacobi, and Laguerre. It generalizes the work by Hale and Townsend (2014).

Manuscripts describing the method will be furnished soon.

All tests pass.