### PR TITLE
Feature quiver slopefield

### DIFF
--- a/@chebop/quiver.m
+++ b/@chebop/quiver.m
@@ -5,8 +5,8 @@ function varargout = quiver(N, varargin)
 %   H = QUIVER(N, AXIS, 'OPT1', VAL1, ...)
 %
 % Here, the inputs are:
-%   N    : A chebop, whose N.op arguments specifies a second order scalar ODE,
-%          or a coupled system of two first order ODEs.
+%   N    : A chebop, whose N.op arguments specifies a first or second order
+%          scalar ODE, or a coupled system of two first order ODEs.
 %   AXIS : A 4-vector with elements [XMIN XMAX YMIN YMAX] that specify the
 %          rectangular region shown on the phase plot. If none is passed, the
 %          default values [-1 1 -1 1] are used.
@@ -38,7 +38,8 @@ function varargout = quiver(N, varargin)
 % Note: The CHEBOP QUIVER command works by reformulating higher order problems
 % as coupled first order systems, evaluating the resulting first order system at
 % grid that should be interpreted as values of u and u', then calling the
-% built-ing MATLAB QUIVER method on the results.
+% built-ing MATLAB QUIVER method on the results. In the case of first order
+% scalar problems, the grid should be interpreted as values of t and u.
 %
 % Example 1 -- van der Pol equation (second order ODE)
 %   N = chebop(0,100);
@@ -58,6 +59,11 @@ function varargout = quiver(N, varargin)
 %   [u, v] = N\0;
 %   plot(u, v, 'linewidth', 2)
 %   plot(0.5, 1,'m*','markersize',15) % Mark initial condition
+%
+% Example 3 -- Slopefield for a first order problem
+%   N = chebop(@(t,u) diff(u)-sin(t)*u);
+%   quiver(N,[-1.2*pi 1.2*pi -1 1])
+
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers. See
 % http://www.chebfun.org/ for Chebfun information.

--- a/@chebop/quiver.m
+++ b/@chebop/quiver.m
@@ -135,7 +135,7 @@ if ( isempty(yl) )
 end
 
 % Convert the operator in N to first order.
-firstOrderFun = treeVar.toFirstOrder(N.op, 0, N.domain);
+[firstOrderFun, ~, ~, ~, diffOrd] = treeVar.toFirstOrder(N.op, 0, N.domain);
 
 % Vectors for constructing a meshgrid:
 y1 = linspace(xl(1), xl(end), xpts);
@@ -159,11 +159,19 @@ if ( numEquations > 2 )
         'order ODE or a system of two first order equations.'])
 end
 
-% [TODO]: Could probably vectorize this, with reshapes. For now, just loop.
-for i = 1:numel(x)
-    res = firstOrderFun(t,[x(i); y(i)]);
-    u(i) = res(1);
-    v(i) = res(2);
+% Are we plotting a slope field (cf. #2238), or a standard phase plane?
+if( (length(diffOrd) == 1) && (diffOrd == 1))   % Slope field
+    for i = 1:numel(x)
+        res = firstOrderFun(x(i), y(i));
+        u(i) = 1;
+        v(i) = res(1);
+    end
+else                                            % Phase plane
+    for i = 1:numel(x)
+        res = firstOrderFun(t,[x(i); y(i)]);
+        u(i) = res(1);
+        v(i) = res(2);
+    end
 end
 
 if ( normalize )

--- a/tests/chebop/test_quiver.m
+++ b/tests/chebop/test_quiver.m
@@ -20,13 +20,17 @@ N = chebop(@(t,u,v) [diff(u)-2.*u+u.*v; diff(v)+v-u.*v], [0 4]);
 pass(3) = doesNotCrash(@() quiver(N, [0 2 0 4], 'normalize', true, ...
     'scale',.5,'linewidth',2));
 
+%% Slopefield for a first order problem
+N = chebop(@(t,u) diff(u)-sin(t)*u);
+pass(4) = doesNotCrash(@() quiver(N,[-1.2*pi 1.2*pi -1 1]));
+
 %% Third order ODE should give an error
 N = chebop(0, 10*pi);
 N.op = @(t,y) diff(y, 3) + sin(y);
 try 
     quiver(N,[-2 2 -1 1]);
 catch ME
-    pass(4) = strcmp(ME.identifier, 'CHEBFUN:CHEBOP:quiver:tooHighOrder');
+    pass(5) = strcmp(ME.identifier, 'CHEBFUN:CHEBOP:quiver:tooHighOrder');
 end
 
 %% Second order coupled system should also give an error
@@ -34,7 +38,7 @@ N = chebop(@(t,u,v) [diff(u,2)-2.*u+u.*v; diff(v)+v-u.*v], [0 4]);
 try 
     quiver(N,[-2 2 -1 1]);
 catch ME
-    pass(5) = strcmp(ME.identifier, 'CHEBFUN:CHEBOP:quiver:tooHighOrder');
+    pass(6) = strcmp(ME.identifier, 'CHEBFUN:CHEBOP:quiver:tooHighOrder');
 end
 
 end


### PR DESCRIPTION
Closes #2238.

For example
```
N = chebop(@(t,u) diff(u)-sin(t)*u);
quiver(N,[-1.2*pi 1.2*pi -1 1])
```
yields the following figure:
![quiver-slopefield](https://user-images.githubusercontent.com/3543429/35306303-e0b01030-0094-11e8-82d0-e823cfb853e9.png)

I did some spot checks plots currently created using quiver, and they seemed to still give the original results.