### PR TITLE
Support for CHEBMATRIX syntax for IVPs.

### DIFF
--- a/@chebop/solveivp.m
+++ b/@chebop/solveivp.m
@@ -119,6 +119,18 @@ if ( strcmp(solver, 'values') || strcmp(solver, 'coeffs') || ...
     return
 end
 
+% Find out how many variables N operates on:
+nVars = numVars(N);
+
+% Check if we're working with a CHEBMATRIX syntax, e.g.
+%   @(x,u) [diff(u{1}) + u{2}; ...]
+% as we'll need different feval calls if that's the case.
+if ( nargin(N) == 2 && nVars > 1 )
+    cellArg = 1;
+else
+    cellArg = 0;
+end
+
 %% Convert to a first-order system
 
 % We call the conversion methods of the TREEVAR class, the call depends on
@@ -127,7 +139,7 @@ end
 % encounters unsupported methods.
 try
     [anonFun, varIndex, problemDom, coeffs, diffOrders] = ...
-        treeVar.toFirstOrder(N.op, rhs, N.domain);
+        treeVar.toFirstOrder(N.op, rhs, N.domain, nVars, cellArg);
 catch ME
     % Did we encounter an unsupported method? If so, try to solve it globally:
     if ( ~isempty(regexp(ME.identifier, 'CHEBFUN:TREEVAR:.+:notSupported', ...
@@ -157,8 +169,13 @@ if ( ~isempty(N.lbc) )
     % above for giving us information about the number of variables in the
     % problem:
     cheb0 = repmat({cheb0}, length(diffOrders), 1);
-    % Evaluate the initial condition:
-    bcEvalFun = N.lbc(cheb0{:});
+    % Evaluate the initial condition, depending on whether we're dealing with
+    % CHEBMATRIX syntax or not:
+    if ( cellArg && nargin(N.lbc) == 1 )
+       bcEvalFun = N.lbc(cheb0); 
+    else
+        bcEvalFun = N.lbc(cheb0{:});
+    end
     % Store the point at which the initial condition is evaluated (left
     % endpoint):
     evalPoint = dom(1);
@@ -170,8 +187,13 @@ else
     % Create enough copies to allow to evaluate the initial condition for
     % systems:
     cheb0 = repmat({cheb0}, length(diffOrders), 1);
-    % Evaluate the final condition:
-    bcEvalFun = N.rbc(cheb0{:});
+    % Evaluate the final condition, depending on whether we're dealing with
+    % CHEBMATRIX syntax or not:
+    if ( cellArg && nargin(N.rbc) == 1 )
+       bcEvalFun = N.rbc(cheb0); 
+    else
+        bcEvalFun = N.rbc(cheb0{:});
+    end
     % Store the point at which the final condition is evaluated (right
     % endpoint):
     evalPoint = dom(end);

--- a/@treeVar/sortConditions.m
+++ b/@treeVar/sortConditions.m
@@ -51,9 +51,14 @@ for argCount = 1:numArgs
     argsVec = 0*argsVec;
 end
 
-% Evaluate FUNIN with the TREEVAR arguments:
-bcResults = funIn(args{:});
-
+% Evaluate FUNIN with the TREEVAR arguments. If we're working with the
+% CHEBMATRIX syntax, we should not expand the ARGS cell (but do it otherwise):
+if ( ( nargin(funIn) == 1 ) && ( length(args) > 1 ) )
+    % CHEBMATRIX syntax in specifying BCs:
+    bcResults = funIn(args);
+else
+    bcResults = funIn(args{:});
+end
 % Look at the results of evaluating the boundary conditions, find what
 % constraint operated on what variable, and what its diffOrder was:
 varList = cell(numArgs, 1);

--- a/@treeVar/treeVar.m
+++ b/@treeVar/treeVar.m
@@ -542,7 +542,7 @@ classdef  (InferiorClasses = {?chebfun}) treeVar
         
         % Convert higher order anonymous functions to first order systems
         [funOut, indexStart, problemDom, coeffs, totalDiffOrders] = ...
-            toFirstOrder(funIn, rhs, domain)
+            toFirstOrder(funIn, rhs, domain, numArgs, cellArg)
         
     end
     

--- a/tests/chebop/test_ivp_chebmatrix_syntax.m
+++ b/tests/chebop/test_ivp_chebmatrix_syntax.m
@@ -1,0 +1,55 @@
+function pass = test_ivp_chebmatrix_syntax
+% Test CHEBMATRIX syntax for IVPs, using full Brusselator IVP:
+
+%% Setup
+dom = [0 5];
+tol = 1e-14;
+
+%% With CHEBOP, multiple variable syntax for reference
+N = chebop(@(t,u,v,w) [
+    diff(u)-1-u^2*v + (w+1)*u;
+    diff(v) - u*w+u^2*v;
+    diff(w) - 1.5 + w*u], dom);
+%% Test with left and right BCs:
+N.lbc = [1;3;4];
+uL = N\0;
+N.lbc = [];
+pass(1) = norm(feval(uL,dom(1)) - [1;3;4]) < tol;
+%%
+N.lbc = [];
+N.rbc = [.7; 0.9; 1.2];
+uR = N\0;
+pass(2) = norm(feval(uR,dom(end)) - [.7; 0.9; 1.2]) < tol;
+%% CHEBMATRIX syntax
+
+% Define a new CHEBOP
+M = chebop(@(t,u) [
+    diff(u{1})-1-u{1}^2*u{2} + (u{3}+1)*u{1};
+    diff(u{2}) - u{1}*u{3}+u{1}^2*u{2};
+    diff(u{3}) - 1.5 + u{3}*u{1}], dom);
+
+%% CHEBMATRIX left boundary conditions
+M.lbc = @(u)[u{1}-1; u{2}-3; u{3}-4];
+vL1 = M\0;
+% Results should be identical to above
+pass(3) = norm(vL1 - uL) == 0;
+
+%% Vector LBC
+M.lbc = [1; 3; 4];
+vL2 = M\0;
+pass(4) = norm(vL2 - uL) == 0;
+
+%% CHEBMATRIX right boundary conditions
+M.lbc = [];
+M.rbc = @(u)[u{1}-.7; u{2}-0.9; u{3}-1.2];
+vR1 = M\0;
+% Results should be identical to above
+pass(5) = norm(vR1 - uR) == 0;
+
+%% Vector RBC
+M.rbc = [.7; .9; 1.2];
+vR2 = M\0;
+pass(6) = norm(vR2 - uR) == 0;
+
+end
+

--- a/tests/treeVar/test_sortConditions.m
+++ b/tests/treeVar/test_sortConditions.m
@@ -67,6 +67,21 @@ correct = [15 9 4 1 12 11 6 5 3 7 16 2 8 13 10 14];
 idx = treeVar.sortConditions(icFun, dom, [4 4 4 4]);
 pass(10) = all( idx == correct );
 
+%% Second order coupled IVP, two variables, arbitrary order, CHEBMATRIX syntax
+icFun = @(u) [u{1}; diff(u{2}); diff(u{1}); u{2}];
+correct = [1 3 4 2];
+idx = treeVar.sortConditions(icFun, dom, [2 2]);
+pass(11) = all( idx == correct );
+
+%% Fourth order coupled IVP, four variables, arbitrary order, CHEBMATRIX syntax
+icFun = @(u) [diff(u{1}, 3); diff(u{3},3); u{3}; diff(u{1},2); ...
+    diff(u{2}, 3); diff(u{2}, 2); diff(u{3}); u{4}; ...
+    diff(u{1}); diff(u{4}, 2); diff(u{2}); u{2}; ...
+    diff(u{4}, 1); diff(u{4}, 3); u{1}; diff(u{3}, 2)];
+correct = [15 9 4 1 12 11 6 5 3 7 16 2 8 13 10 14];
+idx = treeVar.sortConditions(icFun, dom, [4 4 4 4]);
+pass(12) = all( idx == correct );
+
 %% Unsupported format, multiplying unknown function
 icFun = @(x,u) 5*u -1;
 try


### PR DESCRIPTION
Syntax for indexed variables, such as
    N.op = @(x,u) [diff(u{1},2) + u{2}; sin(u{1}) + diff(u{2})]
has long been supported for BVPs. This was missing for IVPs, which
this PR aims to rectify.