### PR TITLE
feature-array-singfun-hack

### DIFF
--- a/@chebfun/mtimes.m
+++ b/@chebfun/mtimes.m
@@ -28,7 +28,16 @@ elseif ( fIsChebfun && gIsChebfun )         % CHEBFUN * CHEBFUN
     gIsTrans = g(1).isTransposed;
     
     if ( fIsTrans == gIsTrans )
-        f = times(f, g);
+        try
+            f = times(f, g);
+        catch ME
+            if ( strcmp(ME.identifier, ...
+                    'CHEBFUN:SINGFUN:cancelExponent:arrayvalued') )
+                f = times(quasimatrix(f), quasimatrix(g));
+            else
+                rethrow(ME)
+            end
+        end
     elseif ( fIsTrans && ~gIsTrans ) % Row times column.
         % Compute the inner product (we call CONJ() here because
         % INNERPRODUCT() is semilinear in the first factor, 

--- a/@chebfun/rdivide.m
+++ b/@chebfun/rdivide.m
@@ -30,8 +30,21 @@ if ( isa(f,'chebfun') && isa(g, 'chebfun') )
 
     % Check the number of columns match:
     if ( numColumns(f) ~= numColumns(g) )
-        error('CHEBFUN:CHEBFUN:rdivide:quasi', ...
-            'Chebfun quasimatrix dimensions must agree.')
+        if ( numColumns(f) == 1 )
+            h = g;
+            for k = 1:numColumns(g)
+                h(k) = rdivide(f, g(k));
+            end
+        elseif ( numColumns(g) == 1 )
+            h = f;
+            for k = 1:numColumns(f)
+                h(k) = rdivide(f(k), g);
+            end
+        else
+            error('CHEBFUN:CHEBFUN:rdivide:quasi', ...
+                'Chebfun quasimatrix dimensions must agree.')
+        end
+        return
     end
     
     if ( numel(f) == 1 && numel(g) == 1 )

--- a/@singfun/cancelExponents.m
+++ b/@singfun/cancelExponents.m
@@ -13,6 +13,11 @@ function f = cancelExponents(f)
 % Grab the exponents:
 exps = get(f, 'exponents');
 
+if ( size(f, 2) > 2 )
+    error('CHEBFUN:SINGFUN:cancelExponent:arrayvalued', ...
+        'SINGFUN dfoes not support array-valued techs.')
+end
+
 % Grab boundary values:
 boundaryVals = [lval(f.smoothPart),  rval(f.smoothPart)];
 

--- a/@singfun/simplifyExponents.m
+++ b/@singfun/simplifyExponents.m
@@ -12,8 +12,19 @@ function f = simplifyExponents(f)
 % Grab the exponents:
 exps = get(f, 'exponents');
 
+% Tolerance:
+tol = 100*eps*vscale(f.smoothPart);
+
+% Set nearly zeros exponents to zero:
+exps(abs(exps) < tol) = 0;
+f.exponents = exps;
+
+% Set nearly integer exponents to zero:
+idx = abs(round(exps)-exps) < tol;
+exps(idx) = round(exps(idx));
+
 % Grab the indice for exponents larger or equal to 1:
-ind = ( exps >= 1 );
+ind = ( exps >= 1-tol );
 
 % Both exponents are less than 1:
 if ( ~any( ind ) )


### PR DESCRIPTION
I work a lot with weighted Jacobi and Ultraspherical polynomial bases, and it would be useful for me to be able to construct these as follows:
```
>> a = .3; b = .4; n = 4;
>> (1+x)^b * jacpoly(0:n, a, b)
```
However, this currently fails as `singfun` is not able to deal with array-valued `chebtechs`. 
```
Matrix dimensions must agree.
Error in singfun/cancelExponents (line 23)
```
(NB: This error message is not particularly useful.) There's no real reason why this is true, other than that it would be a considerable amount of work to implement for relatively little gain.

This pull request partially addresses support for array-valued functions, although not in a particularly nice way (I try-catch an error in `chebfun/times` and convert the input to a quasimatrix - this probably breaks encapsulation.) 

Any thoughts / improvements / alternatives are welcome.

```
>> (1+x)^b * jacpoly(0:n, a, b)
ans =
   chebfun column1 (1 smooth piece)
       interval       length     endpoint values   endpoint exponents
[      -1,       1]        1         0      1.3         [0.4      0]  
vertical scale = 1.3 
   chebfun column2 (1 smooth piece)
       interval       length     endpoint values   endpoint exponents
[      -1,       1]        2         0      1.7         [0.4      0]  
vertical scale = 1.7 
   chebfun column3 (1 smooth piece)
       interval       length     endpoint values   endpoint exponents
[      -1,       1]        3         0        2         [0.4      0]  
vertical scale =   2 
   chebfun column4 (1 smooth piece)
       interval       length     endpoint values   endpoint exponents
[      -1,       1]        4         0      2.2         [0.4      0]  
vertical scale = 2.2 
   chebfun column5 (1 smooth piece)
       interval       length     endpoint values   endpoint exponents
[      -1,       1]        5         0      2.3         [0.4      0]  
vertical scale = 2.3 
```
