### PR TITLE
Fix truncation level in randnspherefun

### DIFF
--- a/randnfun.m
+++ b/randnfun.m
@@ -26,7 +26,7 @@ function f = randnfun(varargin)
 %   N, if present, is preceded by an explicit specification of LAMBDA.
 %
 %   Reference: S. Filip, A. Javeed, and L. N. Trefethen, "Smooth random
-%   functoins, random ODEs, and Gaussian processes," manuscript, Nov. 2017.
+%   functions, random ODEs, and Gaussian processes," manuscript, Nov. 2017.
 %
 % Examples:
 %

--- a/randnfun.m
+++ b/randnfun.m
@@ -1,6 +1,6 @@
 function f = randnfun(varargin)
-%RANDNFUN   Random smooth function
-%   F = RANDNFUN(LAMBDA) returns a smooth CHEBFUN on [-1,1] with maximum
+%RANDNFUN   Smooth random function
+%   F = RANDNFUN(LAMBDA) returns a CHEBFUN on [-1,1] with maximum
 %   frequency <= 2pi/LAMBDA and standard normal distribution N(0,1)
 %   at each point.  F can be regarded as a sample path of a Gaussian
 %   process.  It is obtained by calling RANDNFUN(LAMBDA, 'trig') on an
@@ -24,6 +24,9 @@ function f = randnfun(varargin)
 %   RANDNFUN() uses the default value LAMBDA = 1.  Combinations such
 %   as RANDNFUN(DOM) and RANDNFUN('big', LAMBDA) are allowed so long as
 %   N, if present, is preceded by an explicit specification of LAMBDA.
+%
+%   Reference: S. Filip, A. Javeed, and L. N. Trefethen, "Smooth random
+%   functoins, random ODEs, and Gaussian processes," manuscript, Nov. 2017.
 %
 % Examples:
 %

--- a/randnfun2.m
+++ b/randnfun2.m
@@ -1,6 +1,6 @@
 function f = randnfun2(varargin)
-%RANDNFUN2   Random smooth 2D function 
-%   F = RANDNFUN2(LAMBDA) returns a smooth CHEBFUN2 on [-1,1,-1,1] with
+%RANDNFUN2   Smooth random function in 2D
+%   F = RANDNFUN2(LAMBDA) returns a CHEBFUN2 on [-1,1,-1,1] with
 %   maximum frequency about 2pi/LAMBDA in both the X and Y directions
 %   and standard normal distribution N(0,1) at each point.  F is obtained
 %   by calling RANDNFUN2(T, 'trig') on a domain of dimensions about 20%

--- a/randnfundisk.m
+++ b/randnfundisk.m
@@ -1,6 +1,6 @@
 function f = randnfundisk(lambda)
-%RANDNFUNDISK   Random smooth function on the unit disk
-%   F = RANDNFUNDISK(LAMBDA) returns a smooth DISKFUN of maximum
+%RANDNFUNDISK   Smooth random function on the unit disk
+%   F = RANDNFUNDISK(LAMBDA) returns a DISKFUN of maximum
 %   frequency about 2pi/LAMBDA and standard normal distribution N(0,1)
 %   at each point.  F is obtained by restricting output of RANDNFUN2
 %   to the unit disk.

--- a/randnfunsphere.m
+++ b/randnfunsphere.m
@@ -1,13 +1,13 @@
 function f = randnfunsphere(lambda, type)
-%RANDNFUNSPHERE   Random smooth function on the unit sphere
-%   F = RANDNFUNSPHERE(LAMBDA) returns a smooth SPHEREFUN of maximum
-%   wavelength of about 2pi/LAMBDA, as measured around the equator, and 
-%   standard normal distribution N(0,1) at each point.  F is obtained from
-%   a combination of spherical harmonics with random coefficients.
+%RANDNFUNSPHERE   Smooth random function on the unit sphere
+%   F = RANDNFUNSPHERE(LAMBDA) returns a SPHEREFUN of maximum
+%   wavelength of about 2pi/LAMBDA and standard normal distribution
+%   N(0,1) at each point.  F is obtained from a combination of
+%   spherical harmonics with random coefficients.
 %
 %   RANDNFUNSPHERE(LAMBDA, 'monochrome') is similar, but uses a
 %   fixed-degree expansion so that all components have wave number
-%   about equal to 2pi/LAMBDA. Note that it is also possible to shorten
+%   about equal to 2pi/LAMBDA. Note that it is possible to shorten
 %   'monochrome' to just 'm'.
 %
 %   RANDNFUNSPHERE() uses the default value LAMBDA = 1.
@@ -52,9 +52,8 @@ elseif nargin == 2
     end
 end
 
-% This is a common measure for the resolution of a spherical harmonic 
-% series in terms of the truncation level (deg) and wave-length lambda
-% as measured along the equator of the sphere.
+% Since the unit sphere has circumference L = 2*pi, the following
+% choice matches the choice deg = floor(L/lambda) in randnfun.
 deg = floor(2*pi/lambda);
 
 % We do not use adaptive construction, but just sample the function on a

