### PR TITLE
Feature-vals2coeffs-1stkind

### DIFF
--- a/chebcoeffs2chebvals.m
+++ b/chebcoeffs2chebvals.m
@@ -1,18 +1,34 @@
-function chebvals = chebcoeffs2chebvals(chebcoeffs)
+function chebvals = chebcoeffs2chebvals(chebcoeffs, kind)
 %CHEBCOEFFS2CHEBVALS  Convert Chebyshev coefficients to values.
 %   CHEBVALS = CHEBCOEFFS2CHEBVALS(CHEBCOEFFS), converts the column vector
 %   CHEBCOEFFS of Chebyshev coefficients in the Chebyshev series
 %       F(X) = C_CHEB(1)*T0(X) + ... + C_CHEB(N)*T{N-1}(X), 
 %   to a vector CHEBVALS of values of the expansion at second-kind Chebyshev
-%   points, i.e.,
-%       CHEBVALS = F(CHEBPTS(N));
+%   points, i.e., CHEBVALS = F(CHEBPTS(N));
+%
+% 	CHEBCOEFFS2CHEBVALS(CHEBVALS, 1) is similar, but returns the entries in
+% 	CHEBVALS from evaluating on a first-kind Chebyshev grid, i.e.,
+%   CHEBVALS = F(CHEBPTS(N,1))). 
 % 
 % See also CHEBTECH2.COEFFS2VALS, CHEBPTS.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.
 
-% This command is a wrapper for chebtech2/coeffs2vals:
-chebvals = chebtech2.coeffs2vals(chebcoeffs);
+% Default to first kind:
+if ( nargin == 1 )
+    kind = 2;
+end
+
+if ( kind == 1 )
+    % This command is a wrapper for chebtech2/coeffs2vals:
+    chebvals = chebtech1.coeffs2vals(chebcoeffs);
+elseif ( kind == 2 )
+    chebvals = chebtech2.coeffs2vals(chebcoeffs);
+else
+    error('CHEBFUN:chebcoeffs2chebvals:kind', ...
+        'Invalid Chebyshev kind. Must be 1 or 2.')
+end
+    
 
 end

--- a/chebvals2chebcoeffs.m
+++ b/chebvals2chebcoeffs.m
@@ -20,10 +20,10 @@ if ( nargin == 1 )
 end
 
 if ( kind == 1 )
-    % This command is a wrapper for chebtech2/vals2coeffs.\
+    % This command is a wrapper for chebtech2/vals2coeffs.
     chebcoeffs = chebtech1.vals2coeffs(chebvals);
 elseif ( kind == 2 )
-    % This command is a wrapper for chebtech1/vals2coeffs.\
+    % This command is a wrapper for chebtech1/vals2coeffs.
     chebcoeffs = chebtech2.vals2coeffs(chebvals);
 else
     error('CHEBFUN:chebvals2chebcoeffs:kind', ...

--- a/chebvals2chebcoeffs.m
+++ b/chebvals2chebcoeffs.m
@@ -1,16 +1,33 @@
-function chebcoeffs = chebvals2chebcoeffs(chebvals)
+function chebcoeffs = chebvals2chebcoeffs(chebvals, kind)
 %CHEBVALS2CHEBCOEFFS  Convert Chebyshev values to coefficients.
 % 	CHEBCOEFFS = CHEBVALS2CHEBCOEFFS(CHEBVALS), converts the column vector
-%   CHEBVALS of values on a second-kind Chebyshev grid (i.e, F(CHEBPTS(N))) to
-%   a vector CHEBCOEFFS of the Chebyshev coefficients of the series
+%   CHEBVALS of values on a second-kind Chebyshev grid (i.e, F(CHEBPTS(N)))
+%   to a vector CHEBCOEFFS of the Chebyshev coefficients of the series
 %       F(X) = C_CHEB(1)*T0(X) + ... + C_CHEB(N)*T{N-1}(X).
+%
+% 	CHEBVALS2CHEBCOEFFS(CHEBVALS, 1) is similar, but assumes the entries in
+% 	CHEBVALS come from evaluating on a first-kind Chebyshev grid, i.e.,
+%   F(CHEBPTS(N,1))).
 % 
 % See also CHEBTECH2.VALS2COEFFS, CHEBPTS.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.
 
-% This command is a wrapper for chebtech2/vals2coeffs.
-chebcoeffs = chebtech2.vals2coeffs(chebvals);
+% Default to second-kind points
+if ( nargin == 1 )
+    kind = 2;
+end
+
+if ( kind == 1 )
+    % This command is a wrapper for chebtech2/vals2coeffs.\
+    chebcoeffs = chebtech1.vals2coeffs(chebvals);
+elseif ( kind == 2 )
+    % This command is a wrapper for chebtech1/vals2coeffs.\
+    chebcoeffs = chebtech2.vals2coeffs(chebvals);
+else
+    error('CHEBFUN:chebvals2chebcoeffs:kind', ...
+        'Invalid Chebyshev kind. Must be 1 or 2.')
+end
 
 end

