### PR TITLE
fix-chebfun-chebpts

### DIFF
--- a/chebpts.m
+++ b/chebpts.m
@@ -56,7 +56,13 @@ elseif ( length(n) ~= length(dom) - 1 )
 end
 
 % Create a dummy CHEBTECH of appropriate type to access static methods.
-f = feval(['chebtech', num2str(type)]);
+if ( type == 1 )
+    f = chebtech1();
+elseif ( type == 2 )
+    f = chebtech2();
+else
+    error('CHEBFUN:chebpts:type', 'Unknown point type.')
+end    
 
 if ( length(n) == 1 ) % Single grid.
     


### PR DESCRIPTION
Remove some unnecessary  overheads in `chebfun.chebpts'.

Before:
```
>> tic, for k = 1:1000, chebpts(10); end, toc
Elapsed time is 0.240198 seconds.
```
After:
```
>> tic, for k = 1:1000, chebpts(10); end, toc
Elapsed time is 0.156915 seconds.
```

It's not a huge difference, but it's a trivial change.
