### PR TITLE
Fix randnfun normalization

### DIFF
--- a/randnfun.m
+++ b/randnfun.m
@@ -11,7 +11,7 @@ function f = randnfun(varargin)
 %   RANDNFUN(LAMBDA, N) returns a quasimatrix with N independent columns.
 %
 %   RANDNFUN(LAMBDA, 'norm') normalizes the output by dividing it by about
-%   2*SQRT(LAMBDA), so white noise is approached in the limit LAMBDA -> 0,
+%   SQRT(LAMBDA/2), so white noise is approached in the limit LAMBDA -> 0,
 %   with an indefinite integral corresponding to standard Brownian motion.
 %
 %   RANDNFUN(LAMBDA, 'trig') returns a random periodic function.  This

--- a/randnfun.m
+++ b/randnfun.m
@@ -11,13 +11,15 @@ function f = randnfun(varargin)
 %   RANDNFUN(LAMBDA, N) returns a quasimatrix with N independent columns.
 %
 %   RANDNFUN(LAMBDA, 'norm') normalizes the output by dividing it by about
-%   SQRT(2*LAMBDA), so white noise is approached in the limit LAMBDA -> 0.
+%   2*SQRT(LAMBDA), so white noise is approached in the limit LAMBDA -> 0,
+%   with an indefinite integral corresponding to standard Brownian motion.
 %
 %   RANDNFUN(LAMBDA, 'trig') returns a random periodic function.  This
 %   is defined by a finite Fourier-Wiener series with independent normally
 %   distributed coefficients of equal variance.
 %
-%   RANDNFUN(LAMBDA, 'complex') returns a complex random function.
+%   RANDNFUN(LAMBDA, 'complex') returns a complex random function.  The
+%   variance is the same as in the real case (i.e., not twice as much).
 %
 %   RANDNFUN() uses the default value LAMBDA = 1.  Combinations such
 %   as RANDNFUN(DOM) and RANDNFUN('norm', LAMBDA) are allowed so long as

--- a/randnfun.m
+++ b/randnfun.m
@@ -19,7 +19,7 @@ function f = randnfun(varargin)
 %   distributed coefficients of equal variance.
 %
 %   RANDNFUN(LAMBDA, 'complex') returns a complex random function.  The
-%   variance is the same as in the real case (i.e., not twice as much).
+%   variance is the same as in the real case (i.e., not twice as great).
 %
 %   RANDNFUN() uses the default value LAMBDA = 1.  Combinations such
 %   as RANDNFUN(DOM) and RANDNFUN('norm', LAMBDA) are allowed so long as
@@ -65,9 +65,9 @@ if trig    % periodic case: finite Fourier-Wiener series.
         c = (c + flipud(conj(c)))/sqrt(2);       % real coeffs, var 1
     end
     if normalize
-        c = c/sqrt(L/2);    % on [-1,1], coeffs from N(0,1) (finite F-W series)
+        c = c/sqrt(L);   % on [-1,1], coeffs from N(0,1/2) (finite F-W series)
     else
-        c = c/sqrt(2*m+1);  % regardless of domain, function values from N(0,1)
+        c = c/sqrt(2*m+1); % regardless of domain, function values from N(0,1)
     end
     f = chebfun(c, dom, 'trig', 'coeffs');
 
@@ -101,9 +101,9 @@ else       % nonperiodic case: call periodic case and restrict
 
            % restrict the result to the prescribed interval
  
-    x = chebpts(5*m+5, dom);  % this number is large enough...
-    f = chebfun(f(x), dom);   % ...so this is equiv. to f{dom(1),dom(2)}
-    f = simplify(f, 1e-13);   % loosened tolerance gives clean Cheb series
+    x = chebpts(5*m+20, dom);  % this number is large enough...
+    f = chebfun(f(x), dom);    % ...so this is equiv. to f{dom(1),dom(2)}
+    f = simplify(f, 1e-13);    % loosened tolerance gives clean Cheb series
 
 end
 end

--- a/randnfun.m
+++ b/randnfun.m
@@ -76,13 +76,16 @@ else       % nonperiodic case: call periodic case and restrict
     dom2 = dom(1) + [0 1.2*diff(dom)];
     m = round(diff(dom)/lambda);
 
-    if lambda == inf    
+    if lambda == inf
         c = randn;
         if cmplx
-            c = (c + 1i*randn)/sqrt(2)
+            c = (c + 1i*randn)/sqrt(2);
+        end
+        if normalize
+            c = c/sqrt(diff(dom2));
         end
         f = chebfun(c, dom);        % random constant function
-	return
+        return
     end
 
     if cmplx

--- a/tests/misc/test_randnfun.m
+++ b/tests/misc/test_randnfun.m
@@ -18,7 +18,7 @@ X = cov(A);
 pass(4) = (norm(X-X') == 0);
 
 rng(0), f1 = randnfun('norm',1/64,[0 3]);
-rng(0), f2 = 2*sqrt(64)*randnfun(1/64, 1, [0 3]);
+rng(0), f2 = sqrt(2*64)*randnfun(1/64, 1, [0 3]);
 pass(5) = norm(f1-f2) < .2*norm(f1);
 
 rng(0), f1 = randnfun(1,[0 4]);
@@ -47,7 +47,7 @@ pass(12) = (norm(X-X') == 0);
 f = randnfun('trig') + 1i*randnfun('trig');
 pass(13) = (abs(f(-.999)-f(.999)) < .1);
 
-rng(0), f1 = randnfun(1/16,'norm','trig')/8;
+rng(0), f1 = randnfun(1/16,'norm','trig')/(4*sqrt(2));
 rng(0), f2 = randnfun(1/16,'trig');
 pass(14) = norm(f1-f2) < .2*norm(f1);
 
@@ -70,5 +70,14 @@ rng(0)
 f = randnfun(.3,'complex',[0 77]);
 pass(19) = (abs(std(f)-1) < .1);
 pass(20) = (abs(mean(f)) < .1);
+
+% test that Brownian motion is normalized properly
+nsamp = 600;
+f = randnfun(.1,[0 1],'norm',nsamp);
+b = cumsum(f); s = sum(b.^2,2)/nsamp; 
+pass(21) = abs(s(1)-1) < .2;
+f = randnfun(.1,[0 1],'norm','complex',nsamp);
+b = cumsum(f); s = sum(conj(b).*b,2)/nsamp; 
+pass(22) = abs(s(1)-1) < .2;
 
 end


### PR DESCRIPTION
Aurya Javeed of Cornell's Center for Applied Math found that `randnfun` had the wrong normalization by a factor of sqrt(2) in `'norm'` mode.  I think I have now fixed this.  