--- a/chebvals2chebvals.m
+++ b/chebvals2chebvals.m
@@ -1,0 +1,28 @@
+function vout = chebvals2chebvals(vin, kind1, kind2)
+%LEGVALS2CHEBVALS   Convert Chebyshev values on first and second-kind grids.
+%   V_OUT = CHEBVALS2CHEBVALS(V_IN, 1, 2), converts the vector of V_IN
+%   representing values of a polynomial at first-kind Chebyshev points to a
+%   vector V_OUT representing the same polynomial evaluated on a second-kind
+%   Chebyshev grid.
+%
+%   V_OUT = CHEBVALS2CHEBVALS(V_IN, 2, 1) is similar except that it maps from a
+%   second-kind grid to a first-kind (i.e., p(CHEBPT(N)) --> p(CHEBPT(N,1))).
+% 
+% See also CHEBVALS2LEGVALS, CHEBPTS, LEGPTS.
+
+% Copyright 2017 by The University of Oxford and The Chebfun Developers. 
+% See http://www.chebfun.org/ for Chebfun information.
+
+if ( kind1 == kind2 )
+    vout = vin;
+elseif ( kind1 == 1 && kind2 == 2 )
+    c = chebtech1.vals2coeffs(vin);
+    vout = chebtech2.coeffs2vals(c);
+elseif ( kind1 == 2 && kind2 == 1 )
+    c = chebtech2.vals2coeffs(vin);
+    vout = chebtech1.coeffs2vals(c);
+else
+    error('CHEBFUN:chebvals2chebcoeffs:kind', 'Invalid chebkind.');
+end
+
+end

--- a/chebvals2legcoeffs.m
+++ b/chebvals2legcoeffs.m
@@ -1,14 +1,32 @@
 function c_leg = chebvals2legcoeffs(v_cheb, varargin)
-%CHEBVALS2LEGCOEFFS  Convert Chebyshev values to Legendre coefficients. 
+%CHEBVALS2LEGCOEFFS  Convert Chebyshev values to Legendre coefficients.
 % 	LEGCOEFFS = CHEBVALS2LEGCOEFFS(CHEBVALS), converts the column vector
-% 	CHEBVALS of values on a second-kind Chebyshev grid (i.e, F(CHEBPTS(N))) to
-% 	a vector LEGCOEFFS of Legendre coefficients, where the degree k Legendre
+% 	CHEBVALS of values on a second-kind Chebyshev grid (i.e, F(CHEBPTS(N))) to a
+% 	vector LEGCOEFFS of Legendre coefficients, where the degree k Legendre
 % 	polynomial P{k} is normalized so that max(|P{k}|) = 1.
-
+%
+%   CHEBVALS2LEGCOEFFS(CHEBVALS, 1) is similar, but assumes the entries in
+% 	CHEBVALS come from evaluating on a first-kind Chebyshev grid, i.e., 
+%   F(CHEBPTS(N, 1))).
+%
+%   CHEBVALS2LEGCOEFFS(CHEBVALS, 'norm') or CHEBVALS2LEGCOEFFS(CHEBVALS, 1,
+%   'norm')  is as above, but with the Legendre polynomials normalized to be
+%   orthonormal.
+%
 % Copyright 2017 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.
 
-c_cheb = chebvals2chebcoeffs(v_cheb);  % Convert to Chebyshev coefficients.
-c_leg = cheb2leg(c_cheb, varargin{:}); % Convert to Legendre coefficients.
+% Parse inputs:
+v1 = {}; v2 = {};
+for k = 1:numel(varargin)
+    if ( isnumeric(varargin{k}) )
+        v1{1} = varargin{k};
+    elseif ( ischar(varargin{k}) )
+        v2{1} = varargin{k};
+    end
+end
+
+c_cheb = chebvals2chebcoeffs(v_cheb, v1{:}); % Convert to Chebyshev coefficients.
+c_leg = cheb2leg(c_cheb, v2{:});             % Convert to Legendre coefficients.
 
 end

--- a/chebvals2legvals.m
+++ b/chebvals2legvals.m
@@ -1,15 +1,30 @@
-function legvals = chebvals2legvals(chebvals)
+function legvals = chebvals2legvals(chebvals, kind)
 %CHEBVALS2LEGVALS   Convert Chebyshev values to Legendre values
 %   LEGVALS = CHEBVALS2LEGVALS(CHEBVALS), converts a vector of CHEBVALS
 %   representing values of a Chebyshev expansion at CHEBPTS to a vector LEGVALS
 %   representing the expansion evaluated at LEGPTS.
