### PR TITLE
Bug fix for raising a chebfun to an array of powers

### DIFF
--- a/@chebfun/power.m
+++ b/@chebfun/power.m
@@ -68,9 +68,7 @@ elseif ( isa(f, 'chebfun') )
         for k = numelB:-1:1
             g(k) = columnPower(f, b(k), pref);
         end
-        if ( all((b > 0) & (round(b) == b)) )
-            g = quasi2cheb(g);
-        end
+        g = quasi2cheb(g);
     elseif ( numelB == 1 )
         % e.g., [x sin(x)].^2
         if ( numel(f) == 1 )

--- a/tests/chebfun/test_power.m
+++ b/tests/chebfun/test_power.m
@@ -387,6 +387,20 @@ tol = 1e4*max(eps*vscale(g));
 
 pass(39) = err < tol;
 
+%% Test single CHEBFUN raised to an array of non-negative integer powers:
+x = chebfun('x');
+f = x.^(0:5);
+g = chebfun(@(x) x.^(0:5));
+pass(40) = norm(f-g,inf) < tol;
+
+pows = [-2 -0.5 1.25 3];
+f = (1 + x.^2).^pows;
+g = chebfun(@(x) (1+x.^2).^pows);
+pass(41) = norm(f-g,inf) < tol;
+
+
+
+
 end
 
 function out = normest(f, dom)


### PR DESCRIPTION
When raising a chebfun to an array of powers, make sure the result is converted from a quasimatrix to an array-valued chebfun.  Fixes #2211. 