### PR TITLE
Fix construction of chebfun2 from univariate data

### DIFF
--- a/@chebfun2/constructor.m
+++ b/@chebfun2/constructor.m
@@ -543,9 +543,19 @@ function [relTol, absTol] = getTol(xx, yy, vals, dom, pseudoLevel)
 
 [m, n] = size( vals );
 grid = max( m, n );
-% Remove some edge values so that df_dx and df_dy have the same size.
-dfdx = diff(vals(1:m-1,:),1,2) ./ diff(xx(1:m-1,:),1,2); % xx diffs column-wise.
-dfdy = diff(vals(:,1:n-1),1,1) ./ diff(yy(:,1:n-1),1,1); % yy diffs row-wise.
+dfdx = 0;
+dfdy = 0;
+if ( m > 1 && n > 1 )
+    % Remove some edge values so that df_dx and df_dy have the same size.
+    dfdx = diff(vals(1:m-1,:),1,2) ./ diff(xx(1:m-1,:),1,2); % xx diffs column-wise.
+    dfdy = diff(vals(:,1:n-1),1,1) ./ diff(yy(:,1:n-1),1,1); % yy diffs row-wise.
+elseif ( m > 1 && n == 1 )
+    % Constant in x-direction
+    dfdy = diff(vals,1,1) ./ diff(yy,1,1);
+elseif ( m == 1 && n > 1 )
+    % Constant in y-direction
+    dfdx = diff(vals,1,2) ./ diff(xx,1,2);
+end
 % An approximation for the norm of the gradient over the whole domain.
 Jac_norm = max( max( abs(dfdx(:)), abs(dfdy(:)) ) );
 vscale = max( abs( vals(:) ) );

--- a/tests/chebfun2/test_constructor2.m
+++ b/tests/chebfun2/test_constructor2.m
@@ -123,4 +123,10 @@ catch ME
     pass(24) = strcmp(ME.identifier, 'CHEBFUN:CHEBFUN2:constructor:equi');
 end
 
+% Test building a chebfun2 from univariate data:
+r = rand(2,1); % Constant in x
+pass(25) = norm( r - chebpolyval2(chebfun2(r)) ) < 10*tol;
+r = rand(1,2); % Constant in y
+pass(26) = norm( r - chebpolyval2(chebfun2(r)) ) < 10*tol;
+
 end


### PR DESCRIPTION
Fix for constructing a `chebfun2` from a row or column vector of values or coefficients (i.e. an `m x 1` or `1 x n` matrix), which gave an error (see #2229). Add some tests.
```
u = chebfun2(rand(2,1));

Operands to the || and && operators must be convertible to
logical scalar values.

Error in chebfun2/constructor>completeACA (line 334)
while ( ( infNorm > absTol ) && ( zRows < width / factor) ...

Error in chebfun2/constructor>constructFromDouble (line 276)
[pivotValue, ~, rowValues, colValues] = completeACA(op,
absTol, 0);

Error in chebfun2/constructor (line 67)
    g = constructFromDouble(op, dom, pref, isEqui);

Error in chebfun2 (line 58)
            f = constructor(f, varargin{:});
```