### PR TITLE
fix-gmres

### DIFF
--- a/@chebop/gmres.m
+++ b/@chebop/gmres.m
@@ -111,7 +111,7 @@ end
 
 % Data mine L for faster "mat-vec" computations in the CG iteration:
 % Uses a non-divergence form
-x = chebfun( @(x) x );
+x = chebfun(@(x) x, dom);
 c = L(x, 1+0*x); 
 bminusa = L(x, x) - c.*x;
 a = -L(x, x.^2/2) + bminusa.*x + c.*x.^2/2;

--- a/tests/chebop/test_gmres.m
+++ b/tests/chebop/test_gmres.m
@@ -1,21 +1,22 @@
 function pass = test_gmres(pref) 
 % Test operator GMRES method. 
-
+%%
 % Tolerance: 
 if ( nargin == 0 )
     pref = cheboppref;
 end
 tol = 1e2*pref.bvpTol;
 
-%% Example 1: (-u_xx=f, bc=0, sum(f)==0)
+%% Example 1: (-u_xx=f, bc=0, sum(f)==0, 0<x<1)
+dom = [0 1];
 a = @(x) 1;
 c = @(x) 1;
 L = @(x,u) -diff(a(x).*diff(u)) + c(x).*u;
 
 % Chebop solve:
-N = chebop( L );
+N = chebop( L, dom );
 N.bc = 0; 
-f = chebfun(@(x) 1-3*x.^2);
+f = chebfun(@(x) 1-3*x.^2, dom);
 
 u = N\f;
 


### PR DESCRIPTION
Fix support for arbitrary domains in `chebop/gmres`, , as pointed out by Kirk Soodhalter:
```
x_cheb = chebfun('x_cheb',[0 1]);
L_cheb = chebop( @(u) diff(u, 2)  + u, [0,1], 0);
f_cheb = chebfun(1-x_cheb,[0 1]);
[u_cheb,flag,relres,iter,resvec] = gmres(L_cheb,f_cheb);
```
yields the following error output
```
Error using chebfun/overlap (line 15)
Inconsistent domains; domain(f) ~= domain(g).
Error in  +  (line 101)
        [f, g] = overlap(f, g);
Error in  -  (line 11)
f = plus(f, uminus(g));
Error in chebop/gmres (line 211)
    g = Pi( R2f - R2( L(z) ) );
Error in test_gmres (line 24)
v = gmres(N, f);
```

Implemented the proposed fix and modified the test to include an example on [0, 1].