### PR TITLE
Fix for chebfun2 losing 'trig'

### DIFF
--- a/@chebfun2/chebfun2.m
+++ b/@chebfun2/chebfun2.m
@@ -13,8 +13,13 @@ classdef chebfun2 < separableApprox
 % CHEBFUN2(F, [A B C D]) specifies a rectangle [A B]x[C D] where the 
 % function is defined. A, B, C, D must all be finite.
 %
-% If F is a matrix, A = (a_ij), the numbers aij are used as function values
-% at tensor Chebyshev points of the 2nd kind.
+% If F is a matrix, F = (f_ij), the numbers f_ij are used as function
+% values at tensor Chebyshev points of the 2nd kind. CHEBFUN2(F, 'equi')
+% assumes the function values f_ij come from an equispaced tensor grid.
+% CHEBFUN2(F, 'equix') assumes the values come from a tensor grid that is
+% equispaced in x and 2nd-kind Chebyshev in y. CHEBFUN2(F, 'equiy') assumes
+% the values come from a tensor grid that is 2nd-kind Chebyshev in x and
+% equispaced in y.
 % 
 % CHEBFUN2(F, k) returns a rank k approximation to F.
 %
@@ -26,8 +31,27 @@ classdef chebfun2 < separableApprox
 % CHEBFUN2(F, k, [A B C D]) or CHEBFUN2(F, [m,n], [A B C D]) is nonadaptive in
 % rank or degrees, as above, returning a chebfun2 on the domain [A B]x[C D]. 
 % 
-% CHEBFUN2(F, 'coeffs') where F is matrix uses the matrix as coefficients in 
-% a Chebyshev tensor expansion.
+% CHEBFUN2(F, 'coeffs') where F is a matrix uses the matrix as coefficients
+% in a Chebyshev tensor expansion. CHEBFUN2(F, 'coeffsx') uses an expansion
+% of coefficients in x and values in y. CHEBFUN2(F, 'coeffsy') uses an
+% expansion of values in x and coefficients in y.
+%
+% CHEBFUN2(F, 'trig') constructs a CHEBFUN2 object representing a smooth
+% and periodic function F on [-1,1]x[-1 1]. The resulting CHEBFUN2 is
+% represented using a bivariate Fourier expansion. CHEBFUN2(F, 'trigx')
+% constructs a CHEBFUN2 that is periodic in x only, represented as a
+% bivariate Fourier-Chebyshev expansion. CHEBFUN2(F, 'trigy') constructs a
+% CHEBFUN2 that is periodic in y only, represented as a bivariate
+% Chebyshev-Fourier expansion.
+%
+% CHEBFUN2(F, 'periodic')  is the same as CHEBFUN2(F, 'trig').
+% CHEBFUN2(F, 'periodicx') is the same as CHEBFUN2(F, 'trigx').
+% CHEBFUN2(F, 'periodicy') is the same as CHEBFUN2(F, 'trigy').
+%
+% CHEBFUN2(F, pref) constructs a CHEBFUN2 object from F with the options
+% determined by the CHEBFUNPREF object pref. CHEBFUN2(F, {prefx, prefy})
+% uses the CHEBFUNPREF objects prefx in x and prefy in y, where one of
+% prefx and prefy may be [].
 %
 % The Chebfun2 software system is based on: 
 %

--- a/@chebfun2/compose.m
+++ b/@chebfun2/compose.m
@@ -84,6 +84,19 @@ elseif ( ( nargin == 3 ) && ( nargin(op) == 2 ) )
     % OP has two input variables.
     
     g = varargin{1};
+
+    % OP(f,g) should be periodic if:
+    %  - f and g are periodic
+    %  - f is periodic, g is scalar
+    %  - f is scalar, g is periodic
+    pref = chebfunpref;
+    if ( (isa(f, 'chebfun2') && isPeriodicTech(f) && ...
+          isa(g, 'chebfun2') && isPeriodicTech(g))                || ...
+         (isa(f, 'chebfun2') && isPeriodicTech(f) && isscalar(g)) || ...
+         (isscalar(f) && isa(g, 'chebfun2') && isPeriodicTech(g)) )
+        pref.tech = @trigtech;
+    end
+
     if ( isa(g, 'double') )     % promote
         g = chebfun2(g, f.domain);
     end
@@ -93,7 +106,7 @@ elseif ( ( nargin == 3 ) && ( nargin(op) == 2 ) )
     end
     
     % Call constructor:
-    f = chebfun2(@(x,y) op(feval(f, x, y), feval(g, x, y)), f.domain);
+    f = chebfun2(@(x,y) op(feval(f, x, y), feval(g, x, y)), f.domain, pref);
     
 else
     % Not sure what to do, error:

--- a/@chebfun2/constructor.m
+++ b/@chebfun2/constructor.m
@@ -683,24 +683,32 @@ if ( any(isPref) )
     end
 end
 
-isEqui = cellfun(@(p) any(strcmpi(p, 'equi')) && ...
-    ~( iscell(p) && numel(p) > 2 ), varargin);
-if ( any(isEqui) )
-    args = varargin(isEqui);
-    varargin(isEqui) = [];
-    isEqui = strcmpi(args{end}, 'equi');
-    isEqui = isEqui | [false false]; % Expand to be 1 x 2
-else
-    isEqui = [false false];
+isEqui = [false false];
+match = cellfun(@(p) any(strcmpi(p, {'equi', 'equix', 'equiy'})), varargin);
+if ( any(match) )
+    args = varargin(match);
+    varargin(match) = [];
+    if ( strcmpi(args{end}, 'equix') )
+        isEqui = [true false];
+    elseif ( strcmpi(args{end}, 'equiy') )
+        isEqui = [false true];
+    else
+        isEqui = [true true];
+    end
 end
 