+%
+%   CHEBVALS2LEGVALS(CHEBVALS, 1) is similar except that the input corresponds
+%   to values at first-kind Chebyshev points (i.e., CHEBPTS(N, 1)).
 % 
 % See also LEGVALS2CHEBVALS, CHEBPTS, LEGPTS.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.
 
-chebcoeffs = chebtech2.vals2coeffs(chebvals);
+% Default to second-kind points:
+if ( nargin == 0 )
+    kind = 2;
+end
+if ( kind == 1 )
+    chebcoeffs = chebtech1.vals2coeffs(chebvals);
+elseif (kind == 2 )
+    chebcoeffs = chebtech2.vals2coeffs(chebvals);
+else
+    error('CHEBFUN:chebvals2legvals:kind', ...
+        'Invalid Chebyshev kind. Must be 1 or 2.')
+end
+    
 legvals = chebfun.ndct(chebcoeffs);
 
 end

--- a/legcoeffs2chebvals.m
+++ b/legcoeffs2chebvals.m
@@ -2,11 +2,24 @@ function v_cheb = legcoeffs2chebvals(c_leg, varargin)
 %LEGCOEFFS2CHEBVALS  Convert Legendre coefficients to Chebyshev values. 
 %   V_CHEB = LEGCOEFFS2CHEBVALS(C_LEG) converts the vector C_LEG of Legendre
 %   coefficients to a vector V_CHEB of values at second-kind Chebyshev points.
+%
+%   V_CHEB = LEGCOEFFS2CHEBVALS(C_LEG, 1) is similar, but evaluates at
+%   first-kind Chebyshev points.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.
 
-c_cheb = leg2cheb(c_leg, varargin{:}); % Convert to Chebyshev coefficients.
-v_cheb = chebcoeffs2chebvals(c_cheb);  % Convert to Chebyshev values.
+% Parse inputs:
+v1 = {}; v2 = {};
+for k = 1:numel(varargin)
+    if ( isnumeric(varargin{k}) )
+        v1{1} = varargin{k};
+    elseif ( ischar(varargin{k}) )
+        v2{1} = varargin{k};
+    end
+end
+
+c_cheb = leg2cheb(c_leg, v2{:}); % Convert to Chebyshev coefficients.
+v_cheb = chebcoeffs2chebvals(c_cheb, v1{:});  % Convert to Chebyshev values.
 
 end

--- a/legvals2chebvals.m
+++ b/legvals2chebvals.m
@@ -1,8 +1,11 @@
-function chebvals = legvals2chebvals(legvals)
+function chebvals = legvals2chebvals(legvals, varargin)
 %LEGVALS2CHEBVALS   Convert Legendre values to Chebyshev values.
 %   CHEBVALS = LEGVALS2CHEBVALS(LEGVALS), converts the vector of LEGVALS
 %   representing values of a polynomial at LEGPTS to a vector CHEBVALS
 %   representing the same polynomial evaluated at CHEBPTS.
+%
+%   LEGVALS2CHEBVALS(LEGVALS, 1) is similar except that the result is the same
+%   polynomial at second-kind Chebyshjegv points (i.e,. CHEBPTS(N,1)).
 % 
 % See also CHEBVALS2LEGVALS, CHEBPTS, LEGPTS.
 
@@ -10,6 +13,6 @@ function chebvals = legvals2chebvals(legvals)
 % See http://www.chebfun.org/ for Chebfun information.
 
 legcoeffs = chebfun.idlt(legvals);
-chebvals = legcoeffs2chebvals(legcoeffs);
+chebvals = legcoeffs2chebvals(legcoeffs, varargin{:});
 
 end

--- a/legvals2chebvals.m
+++ b/legvals2chebvals.m
@@ -5,7 +5,7 @@ function chebvals = legvals2chebvals(legvals, varargin)
 %   representing the same polynomial evaluated at CHEBPTS.
 %
 %   LEGVALS2CHEBVALS(LEGVALS, 1) is similar except that the result is the same
-%   polynomial at second-kind Chebyshjegv points (i.e,. CHEBPTS(N,1)).
+%   polynomial at second-kind Chebyshev points (i.e,. CHEBPTS(N,1)).
 % 
 % See also CHEBVALS2LEGVALS, CHEBPTS, LEGPTS.
 

