### PR TITLE
Make normal vector unit length when 'unit' is given

### DIFF
--- a/@chebfun/normal.m
+++ b/@chebfun/normal.m
@@ -15,12 +15,11 @@ n = -1i*diff(c);
 
 if ( nargin > 1 ) 
     if ( strcmpi(unit, 'unit') )
-        nrmn = norm(n);
-        if ( nrmn == 0 )
-            error('CHEBFUN:CHEBFUN:normal:zero', 'Normal vector is zero.'); 
-        else
-            n = n./nrmn;
+        r = roots( n );
+        if ( ( ~isempty(r) ) || ( norm(n) == 0 ) )
+            error('CHEBFUN:CHEBFUN:normal:zero', 'Normal vector is zero.');
         end
+        n = n ./ abs(n);
     else
         error('CHEBFUN:CHEBFUN:normal:args', ...
             'Second argument is not recognised.');

--- a/tests/chebfun/test_normal.m
+++ b/tests/chebfun/test_normal.m
@@ -1,0 +1,19 @@
+function pass = test_normal( pref )
+% Test normal vector to complex chebfuns.
+
+if ( nargin == 0 )
+    pref = chebfunpref;
+end
+
+tol = pref.chebfuneps;
+
+%% #2268
+g = chebfun(@(t) 0.3*cos(t) + 1i*sin(t), [0, 2*pi]);
+ntrue = -1i*diff(g);
+ntrue = ntrue ./ abs(ntrue);
+ntrue = [real(ntrue), imag(ntrue)];
+n = normal(g, 'unit');
+
+pass(1) = ( norm(n - ntrue) < tol );
+
+end


### PR DESCRIPTION
The normal vector to a complex `chebfun` given by `normal(f, 'unit')` is now actually unit length. This fixes #2268.
```
>> g = chebfun(@(t) 0.3*cos(t) + 1i*sin(t), [0, 2*pi]);
>> ntrue = -1i*diff(g); ntrue = ntrue./abs(ntrue); ntrue = [real(ntrue), imag(ntrue)];
>> n = normal(g, 'unit');
>> norm(n - ntrue)

ans =

     0
```