### PR TITLE
Deal with repeated values in Z in AAA

### DIFF
--- a/aaa.m
+++ b/aaa.m
@@ -65,6 +65,7 @@ F = F(toKeep); Z = Z(toKeep);
 toKeep = ~isnan(F);
 F = F(toKeep); Z = Z(toKeep);
 
+% Remove repeated elements of Z and corresponding elements of F:
 [Z, uni] = unique(Z); F = F(uni);
 
 M = length(Z);

--- a/aaa.m
+++ b/aaa.m
@@ -350,9 +350,9 @@ if ( ni == 0 )
     % Nothing to do.
     return
 elseif ( ni == 1 )
-    fprintf('1 Froissart doublet.\n')
+    warning('CHEBFUN:aaa:Froissart','1 Froissart doublet');
 else
-    fprintf('%d Froissart doublets.\n', ni)
+    warning('CHEBFUN:aaa:Froissart',[int2str(ni) ' Froissart doublets']);
 end
 
 % For each spurious pole find and remove closest support point:

--- a/aaa.m
+++ b/aaa.m
@@ -64,6 +64,9 @@ toKeep = ~isinf(F);
 F = F(toKeep); Z = Z(toKeep);
 toKeep = ~isnan(F);
 F = F(toKeep); Z = Z(toKeep);
+
+[Z, uni] = unique(Z); F = F(uni);
+
 M = length(Z);
 
 % Relative tolerance:

--- a/tests/chebfun/test_aaa.m
+++ b/tests/chebfun/test_aaa.m
@@ -7,6 +7,7 @@ if ( nargin < 1 )
 end
 tol = 1e+4 * pref.chebfuneps;
 
+warning('off', 'CHEBFUN:aaa:Froissart');
 
 Z = linspace(-1, 1, 1000);
 F = exp(Z);
@@ -74,5 +75,7 @@ X = linspace(0,20);
 F = sin(X)./X;
 r = aaa(F,X);
 pass(18) = ( abs(r(2) - sin(2)/2) < 1e-3 );
+
+warning('on', 'CHEBFUN:aaa:Froissart');
 
 end


### PR DESCRIPTION
When an element in Z is repeated and one instance of it is chosen as a support point, AAA throws an error because it doesn't drop the appropriate row of the Loewner matrix. This pull request deals with this issue by removing duplicate elements of Z at the start, altogether. I think this is a better strategy than just removing the appropriate indices in the J vector, because it reduces the size of the Loewner matrix that needs to be formed and is therefore more efficient, while remaining mathematically equivalent.