### PR TITLE
feature-padeapprox-radius

### DIFF
--- a/padeapprox.m
+++ b/padeapprox.m
@@ -1,4 +1,4 @@
-function [r, a, b, mu, nu, poles, residues] = padeapprox(f, m, n, opts)
+function [r, a, b, mu, nu, poles, residues] = padeapprox(f, m, n, tol, r, N)
 %PADEAPPROX   Pade approximation to a function or Taylor series.
 %   [R, A, B, MU, NU, POLES, RESIDUES] = PADEAPPROX(F, M, N, TOL) constructs a
 %   Pade approximant to F using the robust algorithm from [1] based on the SVD.
@@ -12,10 +12,10 @@ function [r, a, b, mu, nu, poles, residues] = padeapprox(f, m, n, opts)
 %   Pade approximant to F with coefficient vectors A and B and, optionally, the
 %   POLES and RESIDUES.
 %
-%   PADEAPPROX(F, M, N, OPTS), where OPTS is a struct containing fields .tol,
-%   .r, and .N, is similar, but allows changing the radius (r) and number of
-%   roots of unity (N) used when F is a function handle to compute approximate
-%   Taylor coefficients via FFT. Default values are r = 1, N = 2048.
+%   PADEAPPROX(F, M, N, TOL, R, N) allows changing the radius R and number of
+%   roots of unity N used when F is a function handle to compute approximate
+%   Taylor coefficients via FFT. Empty values are set to the defaults, which are
+%   TOL = 1e-14, R = 1, and N = 2048.
 %
 %   This code is included in the Chebfun distribution for the convenience of
 %   readers of _Approximation Theory and Approximation Practice_, but it is not
@@ -31,24 +31,15 @@ function [r, a, b, mu, nu, poles, residues] = padeapprox(f, m, n, opts)
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-% Parse inputs:
-tol = []; r = []; N = [];
-if ( nargin == 4 )
-    if ( isnumeric(opts) )
-        tol = opts;
-    elseif ( isstruct(opts) )
-        if ( isfield(opts, 'tol') ), tol = opts.tol; end
-        if ( isfield(opts, 'r') ),   r = opts.r;     end
-        if ( isfield(opts, 'N') ),   N = opts.N;     end
-    end
-end
-% Default values:
-if ( isempty(tol) ), tol = 1e-14; end
-if ( isempty(r) ),   r = 1;       end
-if ( isempty(N) ),   N = 2048;    end
+% Default to relative tolerance of 1e-14.
+if ( nargin < 4 || isempty(tol) ), tol = 1e-14; end
 
 % Compute coefficients if necessary.
 if ( ~isnumeric(f) )
