### PR TITLE
Fix diskfun roots

### DIFF
--- a/@diskfun/roots.m
+++ b/@diskfun/roots.m
@@ -27,7 +27,7 @@ end
 
 % convert f to a polar chebfun2
 f = varargin{1};
-f = cart2pol(f, 'cdr');
+f = cart2pol(f);
 
 %check for a second diskfun
 if ( nargin > 1 )
@@ -36,7 +36,7 @@ if ( nargin > 1 )
         dom = [-pi pi 0 1];
         % we require f and g to be chebfuns. Cart2pol isn't enough because
         % it keeps the rows represented in the Fourier basis.
-        f = chebfun2(@(t,r) feval(f, t, r), dom);
+        f = chebfun2(@(t,r) feval(f, t, r, 'polar'), dom);
         g = chebfun2(@(t,r) feval(g, t, r, 'polar'), dom); 
         r = roots@separableApprox(f,g, varargin{3:end});
         
@@ -51,17 +51,24 @@ rts = roots@separableApprox(f, varargin{2:end});
 
 % Now make into a collection of array-valued chebfuns ready for plotting on
 % the disk. 
-x = chebpts(max(length(rts),17)+1);
 
-vals = feval(rts, x);
-r = cell(size(vals,2), 1);
+%convert from polar coords to complex-valued chebfuns: 
+x = chebpts(max(length(rts),101));
 
+r = feval(rts,x);
+rvals = imag(r).*exp(1i*real(r)); %c = re^(i*x)
+
+r = chebfun(rvals);
+
+% This code, like spherefun, 
+% creates a real-valued parametrization of the curves. 
+%
 % Go through each component and make it an array-valued chebfun: 
-for k = 1:size(vals, 2)
-    comp = feval(rts(:, k), x); 
-    AX = imag(comp) .* cos(real(comp)); 
-    AY = imag(comp) .* sin(real(comp));
-    r{k} = chebfun([AX, AY ]);
-end
+% for k = 1:size(vals, 2)
+%     comp = feval(rts(:, k), x); 
+%     AX = imag(comp) .* cos(real(comp)); 
+%     AY = imag(comp) .* sin(real(comp));
+%     r{k} = chebfun([AX, AY ]);
+% end
 
 end

--- a/@diskfun/roots.m
+++ b/@diskfun/roots.m
@@ -36,21 +36,21 @@ if ( nargin > 1 )
         dom = [-pi pi 0 1];
         % we require f and g to be chebfuns. Cart2pol isn't enough because
         % it keeps the rows represented in the Fourier basis.
-        f = chebfun2(@(t,r) feval(f, t, r, 'polar'), dom);
+        f = chebfun2(@(t,r) feval(f, t, r), dom);
         g = chebfun2(@(t,r) feval(g, t, r, 'polar'), dom); 
         r = roots@separableApprox(f,g, varargin{3:end});
         
         %convert to cartesian
-        [x,y] = pol2cart(r(:,1),r(:,2));
-        r = [x,y];
+        if ~isempty(r)
+            [x,y] = pol2cart(r(:,1),r(:,2));
+            r = [x,y];
+        end
         return
     end
 end
 
 rts = roots@separableApprox(f, varargin{2:end});
 
-% Now make into a collection of array-valued chebfuns ready for plotting on
-% the disk. 
 
 %convert from polar coords to complex-valued chebfuns: 
 x = chebpts(max(length(rts),101));
@@ -60,8 +60,7 @@ rvals = imag(r).*exp(1i*real(r)); %c = re^(i*x)
 
 r = chebfun(rvals);
 
-% This code, like spherefun, 
-% creates a real-valued parametrization of the curves. 
+% The code below creates a real-valued parametrization of the curves. 
 %
 % Go through each component and make it an array-valued chebfun: 
 % for k = 1:size(vals, 2)

--- a/tests/diskfun/test_roots.m
+++ b/tests/diskfun/test_roots.m
@@ -29,13 +29,24 @@ end
 % Zero contour at  x.^2+y.^2=.5^2
 f = diskfun(@(t,r) r.^2-.5^2, 'polar');
 r = roots(f);
-% First component of roots should be cos(pi*lam) (or its negative).
-r1true = chebfun(@(t) .5*cos(pi*t));
-pass(3) = ( ( norm(r{1}(:,1)-r1true) < tol ) || ...
-            ( norm(r{1}(:,1)+r1true) < tol ) );
-% Second component of roots should be sin(pi*lam) (or its negative).
-r2true = chebfun(@(t) .5*sin(pi*t));
-pass(4) = ( ( norm(r{1}(:,2)-r2true) < tol ) || ...
-            ( norm(r{1}(:,2)+r2true) < tol ) );
 
+x = chebpts(257); 
+pass(3) = (norm(.5*exp(1i*x*pi) - r(x))) < tol; 
+
+% multiple roots
+f = diskfun(@(t,r) cos(5*r), 'polar'); 
+r = roots(f); 
+rt = pi/5*[1, 2] - pi/10;
+rt = rt.*exp(1i*x*pi); 
+
+r1 = r(:,1); r2 = r(:,2); 
+pass(4) = (norm(rt(:,1) - r1(x)))<tol; 
+pass(5) = (norm(rt(:,2) - r2(x)))<tol; 
+
+% pair of functions: 
+x = diskfun(@(x,y) x); 
+y = diskfun(@(x,y) y); 
+f = x.^2 + y.^2 - 1/4; 
+r = roots(f,x); 
+pass(6) = (norm(r - [0, -.5; 0, .5]))<tol; 
 end


### PR DESCRIPTION
fixes a few small inconsistencies with `diskfun/roots` and `chebfun2/roots`: 

1. no longer searches for roots across doubled up domain (this was resulting in contours found for negative radius values)
2. returns contours as complex-valued chebfuns, rather than real valued parametrizations.
