### PR TITLE
fix-chebop-matrix

### DIFF
--- a/@chebop/matrix.m
+++ b/@chebop/matrix.m
@@ -1,6 +1,13 @@
 function out = matrix(N, varargin)
-%   OUT = MATRIX(N, DIM) returns an DIM-point discretization of the linear
-%   operator N. If N is not linear an error is thrown. 
+%   OUT = MATRIX(N, DIM) returns an DIM by (DIM+D) discretization of the linear
+%   operator N, where D is the differential order of the operator. If N is not
+%   linear then an error is thrown. 
+%
+%   If the operator N has assigned boundary conditions then these are included
+%   in the discretization, increasing the number of rows. If the domain of N has
+%   breakpoints then DIM must be a vector specifying the discretization size on
+%   each interval. In this case, appropriate continuity constraints are included
+%   in the discretization, again increasing the number of rows accordingly.
 %
 %   OUT = MATRIX(N, DIM, PREFS) allows additional preferences to be passed 
 %   via the CHEBOPPREF, PREFS.
@@ -39,6 +46,8 @@ end
 % Determine the discretization:
 prefs = determineDiscretization(N, L, prefs);
 
+% Derive continuity conditions in the case of breakpoints:
+L = deriveContinuity(L);
 
 % Call LINOP/FEVAL or LINOP/MATRIX:
 if ( (numel(varargin) > 1) && strcmpi(varargin{2}, 'oldschool') )

--- a/tests/chebop/test_matrix.m
+++ b/tests/chebop/test_matrix.m
@@ -41,6 +41,30 @@ D24old = [ ...
      ];
 err(4) = norm(matrix(D2, 4, 'oldschool') - D24old);
 
+%% Boundary conditions:
+D2 = chebop(@(u) diff(u, 2), [-1 1], 0);
+D2bc = [1 0 0 0 ; 0 0 0 1 ; D22];
+err(5) = norm(matrix(D2, 2) - D2bc);
+
+D24oldbc = [1 0 0 0 ; D24old(2:3,:) ; 0 0 0 1]; 
+err(6) = norm(matrix(D2, 4, 'oldschool') - D24oldbc);
+
+%% Continuity conditions:
+D2 = chebop(@(u) diff(u, 2), [-1 0 1]);
+D22cont = [0 0 0 1 -1 0 0 0 ;
+           -1 8/3 -8 19/3 19/3 -8 8/3 -1 ;
+           4*D22 0*D22 ; 
+           0*D22 4*D22];
+err(7) = norm(matrix(D2, [2 2]) - D22cont);
+
+D24oldcont = [0 0 0 1 -1 0 0 0 ;
+              4*D24old(2:4,:) zeros(3,4) ; 
+              zeros(3,4) 4*D24old(1:3,:) ; 
+              -1 8/3 -8 19/3 19/3 -8 8/3 -1];
+err(8) = norm(matrix(D2, [4 4], 'oldschool') - D24oldcont);        
+              
+%%
+
 pass = err < tol;
  
 end


### PR DESCRIPTION
Enforce continuity constraints in `chebop/matrix` as suggested in #2278.

As far as I can tell, there are no dependencies on `chebop/matrix' so I'm happy to make this change.

I also adjusted the help documentation a little (but it's still not perfect) and added some tests.




