### PR TITLE
legcoeffs(f, 1) failed. Fix that.

### DIFF
--- a/@chebfun/legcoeffs.m
+++ b/@chebfun/legcoeffs.m
@@ -73,7 +73,9 @@ if ( isSimple )
         
         % Compute the first two inner-products by hand:
         out(1,:) = out(1,:) + sum(diag(w)*vals);
-        out(2,:) = out(2,:) + sum(diag(w.*z.')*vals);
+        if ( n > 1 )
+            out(2,:) = out(2,:) + sum(diag(w.*z.')*vals);
+        end
         % Evaluate Legendre-Vandermonde matrix by recurrence relation:
         Pm2 = 1; Pm1 = z;
         for kk = 1:n-2

--- a/tests/chebfun/test_polyfit.m
+++ b/tests/chebfun/test_polyfit.m
@@ -76,4 +76,8 @@ pass(12) = length(f) == length(y) && norm(f-y, inf) < 1e-12;
 f = polyfit(y, 19);
 g = chebfun(@(x) cos(20*x), [0 2*pi], 'trig');
 pass(13) = norm(f+g-y, inf) < 1e-12;
+
+% Test best constant fit: 
+y = chebfun(@(x) sqrt(x+1), 'splitting', 'on'); 
+f = polyfit(y, 0); 
 end

--- a/tests/chebfun/test_polyfit.m
+++ b/tests/chebfun/test_polyfit.m
@@ -80,4 +80,5 @@ pass(13) = norm(f+g-y, inf) < 1e-12;
 % Test best constant fit: 
 y = chebfun(@(x) sqrt(x+1), 'splitting', 'on'); 
 f = polyfit(y, 0); 
+pass(14) = norm( f - 0.942809041582063, inf) < 10*eps; 
 end


### PR DESCRIPTION
Fix this. Add test. 
```
f = chebfun(@(x) sqrt(x+1), 'splitting', 'on');
legcoeffs(f,1)
Index exceeds matrix dimensions.
Error in
chebfun/legcoeffs>legcoeffsPiecewise
(line 76)
        out(2,:) = out(2,:) +
        sum(diag(w.*z.')*vals);
Error in chebfun/legcoeffs (line
31)
    out = legcoeffsPiecewise(f,
    varargin{:}); 
```
Closes #2317. 