### PR TITLE
Faster poisson solver

### DIFF
--- a/@chebop2/chebop2.m
+++ b/@chebop2/chebop2.m
@@ -16,7 +16,7 @@ classdef chebop2
 %
 % Boundary conditions are imposed via the syntax N.lbc, N.rbc, N.ubc, and N.dbc.
 %
-% Example 1: (Poisson with Dirichlet conditions):
+% Example 1: (Poisson with zero Dirichlet conditions):
 %    N = chebop2(@(u) diff(u,2,1) + diff(u,2,2));
 %    N.bc = 0;
 %    u = N \ 1;
@@ -31,11 +31,20 @@ classdef chebop2
 %    N.lbc = 0; N.rbc = 0; 
 %    N.dbc = @(x,u) [u - exp(-30*x.^2) ; diff(u)];
 %    u = N \ 0; 
+%
+% Example 4: (Poisson equation with general Dirichlet conditions and rhs)
+%    N = chebop2( @(u) lap(u));
+%    N.lbc = @(y) -y.^2;
+%    N.rbc = @(y) y.^2; 
+%    N.ubc = @(x) x;
+%    N.dbc = @(x) x;
+%    u = N \ chebfun2(@(x,y) cos(x.*y));
 % 
 % For further details about the PDE solver, see:
 %
-% A. Townsend and S. Olver, The automatic solution of partial differential
-% equations using a global spectral method, in preparation, 2014.
+% A. Townsend and S. Olver, The automatic solution of partial differential 
+% equations using a global spectral method, J. Comput. Phys., 299 (2015),
+% pp. 106-123.
 %
 % Warning: This PDE solver is an experimental new feature. It has not been
 % publicly advertised.  Chebop2 cannot do nonlinear problems as more 

--- a/@chebop2/set.m
+++ b/@chebop2/set.m
@@ -66,12 +66,16 @@ while ( length(propertyArgIn) >= 2 )
             N.xorder = val; 
         case 'yorder'
             N.yorder = val; 
+        case 'coeffs'
+            N.coeffs = val;
         case 'U'
             N.U = val;
         case 'S'
             N.S = val;
         case 'V'
             N.V = val;
+        case 'rhs'
+            N.rhs = val;
         otherwise
             error('CHEBFUN:CHEBOP2:set:unknownProp', ...
                 'Unknown CHEBOP2 property.')

--- a/@chebop2/subsasgn.m
+++ b/@chebop2/subsasgn.m
@@ -13,37 +13,11 @@ vin = varargin{:};
 switch index(1).type
     
     case '.' 
-        if strcmp(idx, 'bc')
-            varargout = {set(f, 'bc', vin)};
-        elseif strcmp(idx, 'lbc')
-            varargout = {set(f, 'lbc', vin)};
-        elseif strcmp(idx, 'rbc')
-            varargout = {set(f, 'rbc', vin)};
-        elseif strcmp(idx, 'ubc')
-            varargout = {set(f, 'ubc', vin)};
-        elseif strcmp(idx, 'dbc')
-            varargout = {set(f, 'dbc', vin)};
-        elseif strcmp(idx, 'op')
-            varargout = {set(f, 'op', vin)};
-        elseif strcmp(idx, 'domain')
-            varargout = {set(f, 'domain', vin)};
-        elseif strcmp(idx, 'coeffs')
-            varargout = {set(f, 'coeffs', vin)};
-        elseif strcmp(idx, 'xorder')
-            varargout = {set(f, 'xorder', vin)};   
-        elseif strcmp(idx, 'yorder')
-            varargout = {set(f, 'yorder', vin)};
-        elseif strcmp(idx, 'U')
-            varargout = {set(f, 'U', vin)};
-        elseif strcmp(idx, 'S')
-            varargout = {set(f, 'S', vin)};
-        elseif strcmp(idx, 'V')
-            varargout = {set(f, 'V', vin)};
+        if ischar(idx)
+            varargout = {set(f, idx, vin)};
         else
             error('CHEBFUN:CHEBOP2:subsasgn:UnexpectedType', ...
-                'Unrecognized chebop2 property.')
-        end
-        
+                  'Chebop2 properties are string arrays.')
+        end   
 end
-
 end


### PR DESCRIPTION
Old code, which called chebop2's automatic differentiation code on Laplace operator:  
```
tic
u = chebfun2.poisson(chebfun2(1),0);
toc
Elapsed time is 0.727262 seconds.
```
Updated code, which just fills in the Laplace operator (as we know it is Laplace):   
```
tic
u = chebfun2.poisson(chebfun2(1),0);
toc
Elapsed time is 0.592926 seconds.
```