### PR TITLE
fix bug in padeapprox for complex inputs

### DIFF
--- a/padeapprox.m
+++ b/padeapprox.m
@@ -100,7 +100,7 @@ else                                           % General case.
 
         % Do final computation via reweighted QR for better zero preservation.
         D = diag(abs(b) + sqrt(eps));
-        [Q, R] = qr((C*D).');
+        [Q, R] = qr((C*D)');           % until July 2018 there was an erroneous .' here
 
         % Compensate for reweighting.
         b = D*Q(:,n+1);

--- a/tests/misc/test_padeapprox.m
+++ b/tests/misc/test_padeapprox.m
@@ -7,4 +7,8 @@ f = @(x) (x.^4 - 3)./((x + 3.2).*(x - 2.2));
 pass(1) = (mu == 4) && (nu == 2) && ...
     (max(abs(sort(poles) - [-3.2 ; 2.2])) < 1e-10);
 
+c = [1 1i];
+[r, a, b] = padeapprox(c, 0, 1);
+pass(2) = (abs(a-1) < 1e-10) && (abs(b(2)-(-1i)) < 1e-10); 
+
 end


### PR DESCRIPTION
@abigopal and I found a .' that should have been a '   .    