--- a/tests/misc/test_coeffs2vals.m
+++ b/tests/misc/test_coeffs2vals.m
@@ -32,10 +32,12 @@ pass(12) = norm(v_leg - chebvals2legvals(v_cheb2, 2), inf) < tol;
 pass(13) = norm(v_cheb1 - legcoeffs2chebvals(c_leg, 1), inf) < tol;
 pass(14) = norm(v_cheb1 - chebcoeffs2chebvals(c_cheb,1), inf) < tol;
 pass(15) = norm(v_cheb1 - legvals2chebvals(v_leg, 1), inf) < tol;
+pass(16) = norm(v_cheb1 - chebvals2chebvals(v_cheb2, 2, 1), inf) < tol;
 
-pass(16) = norm(v_cheb2 - legcoeffs2chebvals(c_leg, 2), inf) < tol;
-pass(17) = norm(v_cheb2 - chebcoeffs2chebvals(c_cheb,2), inf) < tol;
-pass(18) = norm(v_cheb2 - legvals2chebvals(v_leg, 2), inf) < tol;
+pass(17) = norm(v_cheb2 - legcoeffs2chebvals(c_leg, 2), inf) < tol;
+pass(18) = norm(v_cheb2 - chebcoeffs2chebvals(c_cheb,2), inf) < tol;
+pass(19) = norm(v_cheb2 - legvals2chebvals(v_leg, 2), inf) < tol;
+pass(20) = norm(v_cheb2 - chebvals2chebvals(v_cheb1, 1, 2), inf) < tol;
 
 end
 

--- a/tests/misc/test_coeffs2vals.m
+++ b/tests/misc/test_coeffs2vals.m
@@ -1,0 +1,42 @@
+function pass = test_coeffs2vals(pref)
+% test various coeffs2vals, vals2coeffs, vals2vals, and coeffs2coeffs codes.
+if ( nargin == 0 )
+    pref = chebfunpref();
+end
+
+tol = 1000*eps;
+
+f = chebfun(@exp, pref);
+N = length(f);
+c_leg = legcoeffs(f);
+c_cheb = chebcoeffs(f);
+v_leg = f(legpts(N));
+v_cheb1 = f(chebpts(N,1));
+v_cheb2 = f(chebpts(N,2));
+
+pass(1) = norm(c_leg - chebcoeffs2legcoeffs(c_cheb), inf) < tol;
+pass(2) = norm(c_leg - legvals2legcoeffs(v_leg), inf) < tol;
+pass(3) = norm(c_leg - chebvals2legcoeffs(v_cheb1, 1), inf) < tol;
+pass(4) = norm(c_leg - chebvals2legcoeffs(v_cheb2, 2), inf) < tol;
+
+pass(5) = norm(c_cheb - legcoeffs2chebcoeffs(c_leg), inf) < tol;
+pass(6) = norm(c_cheb - legvals2chebcoeffs(v_leg), inf) < tol;
+pass(7) = norm(c_cheb - chebvals2chebcoeffs(v_cheb1, 1), inf) < tol;
+pass(8) = norm(c_cheb - chebvals2chebcoeffs(v_cheb2, 2), inf) < tol;
+
+pass(9) = norm(v_leg - legcoeffs2legvals(c_leg), inf) < tol;
+pass(10) = norm(v_leg - chebcoeffs2legvals(c_cheb), inf) < tol;
+pass(11) = norm(v_leg - chebvals2legvals(v_cheb1, 1), inf) < tol;
+pass(12) = norm(v_leg - chebvals2legvals(v_cheb2, 2), inf) < tol;
+
+pass(13) = norm(v_cheb1 - legcoeffs2chebvals(c_leg, 1), inf) < tol;
+pass(14) = norm(v_cheb1 - chebcoeffs2chebvals(c_cheb,1), inf) < tol;
+pass(15) = norm(v_cheb1 - legvals2chebvals(v_leg, 1), inf) < tol;
+
+pass(16) = norm(v_cheb2 - legcoeffs2chebvals(c_leg, 2), inf) < tol;
+pass(17) = norm(v_cheb2 - chebcoeffs2chebvals(c_cheb,2), inf) < tol;
+pass(18) = norm(v_cheb2 - legvals2chebvals(v_leg, 2), inf) < tol;
+
+end
+
+

--- a/tests/misc/test_coeffs2vals.m
+++ b/tests/misc/test_coeffs2vals.m
@@ -40,5 +40,3 @@ pass(19) = norm(v_cheb2 - legvals2chebvals(v_leg, 2), inf) < tol;
 pass(20) = norm(v_cheb2 - chebvals2chebvals(v_cheb1, 1, 2), inf) < tol;
 
 end
-
-


### PR DESCRIPTION
Modified vals2coeffs code to work with either first- or second-kind Chebyshev grids.
Added a test for all of these codes (which was totally lacking?).
Add chebvals2chebvals for converting between Chebyshev grids.


