### PR TITLE
modifications to randnfun

### DIFF
--- a/randnfun.m
+++ b/randnfun.m
@@ -2,24 +2,26 @@ function f = randnfun(varargin)
 %RANDNFUN   Random smooth function
 %   F = RANDNFUN(LAMBDA) returns a smooth CHEBFUN on [-1,1] with maximum
 %   frequency about 2pi/LAMBDA and standard normal distribution N(0,1)
-%   at each point.  F can be regarded as one sample path of a Gaussian
+%   at each point.  F can be regarded as a sample path of a Gaussian
 %   process.  It is obtained by calling RANDNFUN(LAMBDA, 'trig') on an
-%   interval about 20% longer and restricting the result to [-1,1].
+%   interval 20% longer and restricting the result to [-1,1].
 %
 %   RANDNFUN(LAMBDA, DOM) returns a result with domain DOM = [A, B].
 %
 %   RANDNFUN(LAMBDA, N) returns a quasimatrix with N independent columns.
 %
-%   RANDNFUN(LAMBDA, 'norm') normalizes the output by dividing it by
-%   SQRT(LAMBDA), so white noise is approached in the limit LAMBDA -> 0.
+%   RANDNFUN(LAMBDA, 'norm') normalizes the output by dividing it by about
+%   SQRT(2*LAMBDA), so white noise is approached in the limit LAMBDA -> 0.
 %
 %   RANDNFUN(LAMBDA, 'trig') returns a random periodic function.  This
-%   is defined by a finite Fourier series with independent normally
+%   is defined by a finite Fourier-Wiener series with independent normally
 %   distributed coefficients of equal variance.
 %
+%   RANDNFUN(LAMBDA, 'complex') returns a complex random function.
+%
 %   RANDNFUN() uses the default value LAMBDA = 1.  Combinations such
-%   as RANDNFUN(DOM), RANDNFUN('norm', LAMBDA) are allowed so long as
-%   LAMBDA, if present, precedes N, if present.
+%   as RANDNFUN(DOM) and RANDNFUN('norm', LAMBDA) are allowed so long as
+%   N, if present, is preceded by an explicit specification of LAMBDA.
 %
 % Examples:
 %
@@ -28,59 +30,88 @@ function f = randnfun(varargin)
 %
 %   X = randnfun(.01,2); cov(X)
 %
-%   f = randnfun(0.1,'norm',[0 10]); plot(cumsum(f))
+%   s = randi(100);
+%   rng(s), f1 = randnfun(0.5,'norm',[0 10],3);
+%   rng(s), f2 = randnfun(0.1,'norm',[0 10],3);
+%   plot(cumsum(f1),'k',cumsum(f2),'r')
 %
 % See also RANDNFUN2, RANDNFUNSPHERE, RANDNFUNDISK.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.
 
-[lambda, n, dom, normalize, trig] = parseInputs(varargin{:});
+[lambda, n, dom, normalize, trig, cmplx] = parseInputs(varargin{:});
 
-if trig    % periodic case: random Fourier series
+if trig    % periodic case: finite Fourier-Wiener series.
+           % See sec. 16.3 of Kahane, "Some Random Series of Functions".
+           % Usually Fourier-Wiener series are written with sines and
+           % cosines, but we use complex arithmetic because that's what
+           % the trigtech constructor expects with 'coeffs'.
+           % The reordered index vector ii is introduced so that
+           % the random coefficients are chosen in the order
+           % correponding to wave numbers 0, 1, -1, 2, -2, 3, ....
 
-    m = round(diff(dom)/lambda);
-    c = randn(2*m+1, n) + 1i*randn(2*m+1, n);
-    c = (c + flipud(conj(c)))/2;
-    f = chebfun(c/sqrt(2*m+1), dom, 'trig', 'coeffs');
-    if normalize
-        f = f/sqrt(lambda);
+    L = diff(dom);
+    m = round(L/lambda);
+    c = randn(2*n, 2*m+1);                       % real numbers, var 1
+    ii = [2*m+1:-2:1 2:2:2*m];
+    c = c(:,ii)'; 
+    c = (c(:,1:n) + 1i*c(:,n+(1:n)))/sqrt(2);    % complex coeffs, var 1
+    if ~cmplx
+        c = (c + flipud(conj(c)))/sqrt(2);       % real coeffs, var 1
     end
+    if normalize
+        c = c/sqrt(L/2);    % on [-1,1], coeffs from N(0,1) (finite F-W series)
+    else
+        c = c/sqrt(2*m+1);  % regardless of domain, function values from N(0,1)
+    end
+    f = chebfun(c, dom, 'trig', 'coeffs');
 
 else       % nonperiodic case: call periodic case and restrict
 
+    dom2 = dom(1) + [0 1.2*diff(dom)];
+    m = round(diff(dom)/lambda);
+
     if lambda == inf    
