### PR TITLE
feature-singmaps

### DIFF
--- a/@bndfun/bndfun.m
+++ b/@bndfun/bndfun.m
@@ -93,10 +93,18 @@ classdef bndfun < classicfun
             data.hscale = data.hscale / diff(data.domain);
 
             % Remap the OP to be a function on [-1, 1].
-            linmap = bndfun.createMap(data.domain);
-            if ( isa(op, 'function_handle') && ~all(data.domain == [-1, 1]) ...
-                    && ~isnumeric(op) )
-                op = @(x) op(linmap.For(x));
+            if ( isfield(data, 'map') )
+                map = data.map;
+                if ( isa(map, 'function_handle') )
+                    map = map(data.domain);   
+                end
+                trivialMap = false;
+            else
+                map = bndfun.createMap(data.domain);
+                trivialMap = all(data.domain == [-1, 1]);
+            end
+            if ( isa(op, 'function_handle') && ~trivialMap && ~isnumeric(op) )
+                op = @(x) op(map.For(x));
             end
 
             % Call the ONEFUN constructor:
@@ -104,8 +112,9 @@ classdef bndfun < classicfun
 
             % Add the domain and mapping:
             obj.domain = data.domain;
-            obj.mapping = linmap;
+            obj.mapping = map;
         end
+        
     end       
 
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/@bndfun/changeMap.m
+++ b/@bndfun/changeMap.m
@@ -8,7 +8,11 @@ function f = changeMap(f, newdom)
 % See http://www.chebfun.org/ for Chebfun information.
 
 % Assign a new linear map to f, obtained from the BNDFUN.CREATEMAP() method:
-f.mapping = mapping.linear(newdom);
+if ( islinear(f.mapping) )
+    f.mapping = mapping.linear(newdom);
+else
+    f.mapping = singularMapping.singmap(newdom, f.mapping.params);
+end
 
 % Assign the new endpoints of f to the domain property:
 f.domain = newdom;

--- a/@bndfun/cumsum.m
+++ b/@bndfun/cumsum.m
@@ -25,9 +25,16 @@ end
 
 if ( dim == 1 )
     
-    % Integrate once to see if a cell is returned:
-    g = cumsum(f.onefun);
-
+    if ( islinear(f.mapping) )
+        % Integrate once to see if a cell is returned:
+        g = cumsum(f.onefun);
+    else
+        % TODO: Comment what is going on (change of variables).
+        m = f.mapping;
+        mp = diff(bndfun(m.For));
+        f.mapping = mapping.linear([-1,1]);
+        g = cumsum(f.*mp);
+    end
     
     if ( iscell(g) )
         

--- a/@bndfun/cumsum.m
+++ b/@bndfun/cumsum.m
@@ -31,7 +31,8 @@ if ( dim == 1 )
     else
         % TODO: Comment what is going on (change of variables).
         m = f.mapping;
-        mp = diff(bndfun(m.For));
+%         mp = diff(bndfun(m.For));
+        mp = bndfun(m.Der);
         f.mapping = mapping.linear([-1,1]);
         g = cumsum(f.*mp);
     end

--- a/@bndfun/cumsum.m
+++ b/@bndfun/cumsum.m
@@ -35,6 +35,7 @@ if ( dim == 1 )
         mp = bndfun(m.Der);
         f.mapping = mapping.linear([-1,1]);
         g = cumsum(f.*mp);
+        g.mapping = m;
     end
     
     if ( iscell(g) )

--- a/@bndfun/diff.m
+++ b/@bndfun/diff.m
@@ -23,14 +23,17 @@ if ( nargin < 3 )
     dim = 1;
 end
 
-% Rescaling factor, (b-a)/2, to the kth power
-rescaleFactork = (.5*diff(f.domain))^k;
-
 % Assign the ONEFUN of the output to be the output of the DIFF method of the
 % ONEFUN of the input. If we called DIFF with third argument equal to 2 (i.e.
 % dim = 2), we only wanted to compute difference between columns, in which case,
 % we should not rescale the result.
 if ( dim == 1 )
