### PR TITLE
fix buggy initialization of the levelled error

### DIFF
--- a/minimax.m
+++ b/minimax.m
@@ -519,8 +519,9 @@ if ( opts.displayIter && dialogFlag)
     disp('It.   Max(|Error|)     |ErrorRef|    Delta ErrorRef    Delta Ref     m  n')
 end
 
-h = -1;
 err = normf;
+% Initialise the levelled error such that one iteration always executes
+h = 2*err + 1;
 interpSuccess = 1;
 % Run the main algorithm.
 while ( (abs(abs(h)-abs(err))/abs(err) > opts.tol) && ...


### PR DESCRIPTION
This pull request fixes issue #2230 . It modifies a hard coded value of the leveled error variable `h` that prevented the code from executing correctly in certain cases.