### PR TITLE
norm -> big in randnfun

### DIFF
--- a/randnfun.m
+++ b/randnfun.m
@@ -1,7 +1,7 @@
 function f = randnfun(varargin)
 %RANDNFUN   Random smooth function
 %   F = RANDNFUN(LAMBDA) returns a smooth CHEBFUN on [-1,1] with maximum
-%   frequency about 2pi/LAMBDA and standard normal distribution N(0,1)
+%   frequency <= 2pi/LAMBDA and standard normal distribution N(0,1)
 %   at each point.  F can be regarded as a sample path of a Gaussian
 %   process.  It is obtained by calling RANDNFUN(LAMBDA, 'trig') on an
 %   interval 20% longer and restricting the result to [-1,1].
@@ -10,7 +10,7 @@ function f = randnfun(varargin)
 %
 %   RANDNFUN(LAMBDA, N) returns a quasimatrix with N independent columns.
 %
-%   RANDNFUN(LAMBDA, 'norm') normalizes the output by dividing it by about
+%   RANDNFUN(LAMBDA, 'big') normalizes the output by dividing it by
 %   SQRT(LAMBDA/2), so white noise is approached in the limit LAMBDA -> 0,
 %   with an indefinite integral corresponding to standard Brownian motion.
 %
@@ -22,7 +22,7 @@ function f = randnfun(varargin)
 %   variance is the same as in the real case (i.e., not twice as great).
 %
 %   RANDNFUN() uses the default value LAMBDA = 1.  Combinations such
-%   as RANDNFUN(DOM) and RANDNFUN('norm', LAMBDA) are allowed so long as
+%   as RANDNFUN(DOM) and RANDNFUN('big', LAMBDA) are allowed so long as
 %   N, if present, is preceded by an explicit specification of LAMBDA.
 %
 % Examples:
@@ -33,18 +33,18 @@ function f = randnfun(varargin)
 %   X = randnfun(.01,2); cov(X)
 %
 %   s = randi(100);
-%   rng(s), f1 = randnfun(0.5,'norm',[0 10],3);
-%   rng(s), f2 = randnfun(0.1,'norm',[0 10],3);
+%   rng(s), f1 = randnfun(0.5,'big',[0 10],3);
+%   rng(s), f2 = randnfun(0.1,'big',[0 10],3);
 %   plot(cumsum(f1),'k',cumsum(f2),'r')
 %
-%   plot(cumsum(randnfun(.01,[0 5],'complex','norm'))), axis equal
+%   plot(cumsum(randnfun(.01,[0 5],'complex','big'))), axis equal
 %
 % See also RANDNFUN2, RANDNFUNSPHERE, RANDNFUNDISK.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.
 
-[lambda, n, dom, normalize, trig, cmplx] = parseInputs(varargin{:});
+[lambda, n, dom, makebig, trig, cmplx] = parseInputs(varargin{:});
 
 if trig    % periodic case: finite Fourier-Wiener series.
            % See sec. 16.3 of Kahane, "Some Random Series of Functions".
@@ -56,7 +56,7 @@ if trig    % periodic case: finite Fourier-Wiener series.
            % correponding to wave numbers 0, 1, -1, 2, -2, 3, ....
 
     L = diff(dom);
-    m = round(L/lambda);
+    m = floor(L/lambda);
     c = randn(2*n, 2*m+1);                       % real numbers, var 1
     ii = [2*m+1:-2:1 2:2:2*m];
     c = c(:,ii)'; 
@@ -64,7 +64,7 @@ if trig    % periodic case: finite Fourier-Wiener series.
     if ~cmplx
         c = (c + flipud(conj(c)))/sqrt(2);       % real coeffs, var 1
     end
-    if normalize
+    if makebig
         c = c/sqrt(L);   % on [-1,1], coeffs from N(0,1/2) (finite F-W series)
     else
         c = c/sqrt(2*m+1); % regardless of domain, function values from N(0,1)
@@ -81,7 +81,7 @@ else       % nonperiodic case: call periodic case and restrict
         if cmplx
             c = (c + 1i*randn)/sqrt(2);
         end
-        if normalize
+        if makebig
             c = c/sqrt(diff(dom2));
         end
         f = chebfun(c, dom);        % random constant function
@@ -89,14 +89,14 @@ else       % nonperiodic case: call periodic case and restrict
     end
 
     if cmplx