+    if ( ~islinear(f.mapping) ) 
+       error('CHEBFUN:BNDFUN:diff:mapping', ...
+           'diff is not yet implemented for nonlinear mappings.'); % TODO.
+    end
+    % Rescaling factor, (b-a)/2, to the kth power
+    rescaleFactork = (.5*diff(f.domain))^k;
     f.onefun = diff(f.onefun, k, dim)/rescaleFactork;
 else
     f.onefun = diff(f.onefun, k, dim);

--- a/@bndfun/restrict.m
+++ b/@bndfun/restrict.m
@@ -42,6 +42,10 @@ if ( (numel(s) == 2) && all( s == f.domain) )
     return
 end
 
+if ( ~islinear(f.mapping) )
+    error('Restrict not yet implemented for nonlinear mappings.');
+end
+
 % Compute the breaks in [-1,1] space and restrict the onefun:
 t = f.mapping.Inv(s);
 

--- a/@bndfun/sum.m
+++ b/@bndfun/sum.m
@@ -27,7 +27,16 @@ end
 % Rescaling factor, (b - a)/2
 rescaleFactor = 0.5*diff(f.domain);
 
-% Assign the output to be the sum of the onefun of the input, rescaled.
-out = sum(f.onefun)*rescaleFactor;
+if ( islinear(f.mapping) )
+    % Assign the output to be the sum of the onefun of the input, rescaled.
+    out = sum(f.onefun)*rescaleFactor;
+else
+    % TODO: Comment what is going on (change of variables).
+    m = f.mapping;
+    mp = diff(bndfun(m.For));
+    f.mapping = mapping.linear([-1,1]);
+    f.domain = [-1,1];
+    out = sum(f.*mp);
+end
 
 end

--- a/@bndfun/sum.m
+++ b/@bndfun/sum.m
@@ -33,7 +33,8 @@ if ( islinear(f.mapping) )
 else
     % TODO: Comment what is going on (change of variables).
     m = f.mapping;
-    mp = diff(bndfun(m.For));
+%     mp = diff(bndfun(m.For));
+    mp = bndfun(m.Der);
     f.mapping = mapping.linear([-1,1]);
     f.domain = [-1,1];
     out = sum(f.*mp);

--- a/@chebfun/chebfun.m
+++ b/@chebfun/chebfun.m
@@ -640,6 +640,14 @@ function [op, dom, data, pref, flags] = parseInputs(op, varargin)
             % Store exponents.
             data.exponents = args{2};
             args(1:2) = [];
