### PR TITLE
fix-trigtech-plotcoeffs for constant functions

### DIFF
--- a/@trigtech/plotcoeffs.m
+++ b/@trigtech/plotcoeffs.m
@@ -137,11 +137,6 @@ else
     xlabelStr = '|Normalized wave number|+1';
 end
 
-% For constant functions, plot a dot:
-if ( n == 1 )
-    set(h, 'marker', 'o');
-end
-
 % Add title and labels
 title(gca, 'Fourier coefficients')
 xlabel(gca, xlabelStr)


### PR DESCRIPTION
This fixes a bug in trigtech-plotcoefffs for constant functions.
```
g = chebfun(@(x)1, 'trig');
plotcoeffs(g)
```
gives the following plot
![pltcoeffs](https://user-images.githubusercontent.com/31421323/54714599-3aa37f00-4b49-11e9-8ba0-2c6e11242a0a.png)
The new code plots a dot instead of a circle (and is consistent with chebtech/plotcoeffs)
![pltcoeffs2](https://user-images.githubusercontent.com/31421323/54714661-645ca600-4b49-11e9-9d64-59686645ef2c.png)



