### PR TITLE
Fix for aaa failing with infinite data values

### DIFF
--- a/aaa.m
+++ b/aaa.m
@@ -55,6 +55,12 @@ if ( needZ )
     return
 end
 
+% Remove any infinite function values (avoid SVD failures):
+toKeep = ~isinf(F);
+F = F(toKeep); Z = Z(toKeep);
+M = length(Z);
+
+
 % Relative tolerance:
 reltol = tol * norm(F, inf);
 

--- a/tests/chebfun/test_aaa.m
+++ b/tests/chebfun/test_aaa.m
@@ -64,4 +64,9 @@ r2 = aaa('abs(x)', Z);
 x = -1 +2*rand(1);
 pass(16) = ( r1(x) == r2(x) );
 
+% Test that constructor does not fail when a data value is infinite:
+Z = linspace(-1,1);
+r = aaa(gamma(Z),Z);
+pass(17) = ( abs(r(0.63) - gamma(0.63)) < 1e-3 );
+
 end

--- a/tests/chebfun/test_aaa.m
+++ b/tests/chebfun/test_aaa.m
@@ -69,4 +69,10 @@ Z = linspace(-1,1);
 r = aaa(gamma(Z),Z);
 pass(17) = ( abs(r(0.63) - gamma(0.63)) < 1e-3 );
 
+% Test for NaNs
+X = linspace(0,20);
+F = sin(X)./X;
+r = aaa(F,X);
+pass(18) = ( abs(r(2) - sin(2)/2) < 1e-3 );
+
 end


### PR DESCRIPTION
This pull request offers a quick fix to `aaa` failing when infinite data values are supplied by the user (see issue #2217). Following the suggestion of @trefethen, it simply removes infinite values from F(Z) and the corresponding entries from Z.