### PR TITLE
fix-ratinterp-ratapprox-arbpts

### DIFF
--- a/ratinterp.m
+++ b/ratinterp.m
@@ -591,8 +591,8 @@ if ( nu > 0 )
     q = chebfun(Cf(:,1:nu+1) * b, dom, 'tech', @chebtech2);
     r = @(x) p(x) ./ q(x);
 else
-    q = chebfun(b, dom, 'tech', @chebtech2);
-    r = @(x) p(x)/b;
+    q = chebfun(b/R(1, 1), dom, 'tech', @chebtech2);
+    r = @(x) p(x)/(b/R(1, 1));
 end
 
 end

--- a/tests/misc/test_ratinterp.m
+++ b/tests/misc/test_ratinterp.m
@@ -106,4 +106,10 @@ pass(21) = err < 1e-10;
 err = norm(r(xx) - f(xx));
 pass(22) = err < 1e-10;
 
+% Check that interpolation in arbitrary points works when the denominator can
+% be reduced to a constant.
+[p, q, r] = ratinterp(ones(5, 1), 1, 1, [], chebpts(5));
+err = abs(r(1) - 1);
+pass(23) = err < 1e-10;
+
 end


### PR DESCRIPTION
The problem was that the lines that build q in this case did not
compensate for the R factor from the QR of the Vandermonde matrix.
Without this, we get embarrassing results like this:
```
>> [p, q, r] = ratinterp(ones(5, 1), 1, 1, [], chebpts(5));
>> p(1)/q(1)
ans =
    -4.472135954999578e-01
```
With this commit in place, the result is as expected:
```
>> [p, q, r] = ratinterp(ones(5, 1), 1, 1, [], chebpts(5));
>> p(1)/q(1)
ans =
     9.999999999999997e-01
```
This error probably went undetected because the code does compensate for
R when nu > 0, and given how often we play with arbitrary points, it's
conceivable that we just never hit the nu = 0 case in all of our
testing.