### PR TITLE
AAA-Lawson updates

### DIFF
--- a/aaa.m
+++ b/aaa.m
@@ -166,7 +166,7 @@ end
 % successful when the errors are close to machine precision.
 
 wj0 = wj; fj0 = fj;     % Save parameters in case Lawson fails
-wt_new = ones(M,1);
+wt = NaN(M,1); wt_new = ones(M,1);
 if ( nlawson > 0 )      % Lawson iteration
 
     maxerrold = maxerrAAA;

--- a/tests/chebfun/test_aaa.m
+++ b/tests/chebfun/test_aaa.m
@@ -1,11 +1,11 @@
 function pass = test_aaa(pref)
-% Test for aaa().
+% Test for aaa().  Many new tests added August 2019.
 
 % Get preferences.
 if ( nargin < 1 )
     pref = chebtech.techPref();
 end
-tol = 1e+4 * pref.chebfuneps;
+tol = 1e4*pref.chebfuneps;
 
 warning('off', 'CHEBFUN:aaa:Froissart');
 
@@ -21,7 +21,6 @@ pass(4) = ( length(zj) == m1 - 1 );
 [r, ~, ~, ~, zj] = aaa(F, Z, 'tol', 1e-3);
 pass(5) = ( length(zj) < m1 );
 
-
 %
 Z = linspace(-1, 1, 1000);
 F = @(z) tan(pi*z);
@@ -30,7 +29,6 @@ pass(6) = ( norm(F(Z) - r(Z), inf) < 10*tol );
 pass(7) = ( min(abs(zer)) < tol );
 pass(8) = ( min(abs(pol - 0.5)) < tol );
 pass(9) = ( min(abs(res)) > 1e-13 );        % Test for spurious poles.
-
 
 % Case |Z| = 2: needs special treatment.
 Z = [0, 1];
@@ -85,6 +83,31 @@ pass(19) = abs(res(ii)-1) < 1e-10;
 ii = find(abs(pol-(-1))<1e-8);
 pass(20) = abs(res(ii)+(1+1i)) < 1e-10;
 
+% Make sure Lawson matches minimax:
+x = chebfun('x'); f = exp(x);
+xx = linspace(-1,1);
+[p,q,r] = minimax(f,3,3); err_minimax = norm(f(xx) - r(xx),inf);
+r = aaa(f,'mmax',4); err_aaa = norm(f(xx) - r(xx),inf);
+pass(21) = (err_aaa/err_minimax < 1.1);
+
+% Make sure Lawson bails out if unsuccessful because of machine precision
+xx = linspace(-1,1);
+r = aaa(@tanh,Z); err1 = norm(tanh(xx) - r(xx),inf);
+r = aaa(@tanh,Z,'mmax',40); err2 = norm(tanh(xx) - r(xx),inf);
+pass(22) = abs(err2/err1 - 1) < 1.01; 
+
+% Make sure Lawson bails out if unsuccessful because of symmetry
+Z = exp(2i*pi*(1:500)'/500); F = log(2-Z.^4); n = 15;
+r = aaa(F,Z,'mmax',n+1,'lawson',0); err1 = norm(F - r(Z),inf);
+r = aaa(F,Z,'mmax',n+1); err2 = norm(F - r(Z),inf);
+pass(23) = abs(err2/err1 - 1) < 1.01; 
+
+% Make sure Lawson bails out if unsuccessful because of troublesome poles
+Za = chebpts(1000,[-3 -1]); Zb = chebpts(1000,[1,3]); Z = [Za; Zb];
+F = [sign(Za); sign(Zb)]; n = 12; 
+r = aaa(F,Z,'mmax',n+1,'lawson',0); err1 = norm(F - r(Z),inf);
+r = aaa(F,Z,'mmax',n+1); err2 = norm(F - r(Z),inf);
+pass(24) = abs(err2/err1 - 1) < 1.01; 
 
 
 warning('on', 'CHEBFUN:aaa:Froissart');

--- a/tests/chebfun/test_aaa.m
+++ b/tests/chebfun/test_aaa.m
@@ -92,8 +92,8 @@ pass(21) = (err_aaa/err_minimax < 1.1);
 
 % Make sure Lawson bails out if unsuccessful because of machine precision
 xx = linspace(-1,1);
-r = aaa(@tanh,Z); err1 = norm(tanh(xx) - r(xx),inf);
-r = aaa(@tanh,Z,'mmax',40); err2 = norm(tanh(xx) - r(xx),inf);
+r = aaa(@tanh,xx); err1 = norm(tanh(xx) - r(xx),inf);
+r = aaa(@tanh,xx,'mmax',40); err2 = norm(tanh(xx) - r(xx),inf);
 pass(22) = abs(err2/err1 - 1) < 1.01; 
 
 % Make sure Lawson bails out if unsuccessful because of symmetry


### PR DESCRIPTION
In 2018 @abigopal and I put the Lawson iteration into `aaa` as an undocumented feature.  Now we are moving towards making it more robust and adaptive and documented.  In this initial step, the main changes are these: (1) rewritten help text, (2) including rows in the IRLS matrix corresponding to the support points, rather than omitting such rows from the matrix, and (3) automatically invoking Lawson if `'mmax'` is specified and `'lawson'` is not.  Thus if you execute the following code, for example, `aaa` will now automatically try to get you the type (5,5) minimax approximation:
```
X = linspace(-1,1,1000);  F = exp(X);  r = aaa(F, X, 'mmax', 6);  plot(X, F-r(X)), grid on
```

So far, our "adaptivity" consists of just taking 10 Lawson steps!  The next step is to improve this, and also write test codes.  @nakatsukasayuji has agreed to review this.

Note that with this PR, the action of the `aaa` code changes when `'mmax'` is specified (and `'lawson'` is not); to run AAA with prescribed `mmax` but no Lawson steps one would now have to specify `'lawson',0`.  We suspect that there are few users at this stage likely to be affected, and in any case the approximations they get will usually be better.