-isTrig = cellfun(@(p) any(strcmpi(p, 'trig') | strcmpi(p, 'periodic')) && ...
-    ~( iscell(p) && numel(p) > 2 ), varargin);
-if ( any(isTrig) )
-    args = varargin(isTrig);
-    varargin(isTrig) = [];
-    isTrig = strcmpi(args{end}, 'trig') | strcmpi(args{end}, 'periodic');
-    isTrig = isTrig | [false false]; % Expand to be 1 x 2
+match = cellfun(@(p) any(strcmpi(p, {'trig', 'trigx', 'trigy', ...
+    'periodic', 'periodicx', 'periodicy'})), varargin);
+if ( any(match) )
+    args = varargin(match);
+    varargin(match) = [];
+    if ( any(strcmpi(args{end}, {'trigx', 'periodicx'})) )
+        isTrig = [true false];
+    elseif ( any(strcmpi(args{end}, {'trigy', 'periodicy'})) )
+        isTrig = [false true];
+    else
+        isTrig = [true true];
+    end
     if ( isTrig(1) ), prefx.tech = @trigtech; end
     if ( isTrig(2) ), prefy.tech = @trigtech; end
 else
@@ -714,7 +722,7 @@ else
               isa(prefy.tech(), 'trigtech')];
 end
 
-isEpsGiven = find(cellfun(@(p) ~iscell(p) && strcmpi(p, 'eps'), varargin));
+isEpsGiven = find(cellfun(@(p) strcmpi(p, 'eps'), varargin));
 if ( isEpsGiven )
     pseudoLevel = varargin{isEpsGiven+1};
     varargin(isEpsGiven+(0:1)) = [];
@@ -725,7 +733,7 @@ prefx.cheb2Prefs.chebfun2eps = max(prefx.cheb2Prefs.chebfun2eps, pseudoLevel);
 prefy.cheb2Prefs.chebfun2eps = max(prefy.cheb2Prefs.chebfun2eps, pseudoLevel);
 
 % Look for vectorize flag:
-vectorize = find(cellfun(@(p) ~iscell(p) && strncmpi(p, 'vectori', 7), varargin));
+vectorize = find(cellfun(@(p) strncmpi(p, 'vectori', 7), varargin));
 if ( vectorize )
     varargin(vectorize) = [];
     vectorize = true;
@@ -753,20 +761,24 @@ if ( fixedLength && ~isnumeric(op) )
     end
 end
 
-isPadua = find(cellfun(@(p) ~iscell(p) && strcmpi(p, 'padua'), varargin));
+isPadua = find(cellfun(@(p) strcmpi(p, 'padua'), varargin));
 if ( isPadua )
     varargin(isPadua) = [];
     op = chebfun2.paduaVals2coeffs(op);
     op = chebfun2.coeffs2vals(op);
 end
 