+    % Default radius and evaluation points if not specified:
+    if ( nargin < 5 || isempty(r) ),   r = 1;       end
+    if ( nargin < 6 || isempty(N) ),   N = 2048;    end
+    
     % Sample at many (scaled) roots of unity and use FFT to get coeffs.
     z = r*exp(2i*pi*(0:N-1)'/N);
     f = fft(f(z))/N;

--- a/padeapprox.m
+++ b/padeapprox.m
@@ -2,29 +2,30 @@ function [r, a, b, mu, nu, poles, residues] = padeapprox(f, m, n, tol, r, N)
 %PADEAPPROX   Pade approximation to a function or Taylor series.
 %   [R, A, B, MU, NU, POLES, RESIDUES] = PADEAPPROX(F, M, N, TOL) constructs a
 %   Pade approximant to F using the robust algorithm from [1] based on the SVD.
-%   F must be a function handle or a vector of coefficients f_0, ..., f_{m + n},
-%   and if F is a function handle, the function must be analytic in a
-%   neighborhood of the unit disc, since the coefficients are computed via FFT.
-%   M and N are the desired numerator and denominator degrees, respectively, and
-%   must be nonnegative. The optional TOL argument specifies the relative
-%   tolerance; if omitted, it defaults to 1e-14. Set TOL to 0 to turn off
-%   robustness. The output is a function handle R of for an exact type (MU, NU)
-%   Pade approximant to F with coefficient vectors A and B and, optionally, the
-%   POLES and RESIDUES.
+%   F must be a function handle or a vector of coefficients f_0, ..., f_K with
+%   K >= M+N, and if F is a function handle, the function must be analytic by
+%   default in a neighborhood of the unit disc, since the coefficients are
+%   computed via FFT; alternatively one can adjust the radius for this
+%   computation as inidcated below.  M and N are the desired numerator and
+%   denominator degrees, respectively, and must be nonnegative.  The optional
+%   TOL argument specifies the relative tolerance; if omitted, it defaults to
+%   1e-14.  Set TOL to 0 to turn off robustness.  The output is a function
+%   handle R for an exact type (MU, NU) Pade approximant to F with coefficient
+%   vectors A and B and, optionally, the POLES and RESIDUES.
 %
 %   PADEAPPROX(F, M, N, TOL, R, N) allows changing the radius R and number of
-%   roots of unity N used when F is a function handle to compute approximate
-%   Taylor coefficients via FFT. Empty values are set to the defaults, which are
+%   roots of unity N used when F is a function handle to compute Taylor 
+%   coefficients via FFT.  Empty values are set to the defaults, which are
 %   TOL = 1e-14, R = 1, and N = 2048.
 %
 %   This code is included in the Chebfun distribution for the convenience of
-%   readers of _Approximation Theory and Approximation Practice_, but it is not
-%   actually a Chebfun code. A Chebfun analogue is CHEBPADE.
+%   readers of _Approximation Theory and Approximation Practice_, though it
+%   does not involve chebfuns.  A Chebfun analogue is CHEBPADE.
 %
 %   References:
 %
-%   [1] P. Gonnet, S. Guettel, and L. N. Trefethen, "ROBUST PADE APPROXIMATION 
-%       VIA SVD", SIAM Rev., 55:101-117, 2013.
+%   [1] P. Gonnet, S. Guettel, and L. N. Trefethen, "Robust Pade approximation 
+%       via SVD", SIAM Rev., 55:101-117, 2013.
 %
 % See also AAA, CF, CHEBPADE, MINIMAX, RATINTERP.
 

--- a/tests/misc/test_padeapprox.m
+++ b/tests/misc/test_padeapprox.m
@@ -14,8 +14,7 @@ c = [1 1i];
 pass(2) = (abs(a-1) < 1e-10) && (abs(b(2)-(-1i)) < tol); 
 
 f = @(x) x./(1-x);
-opts = struct('tol', 1e-10, 'r', 0.5);
-[r, a, b, mu, nu, poles, residues] = padeapprox(f, 5, 6, opts);
+[r, a, b, mu, nu, poles, residues] = padeapprox(f, 5, 6, [], 0.5);
 pass(3) = (mu == 1) && (nu == 1) && norm(a-[0;1])<tol && ...
     norm(b-[1;-1])<tol && abs(poles-1)<tol && abs(residues+1)<tol;
 

--- a/tests/misc/test_padeapprox.m
+++ b/tests/misc/test_padeapprox.m
@@ -2,13 +2,22 @@
 
 function pass = test_padeapprox(pref)
 
+tol = 1e-10;
+
 f = @(x) (x.^4 - 3)./((x + 3.2).*(x - 2.2));
 [r, a, b, mu, nu, poles, residues] = padeapprox(f, 10, 10);
 pass(1) = (mu == 4) && (nu == 2) && ...
-    (max(abs(sort(poles) - [-3.2 ; 2.2])) < 1e-10);
+    (max(abs(sort(poles) - [-3.2 ; 2.2])) < tol);
 
 c = [1 1i];
 [r, a, b] = padeapprox(c, 0, 1);
-pass(2) = (abs(a-1) < 1e-10) && (abs(b(2)-(-1i)) < 1e-10); 
+pass(2) = (abs(a-1) < 1e-10) && (abs(b(2)-(-1i)) < tol); 
+
+f = @(x) x./(1-x);
+opts = struct('tol', 1e-10, 'r', 0.5);
+[r, a, b, mu, nu, poles, residues] = padeapprox(f, 5, 6, opts);
+pass(3) = (mu == 1) && (nu == 1) && norm(a-[0;1])<tol && ...
+    norm(b-[1;-1])<tol && abs(poles-1)<tol && abs(residues+1)<tol;
+
 
 end


### PR DESCRIPTION
Add option to pass radius when computing coeffs in padeapprox. (Implemented at request of JAC Weideman.)

Allows the easy construction of Pade' approximants of, for example, f = x/(1-x). This was not previously possible as one could not change the radius of the complex valued sampled used to compute the Taylor coefficients of f. (Of course, one could get around this by constructing the coefficients manually.) Now it works directly:

```
[r, a, b, mu, nu, poles] = padeapprox(@(x) x./(1-x), 5, 5, struct('r', 0.5))
>> [r, a, b, mu, nu, poles] = padeapprox(@(x) x./(1-x), 5, 5, struct('r', 0.5))
r =
  function_handle with value:
    @(z)polyval(a(end:-1:1),z)./polyval(b(end:-1:1),z)
a =
     0
     1
b =
   1.000000000000000
  -1.000000000000000
mu =
     1
nu =
     1
poles =
   1.000000000000000
```

Note, I decided to go with passing the structure rather than additional parameters as (a) this seems to be the direction MATLAB is moving (see most of the optimisation routines and ODE solvers) and (b) I think it's tidier this way as it avoids including empty input values.

