### PR TITLE
feature-ultra-to-ultra

### DIFF
--- a/jac2jac.m
+++ b/jac2jac.m
@@ -59,6 +59,11 @@ Lambda4 = @(z) exp( gammaln( z+beta+1 ) - gammaln( z + alpha +beta + 1) );
 
 % Diagonal matrices in A = D1(T.*H)D2:
 [N, numCols] = size(v); % Size of coefficients.
+if ( N == 1 )
+    c_jac = v;
+    return
+end
+
 D1 = spdiags( ((2*(0:N-1)+gam+beta+1).*Lambda3([1 1:N-1]))',0,N,N ); 
 D1(1,1) = 1;
 D2 = 1./gamma(alpha-gam)*spdiags( Lambda4([1 1:N-1])', 0, N, N );
@@ -95,6 +100,9 @@ while ( mx > tol )
 end
 sz = size(C, 2);                                     % Numerical rank of H.
 C = C * spdiags( sqrt( pivotValues ), 0, sz, sz );   % Share out scaling.
+if ( sz == 1 )
+    C = full(C); % (C will be sparse if sz = 1)
+end
 
 % Upper-triangular Toeplitz matrix in A = D1(T.*H)D2:
 T_row = Lambda2( [1, 1:N-1] );

--- a/tests/misc/test_ultra2ultra.m
+++ b/tests/misc/test_ultra2ultra.m
@@ -1,0 +1,35 @@
+function pass = test_ultra2ultra(pref)
+% Test for ultra2ultra
+
+% TO test, we construct a chebfun and obtain it's coefficients using
+% chebfun.ultracoeffs for two values of lamba. We then convert between these
+% expansions using ultra2ultra and check the difference is within tolerance. 
+% (This test therefore assumes that chebfun.ultracoeffs is behaving correctly.)
+
+if ( nargin == 0 )
+    pref = chebfunpref;
+end
+
+tol = 100*eps;
+
+%% Real-valued function
+
+f = chebfun(@exp, pref);
+lam1 = .6;
+lam2 = .7;
+c1 = ultracoeffs(f, lam1);
+c2 = ultracoeffs(f, lam2);
+pass(1) = norm(ultra2ultra(c1, lam1, lam2) - c2) < tol;
+pass(2) = norm(ultra2ultra(c2, lam2, lam1) - c1) < tol;
+
+%% Complex-valued function
+
+f = chebfun(@(x) exp(1i*x), [0 3], pref);
+lam1 = .6;
+lam2 = .7;
+c1 = ultracoeffs(f, lam1);
+c2 = ultracoeffs(f, lam2);
+pass(3) = norm(ultra2ultra(c1, lam1, lam2) - c2) < tol;
+pass(4) = norm(ultra2ultra(c2, lam2, lam1) - c1) < tol;
+
+end

--- a/ultra2ultra.m
+++ b/ultra2ultra.m
@@ -1,0 +1,38 @@
+function c = ultra2ultra(c, lam_in, lam_out)
+%ULTRA2ULTRA   Convert between Ultraspherical (US) expansions.
+%   C_OUT = ULTRA2ULTRA(C_IN, LAM_IN, LAM_OUT) converts the vector C_IN of
+%   US-LAM_IN coefficients to a vector of US-LAM_OUT coefficients.
+%
+%   This code is essentially a wrapper for the JAC2JAC code based on [1].
+%
+%   References:
+%     [1] A. Townsend, M. Webb, and S. Olver, "Fast polynomial transforms
+%     based on Toeplitz and Hankel matrices", submitted, 2016.
+
+% See also JAC2JAC.
+
+% Copyright 2017 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+n = length(c) - 1;
+
+% Scale input from US to Jacobi basis:
+c = c./scl(lam_in, n);
+% Call JAC2JAC:
+c = jac2jac(c, lam_in-.5, lam_in-.5, lam_out-.5, lam_out-.5);
+% Scale output from Jacobi to US:
+c = c.*scl(lam_out, n);
+
+end
+
+function s = scl(lam, n)
+% Scaling from Jacobi to US polynomials. See DLMF Table 18.3.1.
+    if ( lam == 0 )
+        nn = (0:n-1).';
+        s = [1 ; cumprod((nn+.5)./(nn+1))];
+    else
+        nn = (0:n).';
+        s = ( gamma(2*lam) ./ gamma(lam+.5) ) * ...
+            exp( gammaln(lam+.5+nn) - gammaln(2*lam+nn) );
+    end
+end

--- a/ultra2ultra.m
+++ b/ultra2ultra.m
@@ -8,7 +8,7 @@ function c = ultra2ultra(c, lam_in, lam_out)
 %   References:
 %     [1] A. Townsend, M. Webb, and S. Olver, "Fast polynomial transforms
 %     based on Toeplitz and Hankel matrices", submitted, 2016.
-
+%
 % See also JAC2JAC.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.


### PR DESCRIPTION
Ultraspherical to ultraspherical conversion.

This is essentially just a wrapper for `jac2jac`, but the scalings can be tricky to compute (particularly for large n) so I think it's worthwhile having such a method. (I had my own version and I've been using it a lot.)

I also fixed two small bugs in `jac2jac` that occur when `n = 1` or `n = 2`.