### PR TITLE
Fix for chebfun2 losing 'trig'

### DIFF
--- a/@chebfun2/compose.m
+++ b/@chebfun2/compose.m
@@ -84,6 +84,19 @@ elseif ( ( nargin == 3 ) && ( nargin(op) == 2 ) )
     % OP has two input variables.
     
     g = varargin{1};
+
+    % OP(f,g) should be periodic if:
+    %  - f and g are periodic
+    %  - f is periodic, g is scalar
+    %  - f is scalar, g is periodic
+    pref = chebfunpref;
+    if ( (isa(f, 'chebfun2') && isPeriodicTech(f) && ...
+          isa(g, 'chebfun2') && isPeriodicTech(g))                || ...
+         (isa(f, 'chebfun2') && isPeriodicTech(f) && isscalar(g)) || ...
+         (isscalar(f) && isa(g, 'chebfun2') && isPeriodicTech(g)) )
+        pref.tech = @trigtech;
+    end
+
     if ( isa(g, 'double') )     % promote
         g = chebfun2(g, f.domain);
     end
@@ -93,7 +106,7 @@ elseif ( ( nargin == 3 ) && ( nargin(op) == 2 ) )
     end
     
     % Call constructor:
-    f = chebfun2(@(x,y) op(feval(f, x, y), feval(g, x, y)), f.domain);
+    f = chebfun2(@(x,y) op(feval(f, x, y), feval(g, x, y)), f.domain, pref);
     
 else
     % Not sure what to do, error:

--- a/tests/chebfun2/test_trig.m
+++ b/tests/chebfun2/test_trig.m
@@ -45,4 +45,10 @@ C = C0; C(2,1) = .5; C(2,3) = .5;
 f = chebfun2(C,'trig','coeffs');
 pass(11) = norm( f - cos(pi*x) ) < tol;
 
+f = chebfun2(@(x,y) sin(2*pi*x),   'trig');
+g = chebfun2(@(x,y) cos(2*pi*x)+2, 'trig');
+pass(12) = isPeriodicTech( f+1 );
+pass(13) = isPeriodicTech( f.^2 );
+pass(14) = isPeriodicTech( f./g );
+
 end


### PR DESCRIPTION
Fix for `chebfun2` losing `'trig'` on various operations:
```
f = chebfun2(@(x,y) sin(2*pi*x), 'trig')
g = chebfun2(@(x,y) cos(2*pi*x)+2, 'trig')
f + 1 % is not 'trig'
f.^2  % is not 'trig'
f./g  % is not 'trig'
```
Closes #2329.