-        f = chebfun(randn, dom);        % random constant function
-        if normalize
-            f = f/sqrt(lambda);         % zero function
+        c = randn;
+        if cmplx
+            c = (c + 1i*randn)/sqrt(2)
         end
-        return
+        f = chebfun(c, dom);        % random constant function
+	return
     end
 
-    m = round(1.2*diff(dom)/lambda+2);
-    dom2 = dom(1) + [0 m*lambda];
-    if normalize
-        f = randnfun(lambda, n, dom2, 'norm', 'trig');
+    if cmplx
+        if normalize
+            f = randnfun(lambda, n, dom2, 'norm', 'trig', 'complex');
+        else
+            f = randnfun(lambda, n, dom2, 'trig', 'complex');
+        end
     else
-        f = randnfun(lambda, n, dom2, 'trig');
+        if normalize
+            f = randnfun(lambda, n, dom2, 'norm', 'trig');
+        else
+            f = randnfun(lambda, n, dom2, 'trig');
+        end
     end
 
            % restrict the result to the prescribed interval
-
-    x = chebpts(5*m, dom);    % 5*m is large enough...
+ 
+    x = chebpts(5*m+5, dom);  % this number is large enough...
     f = chebfun(f(x), dom);   % ...so this is equiv. to f{dom(1),dom(2)}
     f = simplify(f, 1e-13);   % loosened tolerance gives clean Cheb series
 
 end
 end
 
-function [lambda, n, dom, normalize, trig] = parseInputs(varargin)
+function [lambda, n, dom, normalize, trig, cmplx] = parseInputs(varargin)
 
 lambda = NaN;
 n = NaN;
 dom = NaN;
 normalize = 0;
 trig = 0;
+cmplx = 0;
 
 for j = 1:nargin
     v = varargin{j};
@@ -89,6 +120,8 @@ for j = 1:nargin
             normalize = 1;
         elseif ( v(1) == 't' )
             trig = 1;
+        elseif ( v(1) == 'c' )
+            cmplx = 1;
         else
             error('CHEBFUN:randnfun','Unrecognized string input')
         end

--- a/tests/misc/test_randnfun.m
+++ b/tests/misc/test_randnfun.m
@@ -18,8 +18,8 @@ X = cov(A);
 pass(4) = (norm(X-X') == 0);
 
 rng(0), f1 = randnfun('norm',1/64,[0 3]);
-rng(0), f2 = 8*randnfun(1/64, 1, [0 3]);
-pass(5) = norm(f1-f2) == 0;
+rng(0), f2 = 2*sqrt(64)*randnfun(1/64, 1, [0 3]);
+pass(5) = norm(f1-f2) < .2*norm(f1);
 
 rng(0), f1 = randnfun(1,[0 4]);
 rng(0), f2 = randnfun(1/4,[0 1]);
@@ -47,9 +47,9 @@ pass(12) = (norm(X-X') == 0);
 f = randnfun('trig') + 1i*randnfun('trig');
 pass(13) = (abs(f(-.999)-f(.999)) < .1);
 
-rng(0), f1 = randnfun(1/16,'norm','trig')/4;
+rng(0), f1 = randnfun(1/16,'norm','trig')/8;
 rng(0), f2 = randnfun(1/16,'trig');
-pass(14) = norm(f1-f2) == 0;
+pass(14) = norm(f1-f2) < .2*norm(f1);
 
 rng(0), f1 = randnfun(1,[0 4],'trig');
 rng(0), f2 = randnfun(1/4,[0 1],'trig');
@@ -61,5 +61,14 @@ pass(16) = norm(f1([.8 1.2])-f2([4.8 5.2])) < 1e-14;
 
 f = randnfun(6,'trig');
 pass(17) = norm(diff(f)) == 0;
+
+rng(1), f1 = cumsum(randnfun([7,17],.3,'norm'));
+rng(1), f2 = cumsum(randnfun([7,17],.1,'norm'));
+pass(18) = mean(f1-f2) < .5;
+
+rng(0)
+f = randnfun(.3,'complex',[0 77]);
+pass(19) = (abs(std(f)-1) < .1);
+pass(20) = (abs(mean(f)) < .1);
 
 end


### PR DESCRIPTION
I've made some modifications to `randnfun` to match the literature of Fourier-Wiener series better, and to make it possible to construct Brownian paths or random ODE solutions that converge to a single path as lambda -> 0.   For example the commands
``` 
s = randi(100);
rng(s), f1 = randnfun(0.5,'norm',[0 10],3);
rng(s), f2 = randnfun(0.1,'norm',[0 10],3);
plot(cumsum(f1),'k',cumsum(f2),'r')
```
give a plot like the one below.

I'm going to merge this myself, because nobody else is around just now and I need to code for my talk at the SIAM Annual Meeting next week.
![newrandnfun](https://user-images.githubusercontent.com/3601488/27954768-669e325a-6309-11e7-80c6-e2d268dcfe0b.png)