-        if normalize
-            f = randnfun(lambda, n, dom2, 'norm', 'trig', 'complex');
+        if makebig
+            f = randnfun(lambda, n, dom2, 'big', 'trig', 'complex');
         else
             f = randnfun(lambda, n, dom2, 'trig', 'complex');
         end
     else
-        if normalize
-            f = randnfun(lambda, n, dom2, 'norm', 'trig');
+        if makebig
+            f = randnfun(lambda, n, dom2, 'big', 'trig');
         else
             f = randnfun(lambda, n, dom2, 'trig');
         end
@@ -111,20 +111,20 @@ else       % nonperiodic case: call periodic case and restrict
 end
 end
 
-function [lambda, n, dom, normalize, trig, cmplx] = parseInputs(varargin)
+function [lambda, n, dom, makebig, trig, cmplx] = parseInputs(varargin)
 
 lambda = NaN;
 n = NaN;
 dom = NaN;
-normalize = 0;
+makebig = 0;
 trig = 0;
 cmplx = 0;
 
 for j = 1:nargin
     v = varargin{j};
     if ischar(v)
-        if ( v(1) == 'n' )
-            normalize = 1;
+        if ( v(1) == 'n' | v(1) == 'b' )
+            makebig = 1;
         elseif ( v(1) == 't' )
             trig = 1;
         elseif ( v(1) == 'c' )

--- a/tests/misc/test_randnfun.m
+++ b/tests/misc/test_randnfun.m
@@ -17,7 +17,7 @@ A = randnfun(1,10,[0 10]);
 X = cov(A);
 pass(4) = (norm(X-X') == 0);
 
-rng(0), f1 = randnfun('norm',1/64,[0 3]);
+rng(0), f1 = randnfun('big',1/64,[0 3]);
 rng(0), f2 = sqrt(2*64)*randnfun(1/64, 1, [0 3]);
 pass(5) = norm(f1-f2) < .2*norm(f1);
 
@@ -47,7 +47,7 @@ pass(12) = (norm(X-X') == 0);
 f = randnfun('trig') + 1i*randnfun('trig');
 pass(13) = (abs(f(-.999)-f(.999)) < .1);
 
-rng(0), f1 = randnfun(1/16,'norm','trig')/(4*sqrt(2));
+rng(0), f1 = randnfun(1/16,'big','trig')/(4*sqrt(2));
 rng(0), f2 = randnfun(1/16,'trig');
 pass(14) = norm(f1-f2) < .2*norm(f1);
 
@@ -62,8 +62,8 @@ pass(16) = norm(f1([.8 1.2])-f2([4.8 5.2])) < 1e-14;
 f = randnfun(6,'trig');
 pass(17) = norm(diff(f)) == 0;
 
-rng(1), f1 = cumsum(randnfun([7,17],.3,'norm'));
-rng(1), f2 = cumsum(randnfun([7,17],.1,'norm'));
+rng(1), f1 = cumsum(randnfun([7,17],.3,'big'));
+rng(1), f2 = cumsum(randnfun([7,17],.1,'big'));
 pass(18) = mean(f1-f2) < .5;
 
 rng(0)
@@ -73,11 +73,16 @@ pass(20) = (abs(mean(f)) < .1);
 
 % test that Brownian motion is normalized properly
 nsamp = 600;
-f = randnfun(.1,[0 1],'norm',nsamp);
+f = randnfun(.1,[0 1],'big',nsamp);
 b = cumsum(f); s = sum(b.^2,2)/nsamp; 
 pass(21) = abs(s(1)-1) < .2;
-f = randnfun(.1,[0 1],'norm','complex',nsamp);
+f = randnfun(.1,[0 1],'big','complex',nsamp);
 b = cumsum(f); s = sum(conj(b).*b,2)/nsamp; 
 pass(22) = abs(s(1)-1) < .2;
+
+% Test that 'norm' works as well as 'big'
+rng(7); f = randnfun('norm');
+rng(7); g = randnfun('big');
+pass(23) = (f(.2) == g(.2));
 
 end


### PR DESCRIPTION
I've changed the flag `'norm'` (which is confusing -- is it the big version of a random function that we call normalized, or the small one?) -- to `'big'`.  Thus now:

randnfun(lambda):  a function of size O(1)

randnfun(lambda,'big'): a function of size O(1/sqrt(lambda)), suitable for integration for Brownian motion and other stochastic effects