-isCoeffs = cellfun(@(p) any(strcmpi(p, 'coeffs')) && ...
-    ~( iscell(p) && numel(p) > 2 ), varargin);
-if ( any(isCoeffs) )
-    args = varargin(isCoeffs);
-    varargin(isCoeffs) = [];
-    isCoeffs = strcmpi(args{end}, 'coeffs');
-    isCoeffs = isCoeffs | [false false]; % Expand to be 1x2
+match = cellfun(@(p) any(strcmpi(p, {'coeffs', 'coeffsx', 'coeffsy'})), varargin);
+if ( any(match) )
+    args = varargin(match);
+    varargin(match) = [];
+    if ( strcmpi(args{end}, 'coeffsx') )
+        isCoeffs = [true false];
+    elseif ( strcmpi(args{end}, 'coeffsy') )
+        isCoeffs = [false true];
+    else
+        isCoeffs = [true true];
+    end
 
     % Get the coeffs2vals transform corresponding to each tech
     if ( ~( isa(prefx.tech(), 'chebtech2') || isa(prefy.tech(), 'chebtech2') || ...

--- a/@chebfun2/constructor.m
+++ b/@chebfun2/constructor.m
@@ -28,25 +28,23 @@ function g = constructor(g, op, varargin)
 % See http://www.chebfun.org/ for Chebfun2 information.
 
 % Parse the inputs:
-[op, dom, pref, isEqui, isTrig, fixedRank, vectorize] = parseInputs(op, varargin{:});
+[op, dom, prefx, prefy, isEqui, isTrig, fixedRank, vectorize] = parseInputs(op, varargin{:});
 
 % Preferences:
-tech        = pref.tech();
-tpref       = tech.techPref;
-minSample   = tpref.minSamples;
-maxSample   = tpref.maxLength;
-cheb2Prefs  = pref.cheb2Prefs;
-sampleTest  = cheb2Prefs.sampleTest;
-maxRank     = cheb2Prefs.maxRank;
-pseudoLevel = cheb2Prefs.chebfun2eps;
+techx       = prefx.tech();
+techy       = prefy.tech();
+tprefx      = techx.techPref;
+tprefy      = techy.techPref;
+minSample   = [tprefx.minSamples, tprefy.minSamples];
+maxSample   = [tprefx.maxLength, tprefy.maxLength];
+sampleTest  = prefx.cheb2Prefs.sampleTest | prefy.cheb2Prefs.sampleTest;
+maxRank     = [prefx.cheb2Prefs.maxRank, prefy.cheb2Prefs.maxRank];
+pseudoLevel = min(prefx.cheb2Prefs.chebfun2eps, prefy.cheb2Prefs.chebfun2eps);
 
 % minSample needs to be a power of 2 when building periodic CHEBFUN2 objects or
 % a ones plus power of 2 otherwise.  See #1771.
-if ( isTrig )
-    minSample = 2.^(floor(log2(tpref.minSamples)));
-else
-    minSample = 2.^(floor(log2(tpref.minSamples - 1))) + 1;
-end
+minSample( isTrig) = 2.^(floor(log2(minSample(isTrig))));
+minSample(~isTrig) = 2.^(floor(log2(minSample(~isTrig) - 1))) + 1;
 
 factor  = 4; % Ratio between size of matrix and no. pivots.
 isHappy = 0; % If we are currently unresolved.
@@ -58,13 +56,13 @@ if ( isa(op, 'chebfun2') )  % CHEBFUN2( CHEBFUN2 )
 end
 
 % The 'equi' flag can be used only with numeric data:
-if ( isEqui && ~isa(op, 'double') )
+if ( any(isEqui) && ~isa(op, 'double') )
     error('CHEBFUN:CHEBFUN2:constructor:equi', ...
         'The EQUI flag is valid only when constructing from numeric data');
 end
 % Deal with constructions from numeric data:
 if ( isa(op, 'double') )    % CHEBFUN2( DOUBLE )
-    g = constructFromDouble(op, dom, pref, isEqui);
+    g = constructFromDouble(op, dom, prefx, prefy, isEqui, isTrig);
     % Fix the rank:
     g = fixTheRank(g, fixedRank);
     return
@@ -74,7 +72,7 @@ while ( ~isHappy && ~failure )
     grid = minSample;
     
     % Sample function on a Chebyshev tensor grid:
-    [xx, yy] = points2D(grid, grid, dom, pref);
+    [xx, yy] = points2D(grid(1), grid(2), dom, prefx, prefy);
     vals = evaluate(op, xx, yy, vectorize);
     
     % Does the function blow up or evaluate to NaN?:
@@ -89,7 +87,8 @@ while ( ~isHappy && ~failure )
     
     % Two-dimensional version of CHEBFUN's tolerance:
     [relTol, absTol] = getTol(xx, yy, vals, dom, pseudoLevel);
-    pref.chebfuneps = relTol;
+    prefx.chebfuneps = relTol;
+    prefy.chebfuneps = relTol;
     
     %% %%% PHASE 1: %%%
     % Do GE with complete pivoting:
@@ -97,15 +96,17 @@ while ( ~isHappy && ~failure )
     
     strike = 1;
     % grid <= 4*(maxRank-1)+1, see Chebfun2 paper.
-    while ( iFail && grid <= factor*(maxRank-1)+1 && strike < 3)
+    while ( iFail && all(grid <= factor*(maxRank-1)+1) && strike < 3)
         % Refine sampling on tensor grid:
-        grid = gridRefine( grid , pref);
-        [xx, yy] = points2D(grid, grid, dom, pref);
+        grid(1) = gridRefine(grid(1), prefx);
+        grid(2) = gridRefine(grid(2), prefy);
+        [xx, yy] = points2D(grid(1), grid(2), dom, prefx, prefy);
         vals = evaluate(op, xx, yy, vectorize); % resample
         vscale = max(abs(vals(:)));
         % New tolerance:
         [relTol, absTol] = getTol(xx, yy, vals, dom, pseudoLevel);
-        pref.chebfuneps = relTol;
+        prefx.chebfuneps = relTol;
+        prefy.chebfuneps = relTol;
         % New GE:
         [pivotVal, pivotPos, rowVals, colVals, iFail] = ...
                                  completeACA(vals, absTol, factor);
@@ -116,7 +117,7 @@ while ( ~isHappy && ~failure )
     end
     
     % If the rank of the function is above maxRank then stop.
-    if ( grid > factor*(maxRank-1) + 1 )
+    if ( any(grid > factor*(maxRank-1) + 1) )
         warning('CHEBFUN:CHEBFUN2:constructor:rank', ...
             'Not a low-rank function.');
         failure = 1;
@@ -125,12 +126,12 @@ while ( ~isHappy && ~failure )
     % Check if the column and row slices are resolved.
     colData.hscale = norm(dom(3:4), inf);
     colData.vscale = vscale;
-    colTech = tech.make(sum(colVals,2), colData);
-    resolvedCols = happinessCheck(colTech, [], sum(colVals, 2), colData, pref);
+    colTech = techy.make(sum(colVals,2), colData);
+    resolvedCols = happinessCheck(colTech, [], sum(colVals, 2), colData, prefy);
     rowData.hscale = norm(dom(1:2), inf);
     rowData.vscale = vscale;
-    rowTech = tech.make(sum(rowVals.',2), rowData);
-    resolvedRows = happinessCheck(rowTech, [], sum(rowVals.', 2), rowData, pref);
+    rowTech = techx.make(sum(rowVals.',2), rowData);
+    resolvedRows = happinessCheck(rowTech, [], sum(rowVals.', 2), rowData, prefx);
     isHappy = resolvedRows & resolvedCols;
     
     % If the function is zero, set midpoint of domain as pivot location.
@@ -144,27 +145,27 @@ while ( ~isHappy && ~failure )
     
     %% %%% PHASE 2: %%%
     % Now resolve along the column and row slices:
-    n = grid;  m = grid;
+    n = grid(2);  m = grid(1);
     while ( ~isHappy && ~failure  )
         if ( ~resolvedCols )
             % Double sampling along columns
-            [n, nesting] = gridRefine( n , pref );
-            [xx, yy] = meshgrid(pivPos(:, 1), myPoints(n, dom(3:4), pref));
+            [n, nesting] = gridRefine( n , prefy );
+            [xx, yy] = meshgrid(pivPos(:, 1), myPoints(n, dom(3:4), prefy));
             colVals = evaluate(op, xx, yy, vectorize);
             % Find location of pivots on new grid (using nesting property).
             PP(:, 1) = nesting(PP(:, 1));
         else
-            [xx, yy] = meshgrid(pivPos(:, 1), myPoints(n, dom(3:4), pref));
+            [xx, yy] = meshgrid(pivPos(:, 1), myPoints(n, dom(3:4), prefy));
             colVals = evaluate(op, xx, yy, vectorize);
         end
         if ( ~resolvedRows )
-            [m, nesting] = gridRefine( m , pref );
-            [xx, yy] = meshgrid(myPoints(m, dom(1:2), pref), pivPos(:, 2));
+            [m, nesting] = gridRefine( m , prefx );
+            [xx, yy] = meshgrid(myPoints(m, dom(1:2), prefx), pivPos(:, 2));
             rowVals = evaluate(op, xx, yy, vectorize);
             % find location of pivots on new grid  (using nesting property).
             PP(:, 2) = nesting(PP(:, 2));
         else
-            [xx, yy] = meshgrid(myPoints(m, dom(1:2), pref), pivPos(:, 2));
+            [xx, yy] = meshgrid(myPoints(m, dom(1:2), prefx), pivPos(:, 2));
             rowVals = evaluate(op, xx, yy, vectorize);
         end
         
@@ -184,19 +185,21 @@ while ( ~isHappy && ~failure )
         
         % Are the columns and rows resolved now?
         if ( ~resolvedCols )
-            colTech = tech.make(sum(colVals,2));
-            resolvedCols = happinessCheck(colTech,[],sum(colVals,2), colData, pref);
+            colTech = techy.make(sum(colVals,2));
+            resolvedCols = happinessCheck(colTech,[],sum(colVals,2), colData, prefy);
         end
         if ( ~resolvedRows )
-            rowTech = tech.make(sum(rowVals.',2));
-            resolvedRows = happinessCheck(rowTech,[],sum(rowVals.',2), rowData, pref);
+            rowTech = techx.make(sum(rowVals.',2));
+            resolvedRows = happinessCheck(rowTech,[],sum(rowVals.',2), rowData, prefx);
         end
         isHappy = resolvedRows & resolvedCols;
-        
+
         % STOP if degree is over maxLength:
-        if ( max(m, n) >= maxSample )
+        sampleCheck = ( [m n] < maxSample );
+        if ( ~all(sampleCheck) )
+            k = find( ~sampleCheck );
             warning('CHEBFUN:CHEBFUN2:constructor:notResolved', ...
-                'Unresolved with maximum CHEBFUN length: %u.', maxSample);
+                'Unresolved with maximum CHEBFUN length: %u.', maxSample(k(1)));
             failure = 1;
         end
         
@@ -215,8 +218,8 @@ while ( ~isHappy && ~failure )
     
     % Construct a CHEBFUN2:
     g.pivotValues = pivotVal;
-    g.cols = chebfun(colVals,   dom(3:4), pref);
-    g.rows = chebfun(rowVals.', dom(1:2), pref );
+    g.cols = chebfun(colVals,   dom(3:4), prefy);
+    g.rows = chebfun(rowVals.', dom(1:2), prefx);
     g.pivotLocations = pivPos;
     g.domain = dom;
     
@@ -229,7 +232,8 @@ while ( ~isHappy && ~failure )
         pass = g.sampleTest(sampleOP, absTol, vectorize);
         if ( ~pass )
             % Increase minSamples and try again.
-            minSample = gridRefine(minSample, pref);
+            minSample = [gridRefine(minSample(1), prefx), ...
+                         gridRefine(minSample(2), prefy)];
             isHappy = 0;
         end
     end
@@ -237,7 +241,8 @@ while ( ~isHappy && ~failure )
 end
 
 % Simplifying rows and columns after they are happy.
-g = simplify( g, pref.chebfuneps );
+mineps = min(prefx.chebfuneps, prefy.chebfuneps);
+g = simplify( g, mineps );
 
 % Fix the rank, if in nonadaptive mode.
 g = fixTheRank( g , fixedRank );
@@ -246,11 +251,11 @@ end
 
 %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-function g = constructFromDouble(op, dom, pref, isEqui)
+function g = constructFromDouble(op, dom, prefx, prefy, isEqui, isTrig)
 
 g = chebfun2();
 
-if ( ~isEqui && (numel( op ) == 1) )
+if ( ~any(isEqui) && (numel( op ) == 1) )
     % LNT wants this:
     g = constructor(g, @(x,y) op + 0*x, dom);
     return
@@ -261,29 +266,39 @@ end
 % on the size of the sample matrix, hscale of domain, vscale of
 % the samples, condition number of the function, and the accuracy
 % target in chebfun2 preferences.
-if ( ~isEqui )
-    [xx, yy] = points2D(size(op,2), size(op,1), dom, pref);
+if ( ~isEqui(1) || isTrig(1) )
+    x = myPoints(size(op,2), dom(1:2), prefx);
 else
     x = linspace(dom(1), dom(2), size(op,2));
-    y = linspace(dom(3), dom(4), size(op,1));
-    [xx, yy] = meshgrid(x, y);
 end
-    
-[relTol, absTol] = getTol(xx, yy, op, dom, pref.cheb2Prefs.chebfun2eps);
-pref.chebfuneps = relTol;
+if ( ~isEqui(2) || isTrig(2) )
+    y = myPoints(size(op,1), dom(3:4), prefy);
+else
+    y = linspace(dom(3), dom(4), size(op,1));
+end
+[xx, yy] = meshgrid(x, y);
+
+mineps = min(prefx.cheb2Prefs.chebfun2eps, prefy.cheb2Prefs.chebfun2eps);
+[relTol, absTol] = getTol(xx, yy, op, dom, mineps);
+prefx.chebfuneps = relTol;
+prefy.chebfuneps = relTol;
 
 % Perform GE with complete pivoting:
 [pivotValue, ~, rowValues, colValues] = completeACA(op, absTol, 0);
 
 % Construct a CHEBFUN2:
 g.pivotValues = pivotValue;
-if ( ~isEqui )
-    g.cols = chebfun(colValues,   dom(3:4), pref);
-    g.rows = chebfun(rowValues.', dom(1:2), pref);
+if ( ~isEqui(1) || isTrig(1) )
+    g.rows = chebfun(rowValues.', dom(1:2), prefx);
 else
-    g.cols = chebfun(colValues,   dom(3:4), 'equi', pref);
-    g.rows = chebfun(rowValues.', dom(1:2), 'equi', pref);
+    g.rows = chebfun(rowValues.', dom(1:2), 'equi', prefx);
 end
+if ( ~isEqui(2) || isTrig(2) )
+    g.cols = chebfun(colValues,   dom(3:4), prefy);
+else
+    g.cols = chebfun(colValues,   dom(3:4), 'equi', prefy);
+end
+
 g.domain = dom;
 
 end
@@ -458,29 +473,41 @@ end
 
 %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-function [xx, yy] = points2D(m, n, dom, pref)
+function [xx, yy] = points2D(m, n, dom, prefx, prefy)
 % Get the sample points that correspond to the right grid for a particular
 % technology.
 
-% What tech am I based on?:
-tech = pref.tech();
+if ( nargin == 4 )
+    prefy = prefx;
+end
 
-if ( isa(tech, 'chebtech2') )
-    x = chebpts( m, dom(1:2), 2 );   % x grid.
-    y = chebpts( n, dom(3:4), 2 );
-    [xx, yy] = meshgrid( x, y );
-elseif ( isa(tech, 'chebtech1') )
-    x = chebpts( m, dom(1:2), 1 );   % x grid.
-    y = chebpts( n, dom(3:4), 1 );
-    [xx, yy] = meshgrid( x, y );
-elseif ( isa(tech, 'trigtech') )
-    x = trigpts( m, dom(1:2) );   % x grid.
-    y = trigpts( n, dom(3:4) );
-    [xx, yy] = meshgrid( x, y );
+% What tech am I based on?:
+techx = prefx.tech();
+techy = prefy.tech();
+
+if ( isa(techx, 'chebtech2') )
+    x = chebpts( m, dom(1:2), 2 );
+elseif ( isa(techx, 'chebtech1') )
+    x = chebpts( m, dom(1:2), 1 );
+elseif ( isa(techx, 'trigtech') )
+    x = trigpts( m, dom(1:2) );
 else
     error('CHEBFUN:CHEBFUN2:constructor:points2D:tecType', ...
         'Unrecognized technology');
 end
+
+if ( isa(techy, 'chebtech2') )
+    y = chebpts( n, dom(3:4), 2 );
+elseif ( isa(techy, 'chebtech1') )
+    y = chebpts( n, dom(3:4), 1 );
+elseif ( isa(techy, 'trigtech') )
+    y = trigpts( n, dom(3:4) );
+else
+    error('CHEBFUN:CHEBFUN2:constructor:points2D:tecType', ...
+        'Unrecognized technology');
+end
+
+[xx, yy] = meshgrid( x, y );
 
 end
 
@@ -566,7 +593,7 @@ end
 
 %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-function [op, dom, pref, isEqui, isTrig, fixedRank, vectorize] = parseInputs(op, varargin)
+function [op, dom, prefx, prefy, isEqui, isTrig, fixedRank, vectorize] = parseInputs(op, varargin)
 
 if ( isa(op, 'char') )     % CHEBFUN2( CHAR )
     op = str2op(op);
@@ -640,47 +667,65 @@ if ( any(isinf(dom) ) )
 end
 
 % Preferences structure given?
-isPref = find(cellfun(@(p) isa(p, 'chebfunpref'), varargin));
+isPref = cellfun(@(p) (iscell(p) && numel(p)<3 && any(cellfun(@(q) isa(q, 'chebfunpref'), p))) || ...
+    isa(p, 'chebfunpref'), varargin);
+prefx = chebfunpref();
+prefy = chebfunpref();
 if ( any(isPref) )
-    pref = varargin{isPref};
+    args = varargin(isPref);
     varargin(isPref) = [];
-else
-    pref = chebfunpref();
+    if ( iscell(args{end}) )
+        if ( isa(args{end}{1}, 'chebfunpref') ), prefx = args{end}{1}; end
+        if ( isa(args{end}{2}, 'chebfunpref') ), prefy = args{end}{2}; end
+    else
+        prefx = args{end};
+        prefy = args{end};
+    end
 end
 
-isEqui = find(cellfun(@(p) strcmpi(p, 'equi'), varargin));
-if ( isEqui )
+isEqui = cellfun(@(p) any(strcmpi(p, 'equi')) && ...
+    ~( iscell(p) && numel(p) > 2 ), varargin);
+if ( any(isEqui) )
+    args = varargin(isEqui);
     varargin(isEqui) = [];
-    isEqui = true;
+    isEqui = strcmpi(args{end}, 'equi');
+    isEqui = isEqui | [false false]; % Expand to be 1 x 2
 else
-    isEqui = false;
+    isEqui = [false false];
 end
 
-isTrig = find(cellfun(@(p) any(strcmpi(p, {'trig', 'periodic'})), varargin));
-if ( isTrig )
+isTrig = cellfun(@(p) any(strcmpi(p, 'trig') | strcmpi(p, 'periodic')) && ...
+    ~( iscell(p) && numel(p) > 2 ), varargin);
+if ( any(isTrig) )
+    args = varargin(isTrig);
     varargin(isTrig) = [];
-    pref.tech = @trigtech;
-elseif ( isa(pref.tech(), 'trigtech') )
+    isTrig = strcmpi(args{end}, 'trig') | strcmpi(args{end}, 'periodic');
+    isTrig = isTrig | [false false]; % Expand to be 1 x 2
+    if ( isTrig(1) ), prefx.tech = @trigtech; end
+    if ( isTrig(2) ), prefy.tech = @trigtech; end
+else
     % Even if the user didn't supply the 'trig' flag, we could still be doing a
     % periodic construction if the tech preference is 'trigtech'.
     %
     % TODO:  The only reason this is necessary is because of the adjustments we
     % have to make to minSample in the main construction routine above.  Can we
     % avoid this?
-    isTrig = true;
+    isTrig = [isa(prefx.tech(), 'trigtech'), ...
+              isa(prefy.tech(), 'trigtech')];
 end
 
-isEpsGiven = find(cellfun(@(p) strcmpi(p, 'eps'), varargin));
+isEpsGiven = find(cellfun(@(p) ~iscell(p) && strcmpi(p, 'eps'), varargin));
 if ( isEpsGiven )
     pseudoLevel = varargin{isEpsGiven+1};
     varargin(isEpsGiven+(0:1)) = [];
 else
     pseudoLevel = 0;
 end
-pref.cheb2Prefs.chebfun2eps = max(pref.cheb2Prefs.chebfun2eps, pseudoLevel);
+prefx.cheb2Prefs.chebfun2eps = max(prefx.cheb2Prefs.chebfun2eps, pseudoLevel);
+prefy.cheb2Prefs.chebfun2eps = max(prefy.cheb2Prefs.chebfun2eps, pseudoLevel);
 
 % Look for vectorize flag:
-vectorize = find(cellfun(@(p) strncmpi(p, 'vectori', 7), varargin));
+vectorize = find(cellfun(@(p) ~iscell(p) && strncmpi(p, 'vectori', 7), varargin));
 if ( vectorize )
     varargin(vectorize) = [];
     vectorize = true;
@@ -690,13 +735,14 @@ end
 
 % If the vectorize flag is off, do we need to give user a warning?
 if ( ~vectorize && ~isnumeric(op) ) % another check
-    [vectorize, op] = vectorCheck(op, dom, pref.chebfuneps);
+    mineps = min(prefx.chebfuneps, prefy.chebfuneps);
+    [vectorize, op] = vectorCheck(op, dom, mineps);
 end
 
 % Deal with fixed length construction CHEBFUN(OP,[M N])
 if ( fixedLength && ~isnumeric(op) )
-    x = myPoints(m, dom(1:2), pref);
-    y = myPoints(n, dom(3:4), pref);
+    x = myPoints(m, dom(1:2), prefx);
+    y = myPoints(n, dom(3:4), prefy);
     [xx, yy] = meshgrid(x,y);
     % Handle the special case of the input being a chebfun2.  We can't call
     % evaluate here because, we have to use feval(op,xx,yy).
@@ -707,22 +753,37 @@ if ( fixedLength && ~isnumeric(op) )
     end
 end
 
-isPadua = find(cellfun(@(p) strcmpi(p, 'padua'), varargin));
+isPadua = find(cellfun(@(p) ~iscell(p) && strcmpi(p, 'padua'), varargin));
 if ( isPadua )
     varargin(isPadua) = [];
     op = chebfun2.paduaVals2coeffs(op);
     op = chebfun2.coeffs2vals(op);
 end
 
-isCoeffs = find(cellfun(@(p) strcmpi(p, 'coeffs'), varargin));
-if ( isCoeffs )
-    if ( isTrig )
-        varargin(isCoeffs) = [];
-        op = trigtech.coeffs2vals(trigtech.coeffs2vals( op ).').'; 
-    else
-        varargin(isCoeffs) = [];
-        op = chebfun2.coeffs2vals(op);
+isCoeffs = cellfun(@(p) any(strcmpi(p, 'coeffs')) && ...
+    ~( iscell(p) && numel(p) > 2 ), varargin);
+if ( any(isCoeffs) )
+    args = varargin(isCoeffs);
+    varargin(isCoeffs) = [];
+    isCoeffs = strcmpi(args{end}, 'coeffs');
+    isCoeffs = isCoeffs | [false false]; % Expand to be 1x2
+
+    % Get the coeffs2vals transform corresponding to each tech
+    if ( ~( isa(prefx.tech(), 'chebtech2') || isa(prefy.tech(), 'chebtech2') || ...
+            isa(prefx.tech(), 'chebtech1') || isa(prefy.tech(), 'chebtech1') || ...
+            isa(prefx.tech(), 'trigtech')  || isa(prefy.tech(), 'trigtech') ) )
+        error('CHEBFUN:CHEBFUN2:constructor:parseInputs:techType', ...
+            'Unrecognized technology');
     end
+    transformX = @(x) x;
+    transformY = @(y) y;
+    if ( isCoeffs(1) )
+        transformX = str2func([func2str(prefx.tech) '.coeffs2vals']);
+    end
+    if ( isCoeffs(2) )
+        transformY = str2func([func2str(prefy.tech) '.coeffs2vals']);
+    end
+    op = transformX( transformY( op ).' ).';
 end
 
 end

--- a/@chebfun2/disp.m
+++ b/@chebfun2/disp.m
@@ -32,6 +32,10 @@ techRow = get(F.rows.funs{1}, 'tech');
 % Display the information: 
 if ( isa(techCol(), 'trigtech') && isa(techRow(), 'trigtech') )
     disp('   chebfun2 object  (trig)')
+elseif ( isa(techRow(), 'trigtech') )
+    disp('   chebfun2 object  (trig in x)')
+elseif ( isa(techCol(), 'trigtech') )
+    disp('   chebfun2 object  (trig in y)')
 else
     disp('   chebfun2 object')
 end

--- a/tests/chebfun2/test_mixed_tech.m
+++ b/tests/chebfun2/test_mixed_tech.m
@@ -13,16 +13,14 @@ pass = [];
 % Construct from function handle
 u = @(x,y) sin(2*pi*x).*cos(2*pi*y);
 
-f1 = chebfun2(u, {'trig', []});
-f2 = chebfun2(u, {[], 'periodic'});
-f3 = chebfun2(u, {'periodic', 'trig'});
-f4 = chebfun2(u, 'trig');
-f5 = chebfun2(u);
+f1 = chebfun2(u, 'trigx');
+f2 = chebfun2(u, 'periodicy');
+f3 = chebfun2(u, 'trig');
+f4 = chebfun2(u);
 
 pass(end+1) = ( norm(f1 - f2) < tol );
 pass(end+1) = ( norm(f2 - f3) < tol );
 pass(end+1) = ( norm(f3 - f4) < tol );
-pass(end+1) = ( norm(f4 - f5) < tol );
 
 % Construct from data
 m = 31;
@@ -31,16 +29,14 @@ u = @(x,y) sin(2*pi*x).*cos(2*pi*y);
 [xc, yc] = chebpts2(n, m);
 [xt, yt] = meshgrid(trigpts(n), trigpts(m));
 
-f1 = chebfun2(u(xt,yc), {'trig', []});
-f2 = chebfun2(u(xc,yt), {[], 'periodic'});
-f3 = chebfun2(u(xt,yt), {'periodic', 'trig'});
-f4 = chebfun2(u(xt,yt), 'trig');
-f5 = chebfun2(u(xc,yc));
+f1 = chebfun2(u(xt,yc), 'trigx');
+f2 = chebfun2(u(xc,yt), 'periodicy');
+f3 = chebfun2(u(xt,yt), 'trig');
+f4 = chebfun2(u(xc,yc));
 
 pass(end+1) = ( norm(f1 - f2) < tol );
 pass(end+1) = ( norm(f2 - f3) < tol );
 pass(end+1) = ( norm(f3 - f4) < tol );
-pass(end+1) = ( norm(f4 - f5) < tol );
 
 %% 'equi' in one or both dimensions
 m = 31;
@@ -49,16 +45,14 @@ u = @(x,y) sin(x.*y);
 [xc, yc] = chebpts2(n, m);
 [xe, ye] = meshgrid(linspace(-1,1,n), linspace(-1,1,m));
 
-f1 = chebfun2(u(xe,yc), {'equi', []});
-f2 = chebfun2(u(xc,ye), {[], 'equi'});
-f3 = chebfun2(u(xe,ye), {'equi', 'equi'});
-f4 = chebfun2(u(xe,ye), 'equi');
-f5 = chebfun2(u(xc,yc));
+f1 = chebfun2(u(xe,yc), 'equix');
+f2 = chebfun2(u(xc,ye), 'equiy');
+f3 = chebfun2(u(xe,ye), 'equi');
+f4 = chebfun2(u(xc,yc));
 
 pass(end+1) = ( norm(f1 - f2) < tol );
 pass(end+1) = ( norm(f2 - f3) < tol );
 pass(end+1) = ( norm(f3 - f4) < tol );
-pass(end+1) = ( norm(f4 - f5) < tol );
 
 %% 'coeffs' in one or both dimensions
 m = 31;
@@ -72,15 +66,13 @@ coeffs_vals   = chebtech2.vals2coeffs( vals_vals.' ).';
 coeffs_coeffs = chebtech2.vals2coeffs( vals_coeffs.' ).';
 
 f1 = chebfun2(u);
-f2 = chebfun2(coeffs_vals, {'coeffs', []});
-f3 = chebfun2(vals_coeffs, {[], 'coeffs'});
-f4 = chebfun2(coeffs_coeffs, {'coeffs', 'coeffs'});
-f5 = chebfun2(coeffs_coeffs, 'coeffs');
+f2 = chebfun2(coeffs_vals, 'coeffsx');
+f3 = chebfun2(vals_coeffs, 'coeffsy');
+f4 = chebfun2(coeffs_coeffs, 'coeffs');
 
 pass(end+1) = ( norm(f1 - f2) < tol );
 pass(end+1) = ( norm(f2 - f3) < tol );
 pass(end+1) = ( norm(f3 - f4) < tol );
-pass(end+1) = ( norm(f4 - f5) < tol );
 
 %% 'trig' and 'coeffs' in one or both dimensions
 m = 31;
@@ -99,11 +91,11 @@ trigcoeffs_chebcoeffs =  trigtech.vals2coeffs( trigvals_chebcoeffs.' ).';
 chebvals_trigcoeffs   =  trigtech.vals2coeffs( chebvals_trigvals     );
 
 f1 = chebfun2(u);
-f2 = chebfun2(trigcoeffs_chebvals, {'coeffs', []}, {'trig', ''});
-f3 = chebfun2(trigvals_chebcoeffs, {'', 'coeffs'}, {'trig', ''});
-f4 = chebfun2(trigcoeffs_chebcoeffs, 'coeffs', {'trig', []});
-f5 = chebfun2(trigcoeffs_trigvals, 'trig', {'coeffs', ''});
-f6 = chebfun2(chebvals_trigcoeffs, {[], 'trig'}, {[], 'coeffs'});
+f2 = chebfun2(trigcoeffs_chebvals, 'coeffsx', 'trigx');
+f3 = chebfun2(trigvals_chebcoeffs, 'coeffsy', 'trigx');
+f4 = chebfun2(trigcoeffs_chebcoeffs, 'coeffs', 'trigx');
+f5 = chebfun2(trigcoeffs_trigvals, 'trig', 'coeffsx');
+f6 = chebfun2(chebvals_trigcoeffs, 'trigy', 'coeffsy');
 
 pass(end+1) = ( norm(f1 - f2) < tol );
 pass(end+1) = ( norm(f2 - f3) < tol );
@@ -128,8 +120,8 @@ g = chebfun2(@(x,y) sin(2*pi*x).*sin(2*pi*y));
 pass(end+1) = ( norm(f - g) < tol );
 
 %% The last argument takes precedence
-f = chebfun2(@(x,y) sin(2*pi*x).*y, 'trig', {'trig', ''});
-g = chebfun2(@(x,y) sin(2*pi*x).*y, {'trig', []});
+f = chebfun2(@(x,y) sin(2*pi*x).*y, 'trig', 'trigx');
+g = chebfun2(@(x,y) sin(2*pi*x).*y, 'trigx');
 pass(end+1) = ( norm(f - g) < tol );
 
 m = 31;
@@ -137,7 +129,7 @@ n = 32;
 u = @(x,y) sin(x.*y);
 [xx, yy] = meshgrid(linspace(-1,1,n), linspace(-1,1,m));
 uu = u(xx,yy);
-f = chebfun2(uu, {'equi', []}, 'equi');
+f = chebfun2(uu, 'equix', 'equi');
 g = chebfun2(uu, 'equi');
 pass(end+1) = ( norm(f - g) < tol );
 

--- a/tests/chebfun2/test_mixed_tech.m
+++ b/tests/chebfun2/test_mixed_tech.m
@@ -1,0 +1,150 @@
+function pass = test_mixed_tech( pref )
+% This tests the chebfun2 constructor for mixed technology.
+
+if ( nargin < 1 )
+    pref = chebfunpref;
+end
+tol = 1e2 * pref.cheb2Prefs.chebfun2eps;
+
+pass = [];
+
+%% 'trig' in one or both dimensions
+
+% Construct from function handle
+u = @(x,y) sin(2*pi*x).*cos(2*pi*y);
+
+f1 = chebfun2(u, {'trig', []});
+f2 = chebfun2(u, {[], 'periodic'});
+f3 = chebfun2(u, {'periodic', 'trig'});
+f4 = chebfun2(u, 'trig');
+f5 = chebfun2(u);
+
+pass(end+1) = ( norm(f1 - f2) < tol );
+pass(end+1) = ( norm(f2 - f3) < tol );
+pass(end+1) = ( norm(f3 - f4) < tol );
+pass(end+1) = ( norm(f4 - f5) < tol );
+
+% Construct from data
+m = 31;
+n = 32;
+u = @(x,y) sin(2*pi*x).*cos(2*pi*y);
+[xc, yc] = chebpts2(n, m);
+[xt, yt] = meshgrid(trigpts(n), trigpts(m));
+
+f1 = chebfun2(u(xt,yc), {'trig', []});
+f2 = chebfun2(u(xc,yt), {[], 'periodic'});
+f3 = chebfun2(u(xt,yt), {'periodic', 'trig'});
+f4 = chebfun2(u(xt,yt), 'trig');
+f5 = chebfun2(u(xc,yc));
+
+pass(end+1) = ( norm(f1 - f2) < tol );
+pass(end+1) = ( norm(f2 - f3) < tol );
+pass(end+1) = ( norm(f3 - f4) < tol );
+pass(end+1) = ( norm(f4 - f5) < tol );
+
+%% 'equi' in one or both dimensions
+m = 31;
+n = 32;
+u = @(x,y) sin(x.*y);
+[xc, yc] = chebpts2(n, m);
+[xe, ye] = meshgrid(linspace(-1,1,n), linspace(-1,1,m));
+
+f1 = chebfun2(u(xe,yc), {'equi', []});
+f2 = chebfun2(u(xc,ye), {[], 'equi'});
+f3 = chebfun2(u(xe,ye), {'equi', 'equi'});
+f4 = chebfun2(u(xe,ye), 'equi');
+f5 = chebfun2(u(xc,yc));
+
+pass(end+1) = ( norm(f1 - f2) < tol );
+pass(end+1) = ( norm(f2 - f3) < tol );
+pass(end+1) = ( norm(f3 - f4) < tol );
+pass(end+1) = ( norm(f4 - f5) < tol );
+
+%% 'coeffs' in one or both dimensions
+m = 31;
+n = 32;
+u = @(x,y) sin(x.*y);
+[xc, yc] = chebpts2(n, m);
+
+vals_vals     = u(xc,yc);
+vals_coeffs   = chebtech2.vals2coeffs( vals_vals );
+coeffs_vals   = chebtech2.vals2coeffs( vals_vals.' ).';
+coeffs_coeffs = chebtech2.vals2coeffs( vals_coeffs.' ).';
+
+f1 = chebfun2(u);
+f2 = chebfun2(coeffs_vals, {'coeffs', []});
+f3 = chebfun2(vals_coeffs, {[], 'coeffs'});
+f4 = chebfun2(coeffs_coeffs, {'coeffs', 'coeffs'});
+f5 = chebfun2(coeffs_coeffs, 'coeffs');
+
+pass(end+1) = ( norm(f1 - f2) < tol );
+pass(end+1) = ( norm(f2 - f3) < tol );
+pass(end+1) = ( norm(f3 - f4) < tol );
+pass(end+1) = ( norm(f4 - f5) < tol );
+
+%% 'trig' and 'coeffs' in one or both dimensions
+m = 31;
+n = 32;
+u = @(x,y) sin(2*pi*x).*cos(2*pi*y);
+[xc, yc] = chebpts2(n, m);
+[xt, yt] = meshgrid(trigpts(n), trigpts(m));
+
+trigvals_chebvals     = u(xt,yc);
+chebvals_trigvals     = u(xc,yt);
+trigvals_trigvals     = u(xt,yt);
+trigvals_chebcoeffs   = chebtech2.vals2coeffs( trigvals_chebvals     );
+trigcoeffs_trigvals   =  trigtech.vals2coeffs( trigvals_trigvals.'   ).';
+trigcoeffs_chebvals   =  trigtech.vals2coeffs( trigvals_chebvals.'   ).';
+trigcoeffs_chebcoeffs =  trigtech.vals2coeffs( trigvals_chebcoeffs.' ).';
+chebvals_trigcoeffs   =  trigtech.vals2coeffs( chebvals_trigvals     );
+
+f1 = chebfun2(u);
+f2 = chebfun2(trigcoeffs_chebvals, {'coeffs', []}, {'trig', ''});
+f3 = chebfun2(trigvals_chebcoeffs, {'', 'coeffs'}, {'trig', ''});
+f4 = chebfun2(trigcoeffs_chebcoeffs, 'coeffs', {'trig', []});
+f5 = chebfun2(trigcoeffs_trigvals, 'trig', {'coeffs', ''});
+f6 = chebfun2(chebvals_trigcoeffs, {[], 'trig'}, {[], 'coeffs'});
+
+pass(end+1) = ( norm(f1 - f2) < tol );
+pass(end+1) = ( norm(f2 - f3) < tol );
+pass(end+1) = ( norm(f3 - f4) < tol );
+pass(end+1) = ( norm(f4 - f5) < tol );
+pass(end+1) = ( norm(f5 - f6) < tol );
+
+%% Preferences in one or both dimensions
+p = pref;
+p.tech = @trigtech;
+
+f = chebfun2(@(x,y) sin(2*pi*x).*y, {p, []});
+g = chebfun2(@(x,y) sin(2*pi*x).*y);
+pass(end+1) = ( norm(f - g) < tol );
+
+f = chebfun2(@(x,y) sin(2*pi*y).*x, {[], p});
+g = chebfun2(@(x,y) sin(2*pi*y).*x);
+pass(end+1) = ( norm(f - g) < tol );
+
+f = chebfun2(@(x,y) sin(2*pi*x).*sin(2*pi*y), {p, p});
+g = chebfun2(@(x,y) sin(2*pi*x).*sin(2*pi*y));
+pass(end+1) = ( norm(f - g) < tol );
+
+%% The last argument takes precedence
+f = chebfun2(@(x,y) sin(2*pi*x).*y, 'trig', {'trig', ''});
+g = chebfun2(@(x,y) sin(2*pi*x).*y, {'trig', []});
+pass(end+1) = ( norm(f - g) < tol );
+
+m = 31;
+n = 32;
+u = @(x,y) sin(x.*y);
+[xx, yy] = meshgrid(linspace(-1,1,n), linspace(-1,1,m));
+uu = u(xx,yy);
+f = chebfun2(uu, {'equi', []}, 'equi');
+g = chebfun2(uu, 'equi');
+pass(end+1) = ( norm(f - g) < tol );
+
+prefx = pref;
+prefx.tech = @trigtech;
+f = chebfun2(@(x,y) x, {prefx, []}, pref);
+g = chebfun2(@(x,y) x, pref);
+pass(end+1) = ( norm(f - g) < tol );
+
+end

--- a/tests/chebfun2/test_trig.m
+++ b/tests/chebfun2/test_trig.m
@@ -45,4 +45,10 @@ C = C0; C(2,1) = .5; C(2,3) = .5;
 f = chebfun2(C,'trig','coeffs');
 pass(11) = norm( f - cos(pi*x) ) < tol;
 
+f = chebfun2(@(x,y) sin(2*pi*x),   'trig');
+g = chebfun2(@(x,y) cos(2*pi*x)+2, 'trig');
+pass(12) = isPeriodicTech( f+1 );
+pass(13) = isPeriodicTech( f.^2 );
+pass(14) = isPeriodicTech( f./g );
+
 end


### PR DESCRIPTION
Fix for `chebfun2` losing `'trig'` on various operations:
```
f = chebfun2(@(x,y) sin(2*pi*x), 'trig')
g = chebfun2(@(x,y) cos(2*pi*x)+2, 'trig')
f + 1 % is not 'trig'
f.^1  % is not 'trig'
f.^2  % is not 'trig'
f./g  % is not 'trig'
```
Closes #2329.