### PR TITLE
Improved residue computation

### DIFF
--- a/aaa.m
+++ b/aaa.m
@@ -280,64 +280,6 @@ end
 end % End of PARSEINPUT().
 
 
-%% Evaluate rational function in barycentric form.
-
-function r = reval(zz, zj, fj, wj)
-% Evaluate rational function in barycentric form.
-zv = zz(:);                             % vectorize zz if necessary
-CC = 1./bsxfun(@minus, zv, zj.');       % Cauchy matrix
-r = (CC*(wj.*fj))./(CC*wj);             % vector of values
-
-% Deal with input inf: r(inf) = lim r(zz) = sum(w.*f) / sum(w):
-r(isinf(zv)) = sum(wj.*fj)./sum(wj);
-
-% Deal with NaN:
-ii = find(isnan(r));
-for jj = 1:length(ii)
-    if ( isnan(zv(ii(jj))) || ~any(zv(ii(jj)) == zj) )
-        % r(NaN) = NaN is fine.
-        % The second case may happen if r(zv(ii)) = 0/0 at some point.
-    else
-        % Clean up values NaN = inf/inf at support points.
-        % Find the corresponding node and set entry to correct value:
-        r(ii(jj)) = fj(zv(ii(jj)) == zj);
-    end
-end
-
-% Reshape to input format:
-r = reshape(r, size(zz));
-
-end % End of REVAL().
-
-
-%% Compute poles, residues and zeros.
-
-function [pol, res, zer] = prz(r, zj, fj, wj)
-% Compute poles, residues, and zeros of rational function in barycentric form.
-m = length(wj);
-
-% Compute poles via generalized eigenvalue problem:
-B = eye(m+1);
-B(1,1) = 0;
-E = [0 wj.'; ones(m, 1) diag(zj)];
-pol = eig(E, B);
-% Remove zeros of denominator at infinity:
-pol = pol(~isinf(pol));
-
-% Compute residues via formula for res of quotient of analytic functions:
-N = @(t)(1./bsxfun(@minus,t,zj.')) * (fj.*wj);
-Ddiff = @(t) -((1./bsxfun(@minus,t,zj.')).^2) * wj;
-res = N(pol)./Ddiff(pol);
-
-% Compute zeros via generalized eigenvalue problem:
-E = [0 (wj.*fj).'; ones(m, 1) diag(zj)];
-zer = eig(E, B);
-% Remove zeros of numerator at infinity:
-zer = zer(~isinf(zer));
-
-end % End of PRZ().
-
-
 %% Cleanup
 
 function [r, pol, res, zer, z, f, w] = ...

--- a/aaa.m
+++ b/aaa.m
@@ -324,9 +324,10 @@ pol = eig(E, B);
 % Remove zeros of denominator at infinity:
 pol = pol(~isinf(pol));
 
-% Compute residues via discretized Cauchy integral:
-dz = 1e-5*exp(2i*pi*(1:4)/4);
-res = r(bsxfun(@plus, pol, dz))*dz.'/4;
+% Compute residues via formula for res of quotient of analytic functions:
+N = @(t)(1./bsxfun(@minus,t,zj.')) * (fj.*wj);
+Ddiff = @(t) -((1./bsxfun(@minus,t,zj.')).^2) * wj;
+res = N(pol)./Ddiff(pol);
 
 % Compute zeros via generalized eigenvalue problem:
 E = [0 (wj.*fj).'; ones(m, 1) diag(zj)];

--- a/prz.m
+++ b/prz.m
@@ -1,0 +1,35 @@
+function [pol, res, zer] = prz(r, zj, fj, wj)
+%PRZ   Computes poles, residues, and zeros of rational function in barycentric
+%      form.
+%   [POL, RES, ZER] = PRZ(R, ZJ, FJ, WJ) returns vectors of poles POL,
+%   residues RES, and zeros ZER of R, where R is a function handle, ZJ are
+%   the support points, FJ are the function values, and WJ are the
+%   barycentric weights.
+%
+% See also AAA, MINIMAX, REVAL.
+
+% Copyright 2018 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+m = length(wj);
+
+% Compute poles via generalized eigenvalue problem:
+B = eye(m+1);
+B(1,1) = 0;
+E = [0 wj.'; ones(m, 1) diag(zj)];
+pol = eig(E, B);
+% Remove zeros of denominator at infinity:
+pol = pol(~isinf(pol));
+
+% Compute residues via formula for res of quotient of analytic functions:
+N = @(t)(1./bsxfun(@minus,t,zj.')) * (fj.*wj);
+Ddiff = @(t) -((1./bsxfun(@minus,t,zj.')).^2) * wj;
+res = N(pol)./Ddiff(pol);
+
+% Compute zeros via generalized eigenvalue problem:
+E = [0 (wj.*fj).'; ones(m, 1) diag(zj)];
+zer = eig(E, B);
+% Remove zeros of numerator at infinity:
+zer = zer(~isinf(zer));
+
+end % End of PRZ().

--- a/reval.m
+++ b/reval.m
@@ -1,0 +1,35 @@
+function r = reval(zz, zj, fj, wj)
+%REVAL   Evaluate rational function in barycentric form.
+%   R = REVAL(ZZ, ZJ, FJ, WJ) returns R (vector of floats), the values of the
+%   barycentric rational function with support points ZJ, function values FJ,
+%   and barycentric weights WJ evaluated at the points ZZ.
+%
+% See also AAA, MINIMAX, PRZ.
+
+% Copyright 2018 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+zv = zz(:);                             % vectorize zz if necessary
+CC = 1./bsxfun(@minus, zv, zj.');       % Cauchy matrix
+r = (CC*(wj.*fj))./(CC*wj);             % vector of values
+
+% Deal with input inf: r(inf) = lim r(zz) = sum(w.*f) / sum(w):
+r(isinf(zv)) = sum(wj.*fj)./sum(wj);
+
+% Deal with NaN:
+ii = find(isnan(r));
+for jj = 1:length(ii)
+    if ( isnan(zv(ii(jj))) || ~any(zv(ii(jj)) == zj) )
+        % r(NaN) = NaN is fine.
+        % The second case may happen if r(zv(ii)) = 0/0 at some point.
+    else
+        % Clean up values NaN = inf/inf at support points.
+        % Find the corresponding node and set entry to correct value:
+        r(ii(jj)) = fj(zv(ii(jj)) == zj);
+    end
+end
+
+% Reshape to input format:
+r = reshape(r, size(zz));
+
+end % End of REVAL().

--- a/tests/chebfun/test_aaa.m
+++ b/tests/chebfun/test_aaa.m
@@ -76,6 +76,17 @@ F = sin(X)./X;
 r = aaa(F,X);
 pass(18) = ( abs(r(2) - sin(2)/2) < 1e-3 );
 
+% A couple of tests of residues
+X = linspace(-1.337,2,537);
+[r,pol,res] = aaa(exp(X)./X, X);
+ii = find(abs(pol)<1e-8);
+pass(19) = abs(res(ii)-1) < 1e-10;
+[r,pol,res] = aaa((1+1i)*gamma(X),X);
+ii = find(abs(pol-(-1))<1e-8);
+pass(20) = abs(res(ii)+(1+1i)) < 1e-10;
+
+
+
 warning('on', 'CHEBFUN:aaa:Froissart');
 
 end


### PR DESCRIPTION
As we have seen in numerical experiments, the current contour integral based residue computation can yield low accuracy results when the contour discretization values aren't represented faithfully in floating point arithmetic. This commit instead changes the residue computation to use the identity Res(f/g, z0) = f(z0)/g'(z0), where f and g are analytic at z0. This also obviates difficulties encountered when poles are located close to each other.