### PR TITLE
A small change for baryWeights

### DIFF
--- a/baryWeights.m
+++ b/baryWeights.m
@@ -29,7 +29,7 @@ end
 
 % Compute the weights:
 if ( (n < 2001) )              % For small n using matrices is faster.
-   V = C*bsxfun(@minus, x, x.');
+   V = C*bsxfun(@minus, x.', x); % Make baryWeigths consistent with chebpts when n < 2001 and n = even.
    V(1:n+1:end) = 1;
    VV = exp(sum(log(abs(V))));
    w = 1./(prod(sign(V)).*VV).';


### PR DESCRIPTION
This is not a bug, actually. But for `chebpts` and  for `baryWeights, n > 2001` , the last barycentric weights is positive, this change will make baryWeights consistent with 'chebpts'.