### PR TITLE
code for outputting the poles of the best approximation

### DIFF
--- a/minimax.m
+++ b/minimax.m
@@ -47,7 +47,7 @@ function varargout = minimax(f, varargin)
 %       STATUS.XK    - Last trial reference on which the error
 %                      equioscillates.
 %   In case we are doing rational approximation (denominator degree >=1),
-%   two extra field are computed:
+%   two extra fields are computed:
 %       STATUS.POL   - Poles of the minimax approximation.
 %       STATUS.ZER   - Zeros of the minimax approximation.
 %
@@ -65,7 +65,7 @@ function varargout = minimax(f, varargin)
 %
 %   [1] B. Beckermann, S. Filip, Y. Nakatsukasa and L. N. Trefethen,
 %   "Rational minimax approximation via adaptive barycentric
-%   representations", manuscript in preparation.
+%   representations", arXiv:1705.10132.
 %
 %   [2] R. Pachon and L. N. Trefethen, "Barycentric-Remez algorithms for
 %   best polynomial approximation in the chebfun system", BIT Numerical

--- a/minimax.m
+++ b/minimax.m
@@ -1924,9 +1924,10 @@ E = [0 beta.'; ones(m, 1) diag(zj)];
 zer = eig(E, B);
 % Remove zeros of denominator at infinity:
 zer = zer(~isinf(zer));
+
 rad = 1e-5; % radius for approximating residual
 
-    if ( m > n )% superdiagonal case, remove irrelevant poles        
+    if ( m - 1 > n )% superdiagonal case, remove irrelevant poles        
     dz = rad*exp(2i*pi*(1:4)/4);
     res = rh(bsxfun(@plus, zer, dz))*dz.'/4; % residues
     ix = find( abs(res) > 1e-10 ); % pole with suff. residues

--- a/minimax.m
+++ b/minimax.m
@@ -620,7 +620,7 @@ status.diffx = diffx;
 status.xk = xk;
 status.success = interpSuccess;
 % Compute the poles and zeros in case of a rational approximation
-if ( n > 0 )
+if ( n > 0 &&  ~isempty(beta) )
     status.pol = pzeros(tk, beta, rh, n, dom);
 else
     status.pol = [];
@@ -1052,7 +1052,7 @@ if isempty(pos) % still no solution, give up
         disp('Trial interpolant too far from optimal...')
     end
     interpSuccess = 0; 
-    p = []; q = []; rh = []; h = 1e-19;
+    p = []; q = []; rh = []; h = 1e-19; wD = [];
     return
 elseif ( length(pos) > 1 ) % more than one solution with no sign changes...
     [~,ix] = min(abs(hpre)-diag(abs(d(pos,pos))));

--- a/tests/misc/test_minimax.m
+++ b/tests/misc/test_minimax.m
@@ -119,4 +119,12 @@ x = chebfun('x'); f = 1e40*abs(x);
 [p,q,rh,err] = minimax(f,5,5);
 pass(18) = (err < 1e38);
 
+% Test poles and zeros of the best approximation
+%{
+[p,q,~,~,status] = minimax(@(x) sqrt(x), [0,1], 4,4);
+zer1 = roots(p,'all'); zer1 = sort(zer1); zer2 = sort(status.zer);
+pol1 = roots(q,'all'); pol1 = sort(pol1); pol2 = sort(status.pol);
+pass(19) = ( norm(zer1-zer2,Inf)/norm(zer1,Inf) < 1e-5 && ...
+    norm(pol1-pol2,Inf)/norm(pol1,Inf) < 1e-5 );
+%}
 end


### PR DESCRIPTION
This pull request adds the following feature: when calling `minimax`, the poles of the best approximation are now computed and stored in the output argument `status.pol`.