### PR TITLE
fix-chebtech-abstract-compose

### DIFF
--- a/@chebtech/chebtech.m
+++ b/@chebtech/chebtech.m
@@ -75,9 +75,6 @@ classdef chebtech < smoothfun % (Abstract)
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     methods ( Access = public, Static = false, Abstract = true )
 
-        % Compose method. (Not implemented here as refinement is defined also).
-        h = compose(f, op, g, data, pref)
-
         % Get method.
         val = get(f, prop);
 


### PR DESCRIPTION
When running Chebfun in MATLAB 2019b I get the following warning:
```Warning: In the 'chebtech' class, the 'compose' method has both the Abstract attribute and a function body. ```

I think the solution is simply to remove the declaration of `compose` as an abstract method in `@chebtech`, as implemented in this pull request. Although `compose` is implemented in `@chebtech1` and `@chebtech2` these are not *required* as the `@chebtech` method provides the necessary functionality. Therefore `compose` should not be abstract.
