### PR TITLE
Enforce that the constructor return a chebfun column when the input is a chebfun row

### DIFF
--- a/@chebfun/chebfun.m
+++ b/@chebfun/chebfun.m
@@ -779,6 +779,9 @@ function [op, dom, data, pref, flags] = parseInputs(op, varargin)
             op = vectorCheck(op, dom, vectorize);
         end
         if ( isa(op, 'chebfun') )
+            if ( op.isTransposed )
+                op = op';
+            end
             op = @(x) feval(op, x);
         end
         if ( isa(op, 'function_handle') && pref.enableFunqui )

--- a/tests/chebfun/test_constructor_inputs.m
+++ b/tests/chebfun/test_constructor_inputs.m
@@ -156,4 +156,10 @@ catch ME
         'should not be specified simultaneously.']);
 end
 
+% Test construction from a chebfun row (transposed chebfun). The result
+% should be a chebfun column (not transposed).
+f = chebfun(@(x) cos(pi*x))';
+g = chebfun(f);
+pass(29) = g.isTransposed == 0;
+
 end

--- a/tests/chebfun/test_constructor_inputs_periodic.m
+++ b/tests/chebfun/test_constructor_inputs_periodic.m
@@ -49,4 +49,10 @@ f = chebfun(@(x) 1 + sin(pi*sin(10*pi*x)), 'periodic', 'trunc', 11);
 c = get(f, 'coeffs');
 pass(7) = abs(1 - c(6)) < eps;
 
+% Test construction from a chebfun row (transposed chebfun). The result
+% should be a chebfun column (not transposed).
+f = chebfun(@(x) cos(pi*x), 'trig')';
+g = chebfun(f);
+pass(8) = g.isTransposed == 0;
+
 end


### PR DESCRIPTION
This was causing the constructor to hang since evaluation with a column of values would return a single row of output values.  Fixes #2209.