### PR TITLE
Fix tree var sum

### DIFF
--- a/@treeVar/treeVar.m
+++ b/@treeVar/treeVar.m
@@ -471,6 +471,19 @@ classdef  (InferiorClasses = {?chebfun}) treeVar
             f.tree = f.univariate(f.tree, 'sqrt');
         end
         
+        function f = sum(f)
+            %SUM   Not supported.
+            % We don't support integral equations with our first order
+            % reformulation. However, we could accidentally end up here in case
+            % of first order integral equation, where the conditions are
+            % specified via N.LBC/RBC. Throw a meaningful error message in this
+            % case.
+            error('CHEBFUN:TREEVAR:cumsum:notSupported', ['First order ' ...
+                'reformulation does not support integral equations.\nPlease ' ...
+                'specify conditions via N.BC rather than N.LBC/RBC.'])
+        end
+        
+        
         function f = tan(f)
             f.tree = f.univariate(f.tree, 'tan');
         end

--- a/tests/chebop/test_firstOrderIntegralEqn.m
+++ b/tests/chebop/test_firstOrderIntegralEqn.m
@@ -14,3 +14,11 @@ u2 = L\1;
 
 %% Did we get the same solution?
 pass = (norm(u1-u2) == 0);
+
+%% sum instead of cumsum, rbc
+L = chebop(@(x,u) diff(u) + 2*sum((5-x)*sin(x)*u),d);
+x = chebfun('x', L.domain);
+L.rbc = 1;
+rhs = sin(pi*x);
+u = L\rhs;
+pass(2) = (norm(L*u - rhs,inf) < 1e-10) && (u(end) - 1 < 1e-10);

--- a/tests/chebop/test_intops.m
+++ b/tests/chebop/test_intops.m
@@ -56,5 +56,13 @@ A.lbc = 0;
 u = A\1;
 pass(6) = norm(A*u - 1, inf) < tol;
 
+%%
+% From https://groups.google.com/forum/#!topic/chebfun-users/0dpsggp1RyA . 
+% Also, see #2210.
+
+L = chebop(@(u) diff(u)+sum(u), [0 1]);
+L.lbc = 1; 
+u = L\0;
+pass(7) = norm(u - (1- 2*chebfun('x',[0 1])/3), inf) < tol;
 end
 


### PR DESCRIPTION
This is to fix an issue originally raised on the Google group, https://groups.google.com/forum/#!topic/chebfun-users/0dpsggp1RyA .

`treeVar` was missing a `sum` method, which has now been added to work analogous to the `cumsum` method of the `treeVar` class (throw a meaningful error, and try switching automatically to global methods, rather than time-stepping).