--- a/randnfunsphere.m
+++ b/randnfunsphere.m
@@ -51,11 +51,11 @@ elseif nargin == 2
         type = 'monochromatic';
     end
 end
- 
-% deg = round(pi/lambda);
-deg = ceil(2*pi/lambda);
-% deg = ceil(2*sqrt(2)*pi/lambda);
-% deg = ceil(2*sqrt(4*pi)/lambda)-1;
+
+% This is a common measure for the resolution of a spherical harmonic 
+% series in terms of the truncation level (deg) and wave-length lambda
+% as measured along the equator of the sphere.
+deg = floor(2*pi/lambda);
 
 % We do not use adaptive construction, but just sample the function on a
 % fine enough grid to exactly resolve it then pass this to the constructor.

--- a/randnfunsphere.m
+++ b/randnfunsphere.m
@@ -53,7 +53,10 @@ elseif nargin == 2
     end
 end
  
-deg = round(pi/lambda);
+% deg = round(pi/lambda);
+% deg = ceil(2*pi/lambda);
+% deg = ceil(2*sqrt(2)*pi/lambda);
+deg = ceil(2*sqrt(4*pi)/lambda)-1;
 
 % We do not use adaptive construction, but just sample the function on a
 % fine enough grid to exactly resolve it then pass this to the constructor.

--- a/randnfunsphere.m
+++ b/randnfunsphere.m
@@ -1,23 +1,22 @@
 function f = randnfunsphere(lambda, type)
 %RANDNFUNSPHERE   Random smooth function on the unit sphere
 %   F = RANDNFUNSPHERE(LAMBDA) returns a smooth SPHEREFUN of maximum
-%   frequency about 2pi/LAMBDA and standard normal distribution N(0,1)
-%   at each point.  F is obtained from a combination of spherical
-%   harmonics with random coefficients.
+%   wavelength of about 2pi/LAMBDA, as measured around the equator, and 
+%   standard normal distribution N(0,1) at each point.  F is obtained from
+%   a combination of spherical harmonics with random coefficients.
 %
 %   RANDNFUNSPHERE(LAMBDA, 'monochrome') is similar, but uses a
 %   fixed-degree expansion so that all components have wave number
-%   about equal to 2pi/LAMBDA.
+%   about equal to 2pi/LAMBDA. Note that it is also possible to shorten
+%   'monochrome' to just 'm'.
 %
 %   RANDNFUNSPHERE() uses the default value LAMBDA = 1.
 %
 % Examples:
 %
-%   f = randnfunsphere(0.2); std2(f), plot(f)
-%   colormap([0 0 0; 1 1 1]), caxis(norm(caxis,inf)*[-1 1])
+%   f = randnfunsphere(0.2); std2(f), plot(f,'zebra')
 %
-%   f = randnfunsphere(0.2,'monochromatic'); std2(f), plot(f)
-%   colormap([0 0 0; 1 1 1]), caxis(norm(caxis,inf)*[-1 1])
+%   f = randnfunsphere(0.2,'monochrome'); std2(f), plot(f,'zebra')
 %
 % See also RANDNFUN, RANDNFUN2, RANDNFUNDISK.
 
@@ -54,16 +53,16 @@ elseif nargin == 2
 end
  
 % deg = round(pi/lambda);
-% deg = ceil(2*pi/lambda);
+deg = ceil(2*pi/lambda);
 % deg = ceil(2*sqrt(2)*pi/lambda);
-deg = ceil(2*sqrt(4*pi)/lambda)-1;
+% deg = ceil(2*sqrt(4*pi)/lambda)-1;
 
 % We do not use adaptive construction, but just sample the function on a
 % fine enough grid to exactly resolve it then pass this to the constructor.
 
 % Sampling grid to exactly recover the random spherical harmonic:
-ll = trigpts(2*deg,[-pi pi]);
-tt = linspace(0,pi,2*deg);
+ll = trigpts(2*deg+2,[-pi pi]);
+tt = linspace(0,pi,2*deg+2);
 
 if strcmpi(type,'monochromatic');
     c = randn(2*deg+1, 1);

--- a/tests/misc/test_randnfunsphere.m
+++ b/tests/misc/test_randnfunsphere.m
@@ -12,8 +12,8 @@ pass(2) = (abs(mean2(f)) < .1);
 f = randnfunsphere(1e6);
 pass(3) = norm(diff(f),'fro') < 1e-4;
 
-f = randnfunsphere(1.6);
+f = randnfunsphere(3.1);
 pass(4) = ( rank(f) == 4 );
 
-f = randnfunsphere(1.6,'mono');
+f = randnfunsphere(3.1,'mono');
 pass(5) = ( rank(f) == 3 );


### PR DESCRIPTION
There was a mistake in how we were relating the truncation level of a random spherical harmonic series to the wave-length of the maximum resolved wave.  The primary purpose of this PR is to fix this mistake.  There was an additional bug where the sampling of the random spherical harmonic series at grid of values was not quite large enough to guarantee that we recovered the highest degree sine mode.  This also fixed with this PR.  Finally, the help text was updated.