+        elseif ( strcmpi(args{1}, 'map') )
+            % Store map types.
+            data.map = args{2};
+            args(1:2) = [];     
+        elseif ( strcmpi(args{1}, 'singmap') )
+            % Store map types.
+            data.map = @(dom) singularMapping.singmap(dom, args{2});
+            args(1:2) = [];            
         elseif ( any(strcmpi(args{1}, 'chebkind')) )
             % Translate "chebkind" and "kind" --> "tech.@chebtech".
             if ( (isnumeric(args{2}) && (args{2} == 1)) || ...

--- a/@chebfun/disp.m
+++ b/@chebfun/disp.m
@@ -90,7 +90,7 @@ for j = 1:numFuns
         end
 
         % Print information to screen:
-        s = [s, sprintf('[%8.2g,%8.2g]   %6i  %8.2g %8.2g %s\n', ...
+        s = [s, sprintf('[%8.2g,%8.2g]   %6i  %8.2g %8.2g  %s\n', ...
             f.domain(j), f.domain(j+1), len(j), endvals, extraData{j})];
 
     end

--- a/@chebfun/dispData.m
+++ b/@chebfun/dispData.m
@@ -26,8 +26,8 @@ data = cell(j,1);
 
 % Loop through each fun, look for duplicate names. Insert space if no duplicates.
 for j = 1:numFuns
-    if ( isempty(info{j}) ), continue, end
     for k = 1:numel(info{j})
+        if ( ~isfield(info{j}(k), 'name')), continue, end
         namejk = info{j}(k).name;
         datajk = info{j}(k).data;
         name = [name, namejk];

--- a/@chebfun/dispData.m
+++ b/@chebfun/dispData.m
@@ -13,21 +13,11 @@ numFuns = numel(f.funs);
 
 %% Collect information about the exponents:
 
-% Preallocation:
-exps = zeros(numFuns, 2);
-
 % Loop over each FUN:
 for j = 1:numFuns
-    infoJ = dispData(f.funs{j});
-    if ( ~isempty(infoJ) )
-        numInfo = numel(infoJ);
-        for k = 1:numInfo
-            infoJK = infoJ{k};
-            if ( strcmpi('exponents', infoJK.name) )
-                exps(j,:) = infoJK.data;
-            end
-        end
-    end
+    tmp = dispData(f.funs{j});
+    if  ( ~isempty(tmp) ), tmp = [tmp{:}]; end
+    info{j} = tmp;
 end
 
 %% Organize the output which will be passed to DISPLAY:
@@ -35,18 +25,41 @@ end
 % Preallocate the extra information:
 name = ' ';
 data = cell(j,1);
-    
-% So far, the only extra information is exponents:
-if ( any( exps(:) ) )
-    name = '  endpoint exponents';
-    for j = 1:numFuns
-        data{j} = ['        ' '[' num2str(exps(j,1), '%2.2g') '      ' ...
-            num2str(exps(j,2), '%2.2g') ']' '  '];
+
+% Loop through each fun, look for duplicate names. Insert space if no duplicates.
+for j = 1:numFuns
+    if ( isempty(info{j}) ), continue, end
+    for k = 1:numel(info{j})
+        namejk = info{j}(k).name;
+        datajk = info{j}(k).data;
+        name = [name, namejk];
+        z = repmat(' ', size(datajk))
+        for l = 1:(j-1)
+            data{l,1} = [data{l,1}, z];
+        end
+        data{j,1} = [data{j,1}, datajk];
+        for l = (j+1):numFuns
+            isz = true;
+            if ( ~isempty(info{l}) )
+                for m = 1:numel(info{l})
+                    if ( strcmp(namejk, info{l}(m).name) )
+                        data{l,1} = [data{l,1}, info{l}(m).data];
+                        isz = false;
+                        info{l}(m) = [];
+                        break
+                    end
+                end
+            end
+            isz
+            if ( isz )
+                data{l,1} = [data{l,1}, z];
+            end
+        end
     end
-elseif ( ~isempty(infoJ) )
-    name = infoJ{1}.name;
 end
 
-% More information for F can be appended to INFO:
+data
+
+% More information for F can be appended to DATA:
 
 end

--- a/@chebfun/dispData.m
+++ b/@chebfun/dispData.m
@@ -15,9 +15,7 @@ numFuns = numel(f.funs);
 
 % Loop over each FUN:
 for j = 1:numFuns
-    tmp = dispData(f.funs{j});
-    if  ( ~isempty(tmp) ), tmp = [tmp{:}]; end
-    info{j} = tmp;
+    info{j} = dispData(f.funs{j});
 end
 
 %% Organize the output which will be passed to DISPLAY:
@@ -33,7 +31,7 @@ for j = 1:numFuns
         namejk = info{j}(k).name;
         datajk = info{j}(k).data;
         name = [name, namejk];
-        z = repmat(' ', size(datajk))
+        z = repmat(' ', size(datajk));
         for l = 1:(j-1)
             data{l,1} = [data{l,1}, z];
         end
@@ -50,15 +48,12 @@ for j = 1:numFuns
                     end
                 end
             end
-            isz
             if ( isz )
                 data{l,1} = [data{l,1}, z];
             end
         end
     end
 end
-
-data
 
 % More information for F can be appended to DATA:
 

--- a/@chebtech/dispData.m
+++ b/@chebtech/dispData.m
@@ -1,12 +1,11 @@
 function data = dispData(f)
 %DISPDATA   Useful information for DISPLAY at higher levels.
 %   DATA = DISPDATA(F) extracts useful information from the given CHEBTECH F and
-%   the information DATA will be used by DISPLAY at higher levels. Currently, 
-%   the only information it extracts is exponents.
+%   the information DATA will be used by DISPLAY at higher levels. 
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-data = [];
+data = struct;
 
 end

--- a/@classicfun/dispData.m
+++ b/@classicfun/dispData.m
@@ -8,6 +8,13 @@ function data = dispData(f)
 
 data = dispData(f.onefun);
 
+if ( isa(f.mapping, 'singularMapping') )
+    data{1}(end+1).name = '  singmap params ';
+    params = f.mapping.params;
+    data{1}(end).data = ['  [' num2str(params(1), '%2.2g,') '     ' ...
+            num2str(params(2), '%2.2g') ']  '];
+end
+
 % More information for F can be appended to DATA:
 
 end

--- a/@classicfun/dispData.m
+++ b/@classicfun/dispData.m
@@ -9,9 +9,9 @@ function data = dispData(f)
 data = dispData(f.onefun);
 
 if ( isa(f.mapping, 'singularMapping') )
-    data{1}(end+1).name = '  singmap params ';
+    data(end+1).name = ' singmap params ';
     params = f.mapping.params;
-    data{1}(end).data = ['  [' num2str(params(1), '%2.2g,') '     ' ...
+    data(end).data = ['  [' num2str(params(1), '%2.2g,') '     ' ...
             num2str(params(2), '%2.2g') ']  '];
 end
 

--- a/@classicfun/mat2cell.m
+++ b/@classicfun/mat2cell.m
@@ -47,14 +47,10 @@ end
 % Call MAT2CELL of the ONEFUN:
 oneFuns = mat2cell(f.onefun, M, N);
 
-% Create a cell for storing the new CLASSICFUN objects:
-g = cell(1, numel(N));
-
-% Append the data to the new entries in the cell:
-for k = 1:numel(N)
-    % Create a new CLASSICFUN from the ONEFUN and the domain:
-    data.domain = f.domain;
-    g{k} = f.make(oneFuns{k}, data);
+% Copy the CLASSICFUN N times and replace the onefuns:
+g = repmat({f}, 1, N(1));
+for k = 1:N
+    g{k}.onefun = oneFuns{k};
 end
 
 end

--- a/@classicfun/plus.m
+++ b/@classicfun/plus.m
@@ -34,9 +34,14 @@ else % CLASSICFUN + CLASSICFUN
     
     % Domains and mappings are assumed to match. Hence, we just need to add the
     % ONEFUNs:
-    f.onefun = f.onefun + g.onefun;
+    
+    if ( isequal(f.mapping, g.mapping) )
+        f.onefun = f.onefun + g.onefun;
+    else
+        error('CHEBFUN:CLASSICFUN:plus:mappings', ...
+        'Cannot add bndfuns with different mappings.')
+    end
       
 end
 
 end
-

--- a/@classicfun/times.m
+++ b/@classicfun/times.m
@@ -29,10 +29,15 @@ elseif ( ~isa(f, 'classicfun') )       % double * CLASSICFUN
     % Swap arguments for output variable:
     f = g;
     
-elseif ( isa(g, 'classicfun'))         % CLASSICFUN * CLASSICFUN
+elseif ( isa(g, 'classicfun') )        % CLASSICFUN * CLASSICFUN
     
-    % Multiply the ONEFUN objects of f and g together.
-    f.onefun = times(f.onefun, g.onefun, varargin{:});
+    if ( isequal(f.mapping, g.mapping) )
+        % Multiply the ONEFUN objects of f and g together.
+        f.onefun = times(f.onefun, g.onefun, varargin{:});
+    else
+        error('CHEBFUN:CLASSICFUN:times:mappings', ...
+        'Cannot multiply bndfuns with different mappings.')
+    end
     
 elseif ( isa(g, 'double') )     % CLASSICFUN * double
     

--- a/@mapping/mapping.m
+++ b/@mapping/mapping.m
@@ -111,6 +111,23 @@ classdef mapping
 %                 out = subsref(out, index(2:end));
 %             end
 %         end
+
+        function out = isequal(f, g)
+        %ISEQUAL  Check to see if two mappings are equal.
+            % Trivial mappings will be equal if their domain is the same.
+            dom = [-1 1];
+            fdom = f.For(dom);
+            gdom = g.For(dom);
+            % Assign infinite numbers to some pseudo-random number:
+            fdom(isinf(fdom)) = 0.794349011;
+            gdom(isinf(gdom)) = 0.794349011;
+            tol = 1e-13;
+            out = norm(fdom - gdom, inf)./norm([fdom, gdom]) < tol;
+        end
+        
+        function out = islinear(f)
+            out = all(isfinite(f.For([-1,1])));
+        end  
         
     end
     

--- a/@singfun/dispData.m
+++ b/@singfun/dispData.m
@@ -7,8 +7,13 @@ function data = dispData(f)
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-data{1}.name = 'exponents';
-data{1}.data = f.exponents;
+% data{1}.name = 'exponents';
+% data{1}.data = f.exponents;
+
+data{1}.name = '  endpoint exponents';
+exps = f.exponents;
+data{1}.data = ['        ' '[' num2str(exps(1), '%2.2g') '      ' ...
+            num2str(exps(2), '%2.2g') ']' '   '];
 
 % More information can be appended to DATA:
 

--- a/@singfun/dispData.m
+++ b/@singfun/dispData.m
@@ -7,12 +7,9 @@ function data = dispData(f)
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-% data{1}.name = 'exponents';
-% data{1}.data = f.exponents;
-
-data{1}.name = '  endpoint exponents';
+data.name = '  endpoint exponents';
 exps = f.exponents;
-data{1}.data = ['        ' '[' num2str(exps(1), '%2.2g') '      ' ...
+data.data = ['        ' '[' num2str(exps(1), '%2.2g') '      ' ...
             num2str(exps(2), '%2.2g') ']' '   '];
 
 % More information can be appended to DATA:

--- a/@singularMapping/singularMapping.m
+++ b/@singularMapping/singularMapping.m
@@ -106,7 +106,7 @@ classdef singularMapping < mapping
                     end
             end
             
-            m = singularMapping(For, Inv, Der, pow);
+            m = singularMapping(For, Der, Inv, pow);
             
         end
         

--- a/@singularMapping/singularMapping.m
+++ b/@singularMapping/singularMapping.m
@@ -106,6 +106,8 @@ classdef singularMapping < mapping
                     end
             end
             
+            pow(pow == 1) = 0;
+            
             m = singularMapping(For, Der, Inv, pow);
             
         end

--- a/@singularMapping/singularMapping.m
+++ b/@singularMapping/singularMapping.m
@@ -1,0 +1,116 @@
+classdef singularMapping < mapping
+%TODO: Document    
+    
+    %% %%%%%%%%%%%%%%%%%%%%%%%%%%%  PROPERTIES  %%%%%%%%%%%%%%%%%%%%%%%%%%%
+    
+    properties ( GetAccess = 'public', SetAccess = 'public' )
+        
+        % Parameters:
+        params
+        
+    end
+    
+    %% %%%%%%%%%%%%%%%%%%%%%%%%%%%  METHODS  %%%%%%%%%%%%%%%%%%%%%%%%%%%
+    
+    methods
+        
+        function obj = singularMapping(For, Der, Inv, params)
+            
+            obj@mapping(For, Der, Inv);
+            obj.params = params;
+            
+        end
+        
+        function out = isequal(f,g)
+            
+            if ( ~isa(f, 'singularMapping') || ~isa(g, 'singularMapping') )
+                out = false;
+            elseif ( all(f.params == g.params) )
+                out = true;
+            else
+                out = false;
+            end
+            
+        end
+        
+        function out = islinear(f)
+            out = false;
+        end  
+        
+    end
+    
+    %% %%%%%%%%%%%%%%%%%%%%%%%%%%%  STATIC METHODS  %%%%%%%%%%%%%%%%%%%%%%%%%%%
+    
+    methods ( Static = true )
+        
+        function m = singmap(ends, pow)
+            % TODO: Document (taken from chebfun v4)
+            
+            default_pow = .25;
+            if ( nargin == 1 )
+                pow = [default_pow, default_pow];
+            end
+            
+            pow(~pow) = 1;
+            
+            pos = 0;
+            for k = 1:2
+                if ( pow(k)~=1 && pow(k)~=0 )
+                    pos = pos+(-1)^k;
+                elseif ( isnan(pow(k)) )
+                    pow(k) = default_pow;
+                end
+            end
+            
+            L = mapping.linear(ends);
+            
+            % The map is linear
+            if ( ~pos && all(pow == 1) )
+                m = L;
+                return
+            end
+            
+            % Can only do .25 powers at boths ends (or maybe .5?)
+            if ( ~pos && (~all(pow==.25) && ~all(pow==.5)) )
+                pow = [.25, .25];
+                warning('FUN:sing:bothends',['Singmaps at boths ends may only have ', ...
+                    'parameters 0.25 or 0.5']);
+                
+            end
+            
+            powi = 1./pow;
+            
+            switch pos
+                
+                case -1 % Left point singularity
+                    powi = powi(1);
+                    For = @(y) L.For( 2*( .5*(y+1) ).^powi - 1 );
+                    %         m.der = @(y) L.Der(1) * 2 * powi * ( .5*(y+1) ).^(powi-1);
+                    Inv = @(x) 2*( .5*(L.Inv(x)+1) ).^pow(1) - 1;
+                    Der = @(y) L.Der(1) * 1 * powi * ( .5*(y+1) ).^(powi-1);
+                case 1 % Right point singularity
+                    powi = powi(2);
+                    For = @(y) L.For( 1 - 2*( .5*(1-y) ).^powi);
+                    %         m.der = @(y) -L.Der(1) * 2 * powi * ( .5*(1-y) ).^(powi-1);
+                    Inv = @(x) 1 - 2*( .5*(1-L.Inv(x)) ).^pow(2);
+                    Der = @(y) L.Der(1) * 1 * powi * ( .5*(1-y) ).^(powi-1);
+                case 0 % Both points sigularities
+                    if ( all(pow(1) == .5) )
+                        For = @(y) L.For(sin(pi/2*y));
+                        Inv = @(x) 2/pi*asin(L.Inv(x));
+                        Der = @(y) L.Der(1)*(pi/2)*cos(pi/2*y);
+                    else
+                        For = @(y) L.For(sin(pi/2*sin(pi/2*y)));
+                        Inv = @(x) 2/pi*asin(2/pi*asin(L.Inv(x)));
+                        Der = @(y) L.Der(1)*(1/4)*cos((1/2)*pi*sin((1/2)*pi*y)).*pi^2.*cos((1/2)*pi*y);
+                    end
+            end
+            
+            m = singularMapping(For, Inv, Der, pow);
+            
+        end
+        
+        
+    end
+    
+end

--- a/@trigtech/dispData.m
+++ b/@trigtech/dispData.m
@@ -6,7 +6,7 @@ function data = dispData(f)
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-data{1}.name = 'tech';
-data{1}.data = 'trig';
+data.name = 'tech';
+data.data = 'trig';
 
 end

--- a/@trigtech/dispData.m
+++ b/@trigtech/dispData.m
@@ -6,7 +6,7 @@ function data = dispData(f)
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-data{1}.name = 'trig';
-data{1}.data = [];
+data{1}.name = 'tech';
+data{1}.data = 'trig';
 
 end

--- a/tests/chebfun/test_singmap.m
+++ b/tests/chebfun/test_singmap.m
@@ -1,8 +1,8 @@
-% function pass = test_singmap(pref)
+function pass = test_singmap(pref)
 
-% if ( nargin == 0 )
-%     pref = chebfunpref();
-% end
+if ( nargin == 0 )
+    pref = chebfunpref();
+end
 
 tol = 1e-13;
 
@@ -57,6 +57,4 @@ pass(10) = norm(ff(x) - f(x), inf) < 100*tol && norm(ff(x+1) - f(x), inf) < 100*
 r = 0.114360282839375;
 pass(11) = abs(roots(fcheb-5) - r) < tol;
 
-% end
-
-pass
+end

--- a/tests/chebfun/test_singmap.m
+++ b/tests/chebfun/test_singmap.m
@@ -1,0 +1,62 @@
+% function pass = test_singmap(pref)
+
+% if ( nargin == 0 )
+%     pref = chebfunpref();
+% end
+
+tol = 1e-13;
+
+%% Test 1
+
+f = @(x) exp(1+sqrt(1+x));
+fcheb = chebfun(f, [-1 1], 'singmap', [.5, 0]);
+F = @(x) 2*exp(1 + sqrt(1 + x)).*(-1 + sqrt(1 + x));
+F = @(x) F(x) - F(-1);
+
+x = linspace(-.9, .9);
+% Test length:
+pass(1) = length(f) < 100;
+% Test accuracy:
+pass(2) = norm(f(x) - fcheb(x), inf) < tol;
+% Test sum:
+pass(3) = abs(sum(fcheb) - F(1)) < tol;
+% Test cumsum:
+Fcheb = cumsum(fcheb);
+pass(4) = norm(F(x) - Fcheb(x), inf) < tol;
+
+% Test join:
+ff = join(fcheb,fcheb);
+pass(5) = norm(ff(x) - f(x), inf) < tol && norm(ff(x+2) - f(x), inf) < tol;
+
+% Test roots:
+% opts = optimset('tolx', eps, 'tolfun', eps); 
+% r = fzero(@(x) f(x) - 5, 0, opts);
+r = -0.628585430887966;
+pass(6) = abs(roots(fcheb-5) - r) < tol;
+
+%% Test 2
+
+f = @(x) exp(x)+cos(x)./sqrt(x) + sqrt(1-x);
+fcheb = chebfun(f, [0, 1], 'singmap', [.5, .5], 'exps', [-1 0]);
+x = linspace(.1, .9);
+% Test length:
+pass(7) = length(f) < 100;
+% Test accuracy:
+pass(8) = norm(f(x) - fcheb(x), inf) < 100*tol;
+% Test sum:
+F1 = 4.1939969709262560649765; % Wolfram Alpha
+pass(9) = abs(sum(fcheb) - F1) < 100*tol;
+
+% Test join:
+ff = join(fcheb,fcheb);
+pass(10) = norm(ff(x) - f(x), inf) < 100*tol && norm(ff(x+1) - f(x), inf) < 100*tol;
+
+% Test roots:
+% opts = optimset('tolx', eps, 'tolfun', eps); 
+% r = fzero(@(x) f(x) - 5, .2, opts);
+r = 0.114360282839375;
+pass(11) = abs(roots(fcheb-5) - r) < tol;
+
+% end
+
+pass


### PR DESCRIPTION
See discussion in #1530. (Summary: reintroduce some basic mappings to deal with endpoint singularities)

Creating a pull request (a) to start discussion, (b) since this is fairly light in terms of code and impact elsewhere whilst still allowing some cool stuff (see below), (c) I don't intend to add much more functionality.

```
% Because why not:
>> y = chebfun(@(x) real(sqrt(cos(x)).*cos(200*x)+sqrt(abs(x))-0.7).*(4.2-x.^2).^0.01, [-2 -pi/2 0 pi/2 2], 'singmap', [.5 .5])
>> plot(y); axis equal

y =
   chebfun column (4 smooth pieces)
       interval       length     endpoint values   singmap params 
[      -2,    -1.6]       22       0.7     0.56    [0.5,     0.5]  
[    -1.6,       0]      329      0.56      0.3    [0.5,     0.5]  
[       0,     1.6]      329       0.3     0.56    [0.5,     0.5]  
[     1.6,       2]       22      0.56      0.7    [0.5,     0.5]  
vertical scale = 1.6    Total length = 702
```

![image](https://user-images.githubusercontent.com/2035010/63696097-43942d00-c81a-11e9-9111-cbb27e9b5edf.png)
See also: https://www.chebfun.org/examples/fun/ValentinesDay.html