### PR TITLE
fix-simplify-conv

### DIFF
--- a/@chebfun/conv.m
+++ b/@chebfun/conv.m
@@ -170,6 +170,9 @@ if ( transState )
     h = h.';
 end
 
+% Simplify the result.
+h = simplify(h);
+
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -231,7 +234,6 @@ end
 
 % Construct CHEBFUN:
 h = chebfun(funs);
-h = simplify(h);
 h.isTransposed = f.isTransposed;
 
 end


### PR DESCRIPTION
Simplify the output of `chebfun/conv()`. 

Reasons for doing so: 
 * Consistency with old conv method (pre-Legendre series)
 * Convolution of two smooth functions typically has a much shorter length than input.