### PR TITLE
Add poisson fadi

### DIFF
--- a/@chebfun2/poisson.m
+++ b/@chebfun2/poisson.m
@@ -247,6 +247,13 @@ elseif ( strcmpi(method, 'fadi') )
     u.pivotValues = 1./diag(DX);
     u.domain = dom;
     u = u + g;
+elseif ( strcmpi(method, 'bartelsStewart') )
+    X = chebop2.bartelsStewart(Tm, eye(n), eye(m), -Tn, Cf*Df*Rf.', 0, 0);
+    
+    % Convert back to Chebyshev
+    X = ultra1mx2cheb( ultra1mx2cheb( X ).' ).';
+    u = chebfun2( X, f.domain, 'coeffs' );
+    u = u + g;
 else 
     error('CHEBFUN2:POISSON:SOLVER', ...
         'Method supplied to chebfun2.poisson() is not recognized.');

--- a/@chebfun2/poisson.m
+++ b/@chebfun2/poisson.m
@@ -194,8 +194,8 @@ invDm = spdiags(-1./(jj.*(jj+3)+2), 0, m, m);
 
 % Construct T = D^{-1} * M:
 Tm = scl_x * invDm * Mm;
-Cf = invDm*Cf;
-Rf = invDn*Rf;
+Cf = invDm * Cf;
+Rf = invDn * Rf;
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%  Alternating Direction Implicit method %%%%%%%

--- a/@chebfun2/poisson.m
+++ b/@chebfun2/poisson.m
@@ -19,17 +19,16 @@ function u = poisson( f, varargin )
 %   tensor product discretization, where N is the number of coeffcieints in
 %   the x-direction and M is the number in the y-direction.
 %
-%   POISSON(F, G, METHOD), POISSON(F, G, N, METHOD), or 
-%   POISSON(F, G, M, N, METHOD) is the same as POISSON(F, G), 
-%   POISSON(F, G, N), or POISSON(F, G, M, N), respectively, except the
+%   POISSON(F, G, N, METHOD) or POISSON(F, G, M, N, METHOD) is the same as
+%   POISSON(F, G, N) or POISSON(F, G, M, N), respectively, except the
 %   underlying matrix equation is solved with METHOD. Available methods
-%   are: 
-%   'adi'   - alternating direction implicit method 
-%   'fadi'  - factored alternating direction implicit method 
+%   are:
+%   'adi'   - alternating direction implicit method
+%   'fadi'  - factored alternating direction implicit method
 %   'bartelstewart' - Bartel-Stewart's algorithm
-%   If METHOD is no supplied, then this commands selects one (based on the 
+%   If METHOD is not supplied, then this command selects one (based on the
 %   discretization size and the rank of the righthand side).
-% 
+%
 % EXAMPLE:
 %   f = chebfun2( @(x,y) 1 + 0*x, [-1 2 0 1]);
 %   u = chebfun2.poisson(f);
@@ -65,14 +64,20 @@ dom = f.domain;
 scl_x = (2/(dom(2)-dom(1)))^2;
 scl_y = (2/(dom(4)-dom(3)))^2;
 
+% Not enough input arguments so we call chebop2 to adaptively select a
+% discretization size: 
 if ( nargin == 1 )
+    
     % Call is POISSON(F) so set G = 0 and use chebop2 to determine the
     % discretization size:
     g = 0;
     N = chebop2.setuplaplace( f.domain );
     N.bc = g;
     u = N \ f;
+    return
+    
 elseif ( nargin == 2 )
+    
     % Call is POISSON(F, G) so use chebop2 to determine the discretization
     % size:
     g = varargin{1};
@@ -87,132 +92,164 @@ elseif ( nargin == 2 )
     N.dbc = feval(g, ':', f.domain(3));
     N.ubc = feval(g, ':', f.domain(4));
     u = N \ f;
-elseif ( nargin == 3 && ischar(varargin{2}) )
-    % Call is POISSON(F, G, METHOD). 
-    g = varargin{1}; 
-    method = varargin{2}; 
-else
-    % We are given a discretization size, so no need to use chebop2
-    g = varargin{1};
-    m = varargin{2};
+    return
     
-    if ( nargin == 3 )
-        % Call is POISSON(F, G, N) so employ an NxN discretization:
-        n = m;
+end
+
+% We are given a discretization size. It's solve time!    
+g = varargin{1};
+m = varargin{2};
+if ( nargin == 3 )
+    % Call must be POISSON(F, G, N) so employ an NxN discretization:
+    n = m; % square discretization
+elseif ( nargin == 4 )
+    
+    % The user typed one of the following:
+    % POISSON(F, G, N, METHOD) or POISSON(F, G, M, N).
+    
+    if ( ischar( varargin{3} ) )
+        % Call is POISSON(F, G, N, METHOD):
+        method = varargin{3};
+        n = m; % square discretization
     else
         % Call is POISSON(F, G, M, N):
         n = varargin{3};
     end
     
-    % Set the error tolerance for ADI
-    tol = chebfun2eps();
+elseif ( nargin == 5 )
     
-    % Compute the Chebyshev coefficients of f(x,y):
-    [Cf, Df, Rf] = coeffs2(f, m, n);
+    % We are given a discretization size and a method. It's solve time!
+    % Call must be POISSON(F, G, M, N, METHOD).
+    n = varargin{3};
+    method = varargin{4};
+else
+    error('CHEBFUN2:POISSON:NARGIN', ...
+        'Too many input arguments to chebfun2.poisson().');
+end
+
+% Set the error tolerance for solve:
+tol = chebfun2eps();
+
+% Compute the Chebyshev coefficients of rhs:
+[Cf, Df, Rf] = coeffs2(f, m, n);
+
+% Solver only deals with zero homogeneous Dirichlet conditions. Therefore,
+% if nonzero Dirichlet conditions are given, we solve lap(u) = f with u|bc = g
+% as u = v + w, where v|bc = g, and lap(w) = f - lap(v), w|bc = 0:
+if ( isa(g, 'double') )
     
-    % Solver only deals with zero homogeneous Dirichlet conditions. Therefore,
-    % if nonzero Dirichlet conditions are given, we solve lap(u) = f with u|bc = g
-    % as u = v + w, where v|bc = g, and lap(w) = f - lap(v), w|bc = 0:
-    if ( isa(g, 'double') )
-        g = chebfun2( g, f.domain); 
-%         BC = zeros(m, n);
-%         BC(1,1) = g;
-    elseif ( isa(g, 'chebfun2') )
-        if ( g.domain ~= f.domain )
-            error('CHEBFUN2:POISSON:BC', ...
-                'Dirichlet data should be on the same domain as F.');
-        else
-            % Adjust the rhs:
-            if ( ~iszero( g ))
-                [Cg, Dg, Rg] = coeffs2(lap(g), m, n);
-                Cf = [Cf -Cg];
-                Z = zeros(size(Df,1),size(Dg,1)); 
-                Df = [Df Z ; Z' Dg];
-                Rf = [Rf Rg];
-            end
+    % Make double into chebfun2:
+    g = chebfun2( g, f.domain);
+    
+elseif ( isa(g, 'chebfun2') )
+    if ( g.domain == f.domain )
+        % Adjust the rhs if nonzero:
+        if ( ~iszero( g ))
+            [Cg, Dg, Rg] = coeffs2(lap(g), m, n);
+            Cf = [Cf -Cg];
+            Z = zeros(size(Df,1),size(Dg,1));
+            Df = [Df Z ; Z' Dg];
+            Rf = [Rf Rg];
         end
-    elseif ( isa(g, 'function_handle') )
-        g = chebfun2(g, f.domain);
-        % Adjust the rhs:
+    else
+        error('CHEBFUN2:POISSON:BC', ...
+            'Dirichlet data should be on the same domain as F.');
+    end
+    
+elseif ( isa(g, 'function_handle') )
+    g = chebfun2(g, f.domain);
+    % Adjust the rhs, if nonzero:
+    if ( ~iszero( g ) )
         [Cg, Dg, Rg] = coeffs2(lap(g), m, n);
         Cf = [Cf Cg];
-        Z = zeros(size(Df,1),size(Dg,1)); 
+        Z = zeros(size(Df,1),size(Dg,1));
         Df = [Df Z ; Z' -Dg];
         Rf = [Rf Rg];
-    else
-        error('CHEBFUN2:POISSON',...
-            'Dirichlet data needs to be given as a scalar or function')
     end
-    
-    % Convert rhs to C^{(3/2)} coefficients:
-    Cf = cheb2ultra( Cf );
-    Rf = cheb2ultra( Rf );
-    
-    % Construct M, the multiplication matrix for (1-x^2) in the C^(3/2) basis
-    jj = (0:n-1)';
-    dsub = -1./(2*(jj+3/2)).*(jj+1).*(jj+2)*1/2./(1/2+jj+2);
-    dsup = -1./(2*(jj+3/2)).*(jj+1).*(jj+2)*1/2./(1/2+jj);
-    d = -dsub - dsup;
-    Mn = spdiags([dsub d dsup], [-2 0 2], n, n);
-    % Construct D^{-1}, which undoes the scaling from the Laplacian identity
-    invDn = spdiags(-1./(jj.*(jj+3)+2), 0, n, n);
-    Tn = scl_y * invDn * Mn;
-    
-    jj = (0:m-1)';
-    dsub = -1./(2*(jj+3/2)).*(jj+1).*(jj+2)*1/2./(1/2+jj+2);
-    dsup = -1./(2*(jj+3/2)).*(jj+1).*(jj+2)*1/2./(1/2+jj);
-    d = -dsub - dsup;
-    Mm = spdiags([dsub d dsup], [-2 0 2], m, m);
-    invDm = spdiags(-1./(jj.*(jj+3)+2), 0, m, m);
-    
-    % Construct T = D^{-1} * M:
-    Tm = scl_x * invDm * Mm;
-    Cf = invDm*Cf;
-    Rf = invDn*Rf;
-    
-    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    %%%%%%%  Alternating Direction Implicit method %%%%%%%
-    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    % Solve TmX + XTn' = F using ADI, which requires O(n^2log(n)log(1/eps))
-    % operations:
-    
-    % Calculate ADI shifts based on bounds on the eigenvalues of Tn and Tm:
-    a = -4/pi^2 * scl_y;
-    b = -39*n^-4 * scl_y;
-    c = 39*m^-4 * scl_x;
-    d = 4/pi^2 * scl_x;
-    [p, q] = chebop2.ADIshifts(a, b, c, d, tol);
-    rho = size(Cf,2); 
-    
+else
+    error('CHEBFUN2:POISSON',...
+        'Dirichlet data needs to be given as a scalar or function')
+end
+
+% Convert rhs to C^{(3/2)} coefficients:
+Cf = cheb2ultra( Cf );
+Rf = cheb2ultra( Rf );
+
+% Construct M, the multiplication matrix for (1-x^2) in the C^(3/2) basis
+jj = (0:n-1)';
+dsub = -1./(2*(jj+3/2)).*(jj+1).*(jj+2)*1/2./(1/2+jj+2);
+dsup = -1./(2*(jj+3/2)).*(jj+1).*(jj+2)*1/2./(1/2+jj);
+d = -dsub - dsup;
+Mn = spdiags([dsub d dsup], [-2 0 2], n, n);
+% Construct D^{-1}, which undoes the scaling from the Laplacian identity
+invDn = spdiags(-1./(jj.*(jj+3)+2), 0, n, n);
+Tn = scl_y * invDn * Mn;
+
+jj = (0:m-1)';
+dsub = -1./(2*(jj+3/2)).*(jj+1).*(jj+2)*1/2./(1/2+jj+2);
+dsup = -1./(2*(jj+3/2)).*(jj+1).*(jj+2)*1/2./(1/2+jj);
+d = -dsub - dsup;
+Mm = spdiags([dsub d dsup], [-2 0 2], m, m);
+invDm = spdiags(-1./(jj.*(jj+3)+2), 0, m, m);
+
+% Construct T = D^{-1} * M:
+Tm = scl_x * invDm * Mm;
+Cf = invDm*Cf;
+Rf = invDn*Rf;
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%  Alternating Direction Implicit method %%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Solve TmX + XTn' = F using ADI, which requires O(n^2log(n)log(1/eps))
+% operations:
+
+% Calculate ADI shifts based on bounds on the eigenvalues of Tn and Tm:
+a = -4/pi^2 * scl_y;
+b = -39*n^-4 * scl_y;
+c = 39*m^-4 * scl_x;
+d = 4/pi^2 * scl_x;
+[p, q] = chebop2.ADIshifts(a, b, c, d, tol);
+
+rho = size(Cf,2);  % rank of rhs
+
+if ( ~exist( 'method', 'var' ) )
+    % Let's go and pick a good method to use: 
     % Test if we should use ADI or FADI:
     adi_test = ( min(m,n) < rho*numel(p)/2 ); % Worth doing FADI?
-    
-    % Solve matrix equation:
-    if ( adi_test )
-        % Run the ADI method:
-        X = chebop2.adi(Tm, -Tn', Cf*Df*Rf.', p, q );
-        
-        % Convert back to Chebyshev
-        X = ultra1mx2cheb( ultra1mx2cheb( X ).' ).';
-        u = chebfun2( X, f.domain, 'coeffs' );
-        u = u + g; 
-    else
-        % Run the FADI method:
-        [UX, DX, VX] = chebop2.fadi(Tm, -Tn, Cf*Df, Rf, p, q);
-        
-        % Convert back to Chebyshev: 
-        UX = ultra1mx2cheb(UX);
-        VX = ultra1mx2cheb(VX);
-
-        UX = chebfun(UX, dom(3:4), 'coeffs');
-        VX = chebfun(VX, dom(1:2), 'coeffs');
-        u = chebfun2(); 
-        u.cols = UX; 
-        u.rows = VX; 
-        u.pivotValues = 1./diag(DX); 
-        u.domain = dom;
-        u = u + g;
+    method = 'adi'; 
+    if ( ~adi_test )
+        method = 'fadi';
     end
+end
+
+% Solve matrix equation:
+if ( strcmpi(method, 'adi') )
+    % Run the ADI method:
+    X = chebop2.adi(Tm, -Tn', Cf*Df*Rf.', p, q );
+    
+    % Convert back to Chebyshev
+    X = ultra1mx2cheb( ultra1mx2cheb( X ).' ).';
+    u = chebfun2( X, f.domain, 'coeffs' );
+    u = u + g;
+elseif ( strcmpi(method, 'fadi') )
+    % Run the FADI method:
+    [UX, DX, VX] = chebop2.fadi(Tm, -Tn, Cf*Df, Rf, p, q);
+    
+    % Convert back to Chebyshev:
+    UX = ultra1mx2cheb(UX);
+    VX = ultra1mx2cheb(VX);
+    
+    UX = chebfun(UX, dom(3:4), 'coeffs');
+    VX = chebfun(VX, dom(1:2), 'coeffs');
+    u = chebfun2();
+    u.cols = UX;
+    u.rows = VX;
+    u.pivotValues = 1./diag(DX);
+    u.domain = dom;
+    u = u + g;
+else 
+    error('CHEBFUN2:POISSON:SOLVER', ...
+        'Method supplied to chebfun2.poisson() is not recognized.');
 end
 end
 

--- a/@chebfun2/poisson.m
+++ b/@chebfun2/poisson.m
@@ -248,7 +248,7 @@ elseif ( strcmpi(method, 'fadi') )
     u.domain = dom;
     u = u + g;
 elseif ( strcmpi(method, 'bartelsStewart') )
-    X = chebop2.bartelsStewart(Tm, eye(n), eye(m), -Tn, Cf*Df*Rf.', 0, 0);
+    X = chebop2.bartelsStewart(Tm, eye(n), eye(m), Tn, Cf*Df*Rf.', 0, 0);
     
     % Convert back to Chebyshev
     X = ultra1mx2cheb( ultra1mx2cheb( X ).' ).';

--- a/@chebfun2/poisson.m
+++ b/@chebfun2/poisson.m
@@ -166,9 +166,10 @@ else
     c = 39*m^-4 * scl_x;
     d = 4/pi^2 * scl_x;
     [p, q] = ADIshifts(a, b, c, d, tol);
+    rho = size(Cf,2); 
     
     % Test if we should use ADI or FADI:
-    adi_test = ( min(m,n) > inf ); % Worth doing FADI?
+    adi_test = ( min(m,n) < rho*numel(p) ); % Worth doing FADI?
     
     % Solve matrix equation:
     if ( adi_test )

--- a/@chebop2/ADIshifts.m
+++ b/@chebop2/ADIshifts.m
@@ -1,0 +1,28 @@
+function [p, q] = ADIshifts(a, b, c, d, tol)
+% ADISHIFTS  ADI shifts for solving AX-XB=F.
+%
+% [P, Q] = ADISHIFTS(a, b, c, d, TOL) returns the optimal ADI shifts for 
+% solving AX-XB = F with the ADI method when A and B have  eigenvalues lying
+% in [a,b] and [c,d], respectively. WLOG, we require that a<b<c<d and 
+% 0<tol<1.
+
+gam = (c-a)*(d-b)/(c-b)/(d-a);                 % Cross-ratio of a,b,c,d
+% Calculate Mobius transform T:{-alp,-1,1,alp}->{a,b,c,d} for some alp:
+alp = -1 + 2*gam + 2*sqrt(gam^2-gam);          % Mobius exists with this t
+A = det([-a*alp a 1; -b b 1 ; c c 1]);         % Determinant formulae for Mobius
+B = det([-a*alp -alp a; -b -1 b ; c 1 c]);
+C = det([-alp a 1; -1 b 1 ; 1 c 1]);
+D = det([-a*alp -alp 1; -b -1 1; c 1 1]);
+T = @(z) (A*z+B)./(C*z+D);                     % Mobius transfom
+J = ceil( log(16*gam)*log(4/tol)/pi^2 );       % Number of ADI iterations
+if ( alp > 1e7 )
+    K = (2*log(2)+log(alp)) + (-1+2*log(2)+log(alp))/alp^2/4;
+    m1 = 1/alp^2;
+    u = (1/2:J-1/2)*K/J;
+    dn = sech(u) + .25*m1*(sinh(u).*cosh(u)+u).*tanh(u).*sech(u);
+else
+    K = ellipke( 1-1/alp^2 );
+    [~, ~, dn] = ellipj((1/2:J-1/2)*K/J,1-1/alp^2); % ADI shifts for [-1,-1/t]&[1/t,1]
+end
+p = T( -alp*dn ); q = T( alp*dn );                  % ADI shifts for [a,b]&[c,d]
+end

--- a/@chebop2/adi.m
+++ b/@chebop2/adi.m
@@ -1,0 +1,18 @@
+function X = adi( A, B, F, p, q)
+%ADI    Alternating direction implicit method for solving AX-XB=F.
+%X = ADI( A, B, F, p, q)  solve the Sylvester equation
+%
+%            A*X - X*B = F
+% 
+% using the ADI method with shift parameters p and q.
+
+m = size(A, 1);
+n = size(B, 1);
+X = zeros(m, n);
+Im = speye(m);
+In = speye(n);
+for j = 1:numel(p)
+    X = (F-(A+q(j)*Im)*X) / (B+q(j)*In);
+    X = (A+p(j)*Im) \ ( F - X*(B+p(j)*In) );
+end
+end

--- a/@chebop2/adi.m
+++ b/@chebop2/adi.m
@@ -1,9 +1,9 @@
-function X = adi( A, B, F, p, q)
-%ADI    Alternating direction implicit method for solving AX-XB=F.
-%X = ADI( A, B, F, p, q)  solve the Sylvester equation
+function X = adi( A, B, F, p, q )
+%ADI   Alternating direction implicit method for solving AX-XB=F.
+% X = ADI( A, B, F, p, q) solves the Sylvester equation
 %
 %            A*X - X*B = F
-% 
+%
 % using the ADI method with shift parameters p and q.
 
 %% Reference: 
@@ -20,4 +20,5 @@ for j = 1:numel(p)
     X = (F-(A+q(j)*Im)*X) / (B+q(j)*In);
     X = (A+p(j)*Im) \ ( F - X*(B+p(j)*In) );
 end
+
 end

--- a/@chebop2/adi.m
+++ b/@chebop2/adi.m
@@ -6,6 +6,11 @@ function X = adi( A, B, F, p, q)
 % 
 % using the ADI method with shift parameters p and q.
 
+%% Reference: 
+% [1] Lu, An, and Eugene L. Wachspress. 
+%  "Solution of Lyapunov equations by alternating direction implicit iteration." 
+%  Comp. & Math. with Appl., 21.9 (1991): pp. 43-58.
+
 m = size(A, 1);
 n = size(B, 1);
 X = zeros(m, n);

--- a/@chebop2/adiShifts.m
+++ b/@chebop2/adiShifts.m
@@ -1,9 +1,8 @@
-function [p, q] = ADIshifts(a, b, c, d, tol)
-% ADISHIFTS  ADI shifts for solving AX-XB=F.
-%
-% [P, Q] = ADISHIFTS(a, b, c, d, TOL) returns the optimal ADI shifts for 
-% solving AX-XB = F with the ADI method when A and B have  eigenvalues lying
-% in [a,b] and [c,d], respectively. WLOG, we require that a<b<c<d and 
+function [p, q] = adiShifts(a, b, c, d, tol)
+%ADISHIFTS  ADI shifts for solving AX-XB=F.
+% [P, Q] = ADISHIFTS(a, b, c, d, TOL) returns the optimal ADI shifts for
+% solving AX-XB = F with the ADI method when A and B have eigenvalues lying
+% in [a,b] and [c,d], respectively. WLOG, we require that a<b<c<d and
 % 0<tol<1.
 
 gam = (c-a)*(d-b)/(c-b)/(d-a);                 % Cross-ratio of a,b,c,d

--- a/@chebop2/chebop2.m
+++ b/@chebop2/chebop2.m
@@ -258,6 +258,9 @@ classdef chebop2
         % Matrix equation solver for AX - XB = F (p and q are ADI shifts): 
         X = adi( A, B, F, p, q); 
         
+        % ADI shift parameters for ADI method: 
+        [p, q] = ADIshifts(a, b, c, d, tol);
+        
         % Matrix equation solver for AXB^T + CXD^T = E. xsplit, ysplit = 1 if
         % the even and odd modes (coefficients) decouple.
         X = bartelsStewart(A, B, C, D, E, xsplit, ysplit);

--- a/@chebop2/chebop2.m
+++ b/@chebop2/chebop2.m
@@ -255,7 +255,10 @@ classdef chebop2
     %% STATIC HIDDEN METHODS.
     methods ( Static = true, Hidden = true )
         
-        % Matrix equation solver: AXB^T + CXD^T = E. xsplit, ysplit = 1 if
+        % Matrix equation solver for AX - XB = F (p and q are ADI shifts): 
+        X = adi( A, B, F, p, q); 
+        
+        % Matrix equation solver for AXB^T + CXD^T = E. xsplit, ysplit = 1 if
         % the even and odd modes (coefficients) decouple.
         X = bartelsStewart(A, B, C, D, E, xsplit, ysplit);
         
@@ -266,6 +269,9 @@ classdef chebop2
         % This is used to discretize the linear constrains:
         [bcrow, bcvalue] = constructBC(bcArg, bcpos,...
             een, bcn, dom, scl, order);
+        
+        % Matrix equation solver for A*X-X*B = M*N.' (p and q are ADI shifts):
+        [UX, DX, VX] = fadi( A, B, M, N, p, q);
         
         % Recover coefficient functions of a linear operator:
         p = recoverCoeffs(L);

--- a/@chebop2/chebop2.m
+++ b/@chebop2/chebop2.m
@@ -254,13 +254,16 @@ classdef chebop2
     
     %% STATIC HIDDEN METHODS.
     methods ( Static = true, Hidden = true )
-        
+
         % Matrix equation solver for AX - XB = F (p and q are ADI shifts): 
-        X = adi( A, B, F, p, q); 
-        
+        X = adi( A, B, F, p, q );
+
+        % Matrix equation solver for A*X-X*B = M*N.' (p and q are ADI shifts):
+        [UX, DX, VX] = fadi( A, B, M, N, p, q );
+
         % ADI shift parameters for ADI method: 
-        [p, q] = ADIshifts(a, b, c, d, tol);
-        
+        [p, q] = adiShifts(a, b, c, d, tol);
+
         % Matrix equation solver for AXB^T + CXD^T = E. xsplit, ysplit = 1 if
         % the even and odd modes (coefficients) decouple.
         X = bartelsStewart(A, B, C, D, E, xsplit, ysplit);
@@ -272,9 +275,6 @@ classdef chebop2
         % This is used to discretize the linear constrains:
         [bcrow, bcvalue] = constructBC(bcArg, bcpos,...
             een, bcn, dom, scl, order);
-        
-        % Matrix equation solver for A*X-X*B = M*N.' (p and q are ADI shifts):
-        [UX, DX, VX] = fadi( A, B, M, N, p, q);
         
         % Recover coefficient functions of a linear operator:
         p = recoverCoeffs(L);
@@ -295,8 +295,8 @@ classdef chebop2
         % Compute the separable representation of a PDO: 
         [cellU, S, cellV] = separableFormat(A, xorder, yorder, dom);
         
-        % Setup Laplace operator on domain DOM: 
-        N = setuplaplace( dom ) 
+        % Setup Laplace operator on domain DOM:
+        N = setupLaplace( dom );
         
         % Remove trailing coefficients.
         a = truncate(a, tol);

--- a/@chebop2/fadi.m
+++ b/@chebop2/fadi.m
@@ -15,10 +15,10 @@ VX = zeros(n, RankOfSolution);
 DX = diag( kron(q-p, ones(1,rho)) );
 Im = speye(m);
 In = speye(n);
-UX(:, 1:rho) = (A-q(1)*Im)\M;
-VX(:, 1:rho) = (B-p(1)*In)\N;
+UX(:, 1:rho) = (A+p(1)*Im)\M;
+VX(:, 1:rho) = (B+q(1)*In)\N;
 for j = 1:numel(p)-1
-    UX(:, j*rho+(1:rho)) = (A-p(j)*Im)*((A-q(j+1)*Im)\UX(:,(j-1)*rho+(1:rho)));
-    VX(:, j*rho+(1:rho)) = (B-q(j)*In)*((B-p(j+1)*In)\VX(:,(j-1)*rho+(1:rho)));
+    UX(:, j*rho+(1:rho)) = (A+q(j)*Im)*((A+p(j+1)*Im)\UX(:,(j-1)*rho+(1:rho)));
+    VX(:, j*rho+(1:rho)) = (B+p(j)*In)*((B+q(j+1)*In)\VX(:,(j-1)*rho+(1:rho)));
 end
 end

--- a/@chebop2/fadi.m
+++ b/@chebop2/fadi.m
@@ -7,6 +7,13 @@ function [UX, DX, VX] = fadi( A, B, M, N, p, q)
 % using the FADI method with ADI shifts p and q. It requires that the 
 % righthand side is given in low-rank form, i.e., M and N where rhs = M*N.'.
 
+%% Reference: 
+%
+% [1] Benner, Peter, Ren-Cang Li, and Ninoslav Truhar. 
+% "On the ADI method for Sylvester equations." J. of Comp. and App. Math.
+% 233.4 (2009): 1035-1045. 
+
+
 [m, rho] = size( M ); 
 n = size(N, 1); 
 RankOfSolution = rho * numel(p);

--- a/@chebop2/fadi.m
+++ b/@chebop2/fadi.m
@@ -1,18 +1,17 @@
-function [UX, DX, VX] = fadi( A, B, M, N, p, q)
-%FADI    Factored Alternating direction implicit method.
-%X = FADI( A, B, M, N, p, q)  solves the Sylvester equation
+function [UX, DX, VX] = fadi( A, B, M, N, p, q )
+%FADI   Factored alternating direction implicit method.
+% X = FADI( A, B, M, N, p, q ) solves the Sylvester equation
 %
 %            A*X - X*B = M*N.'
 %
-% using the FADI method with ADI shifts p and q. It requires that the 
-% righthand side is given in low-rank form, i.e., M and N where rhs = M*N.'.
+% using the FADI method with ADI shifts p and q. The righthand side must be
+% given in low-rank form, i.e., M and N where rhs = M*N.'.
 
 %% Reference: 
 %
 % [1] Benner, Peter, Ren-Cang Li, and Ninoslav Truhar. 
 % "On the ADI method for Sylvester equations." J. of Comp. and App. Math.
 % 233.4 (2009): 1035-1045. 
-
 
 [m, rho] = size( M ); 
 n = size(N, 1); 
@@ -28,4 +27,5 @@ for j = 1:numel(p)-1
     UX(:, j*rho+(1:rho)) = (A+q(j)*Im)*((A+p(j+1)*Im)\UX(:,(j-1)*rho+(1:rho)));
     VX(:, j*rho+(1:rho)) = (B+p(j)*In)*((B+q(j+1)*In)\VX(:,(j-1)*rho+(1:rho)));
 end
+
 end

--- a/@chebop2/fadi.m
+++ b/@chebop2/fadi.m
@@ -1,0 +1,24 @@
+function [UX, DX, VX] = fadi( A, B, M, N, p, q)
+%FADI    Factored Alternating direction implicit method.
+%X = FADI( A, B, M, N, p, q)  solves the Sylvester equation
+%
+%            A*X - X*B = M*N.'
+%
+% using the FADI method with ADI shifts p and q. It requires that the 
+% righthand side is given in low-rank form, i.e., M and N where rhs = M*N.'.
+
+[m, rho] = size( M ); 
+n = size(N, 1); 
+RankOfSolution = rho * numel(p);
+UX = zeros(m, RankOfSolution);
+VX = zeros(n, RankOfSolution);
+DX = diag( kron(q-p, ones(1,rho)) );
+Im = speye(m);
+In = speye(n);
+UX(:, 1:rho) = (A-q(1)*Im)\M;
+VX(:, 1:rho) = (B-p(1)*In)\N;
+for j = 1:numel(p)-1
+    UX(:, j*rho+(1:rho)) = (A-p(j)*Im)*((A-q(j+1)*Im)\UX(:,(j-1)*rho+(1:rho)));
+    VX(:, j*rho+(1:rho)) = (B-q(j)*In)*((B-p(j+1)*In)\VX(:,(j-1)*rho+(1:rho)));
+end
+end

--- a/@chebop2/setupLaplace.m
+++ b/@chebop2/setupLaplace.m
@@ -1,7 +1,7 @@
-function N = setuplaplace( dom )
-%SETUPLAPLACE( DOM )  Construct a chebop2 object for Laplace operator. 
+function N = setupLaplace( dom )
+%SETUPLAPLACE( DOM )  Construct a chebop2 object for Laplace operator.
 % A small piece of code that is faster than calling the chebop2
-% constructor for forming the Laplace operator on DOM. 
+% constructor for forming the Laplace operator on DOM.
 
     N = chebop2();
     N.domain = dom;
@@ -10,5 +10,5 @@ function N = setuplaplace( dom )
     N.xorder = 2;
     N.yorder = 2;
     N.rhs = 0;
-    
+
 end

--- a/tests/chebfun2/test_poisson.m
+++ b/tests/chebfun2/test_poisson.m
@@ -67,4 +67,17 @@ f = lap(v);
 u = chebfun2.poisson(f, v, m, n);
 pass(8) = ( norm(u-v) < tol );
 
+% Check the syntax to chebfun2.poisson works: 
+u1 = chebfun2.poisson(f, v);
+u2 = chebfun2.poisson(f, v, n);
+u3 = chebfun2.poisson(f, v, m, n);
+u4 = chebfun2.poisson(f, v, n, 'adi');
+u5 = chebfun2.poisson(f, v, n, 'fadi');
+u6 = chebfun2.poisson(f, v, m, n, 'adi');
+u7 = chebfun2.poisson(f, v, m, n, 'fadi');
+pass(9) = ( norm(u1-u2) < tol & ...
+          norm(u2-u3) < tol & ...
+          norm(u3-u4) < tol & ...
+          norm(u4-u5) < tol & ...
+          norm(u6-u7) < tol );
 end

--- a/tests/chebfun2/test_poisson.m
+++ b/tests/chebfun2/test_poisson.m
@@ -5,7 +5,7 @@ if ( nargin == 0 )
     pref = chebfunpref;
 end
 
-tol = 1e6*pref.cheb2Prefs.chebfun2eps;
+tol = 1e4*pref.cheb2Prefs.chebfun2eps;
 
 % One-argument syntax (RHS):
 v = chebfun2( @(x,y) (1-x.^2).*(1-y.^2).*cos(2*pi*x.*y) );
@@ -62,7 +62,7 @@ pass(7) = ( norm(u-v) < tol );
 m = 201; n = 202;
 a = -3; b = 1; c = 4; d = 4.2;
 p = @(x,y) x.*y + cos(3*x.^2.*(y-.2));
-v = chebfun2( p, [a b c d]);
+v = chebfun2( p, [a b c d] );
 f = lap(v);
 u = chebfun2.poisson(f, v, m, n);
 pass(8) = ( norm(u-v) < tol );
@@ -77,9 +77,10 @@ u6 = chebfun2.poisson(f, v, m, n, 'adi');
 u7 = chebfun2.poisson(f, v, m, n, 'fadi');
 u8 = chebfun2.poisson(f, v, m, n, 'bartelsStewart');
 pass(9) = ( norm(u1-u2) < tol & ...
-          norm(u2-u3) < tol & ...
-          norm(u3-u4) < tol & ...
-          norm(u4-u5) < tol & ...
-          norm(u6-u7) < tol & ... 
-          norm(u7-u8)< tol);
+            norm(u2-u3) < tol & ...
+            norm(u3-u4) < tol & ...
+            norm(u4-u5) < tol & ...
+            norm(u5-u6) < tol & ...
+            norm(u6-u7) < tol & ...
+            norm(u7-u8) < tol );
 end

--- a/tests/chebfun2/test_poisson.m
+++ b/tests/chebfun2/test_poisson.m
@@ -59,7 +59,7 @@ u = chebfun2.poisson(f, p, m, n);
 pass(7) = ( norm(u-v) < tol );
 
 % General Dirichlet data, given as chebfun2:
-m = 201; n = 201;
+m = 201; n = 202;
 a = -3; b = 1; c = 4; d = 4.2;
 p = @(x,y) x.*y + cos(3*x.^2.*(y-.2));
 v = chebfun2( p, [a b c d]);
@@ -75,9 +75,11 @@ u4 = chebfun2.poisson(f, v, n, 'adi');
 u5 = chebfun2.poisson(f, v, n, 'fadi');
 u6 = chebfun2.poisson(f, v, m, n, 'adi');
 u7 = chebfun2.poisson(f, v, m, n, 'fadi');
+u8 = chebfun2.poisson(f, v, m, n, 'bartelsStewart');
 pass(9) = ( norm(u1-u2) < tol & ...
           norm(u2-u3) < tol & ...
           norm(u3-u4) < tol & ...
           norm(u4-u5) < tol & ...
-          norm(u6-u7) < tol );
+          norm(u6-u7) < tol & ... 
+          norm(u7-u8)< tol);
 end

--- a/tests/chebfun2/test_zerofunction.m
+++ b/tests/chebfun2/test_zerofunction.m
@@ -42,11 +42,12 @@ if all(size(v) == size(r))
 end
 
 f = chebfun2( zeros(5,4) ); 
-pass(5) = (norm( coeffs2(f) - zeros(5,4) ) == 0 );
+pass(5) = ( norm( coeffs2(f) - zeros(5,4) ) == 0 );
 
 f = chebfun2( 0 ); 
-[C, D, R] = coeffs2( f, 11, 13); 
-pass(6) = ( norm( C - zeros(11,1) ) == 0 &&...
-            norm( D - 1 ) == 0 && norm( R - zeros(13,1) ) == 0 ); 
+[C, D, R] = coeffs2( f, 11, 13 );
+pass(6) = ( norm( C - zeros(11,1) ) == 0 && ...
+            norm( D - 1 )           == 0 && ...
+            norm( R - zeros(13,1) ) == 0 );
 
 end

--- a/tests/chebop2/test_domain.m
+++ b/tests/chebop2/test_domain.m
@@ -5,7 +5,7 @@ function pass = test_domain( prefs )
 if ( nargin < 1 ) 
     prefs = chebfunpref(); 
 end 
-tol = 1e3*prefs.techPrefs.chebfuneps;
+tol = 1e4*prefs.techPrefs.chebfuneps;
 
 d = [-2 2 -2 2];
 N = chebop2(@(u) diff(u, 2, 1) + diff(u, 2, 2), d);


### PR DESCRIPTION
This PR adds various solution techniques to `chebfun2/poisson`. In particular, this PR adds the factored ADI method (which can be much faster than the standard ADI method when the rhs is of low rank). For example, 

```
g = chebfun2(@(x,y) x.^2); 
n = 1024;
tic, u = chebfun2.poisson(chebfun2(0), g, n, n, 'adi'); toc
tic, v = chebfun2.poisson(chebfun2(0), g, n, n, 'fadi'); toc
tic, w = chebfun2.poisson(chebfun2(0), g, n, n, 'bartelsStewart'); toc
Elapsed time is 6.113386 seconds.
Elapsed time is 0.293362 seconds.
Elapsed time is 50.693990 seconds.
```
