### PR TITLE
fix-rdivide-spurious-inf-and-nan

### DIFF
--- a/@chebfun/feval.m
+++ b/@chebfun/feval.m
@@ -100,6 +100,7 @@ numFuns = numel(f.funs);
 
 funs = f.funs;
 dom = f.domain;
+isTrans = f.isTransposed;
 
 %% LEFT AND RIGHT LIMITS:
 % Deal with feval(f, x, 'left') and feval(f, x, 'right'):
@@ -162,10 +163,12 @@ if ( any(xAtBreaks) )
     if ( leftFlag )
         % Note that for leftFlag we use 'rval-local', which corresponds to the
         % function value at the right part of the subdomain.
-        pointValues = [f.pointValues(1,:); get(f, 'rval-local')];
+        rvals = get(f, 'rval-local'); if ( isTrans ), rvals = rvals.'; end
+        pointValues = [f.pointValues(1,:); rvals];
     elseif ( rightFlag )
         % Similarly rightFlag uses lval-local.
-        pointValues = [get(f, 'lval-local'); f.pointValues(end,:)];
+        lvals = get(f, 'lval-local'); if ( isTrans ), lvals = lvals.'; end
+        pointValues = [lvals; f.pointValues(end,:)];
     else
         pointValues = f.pointValues;
     end

--- a/@chebfun/get.m
+++ b/@chebfun/get.m
@@ -11,7 +11,7 @@ function out = get(f, prop, simpLevel)
 %       'ishappy'        - Is F happy?
 %       'lval'           - Value(s) of F at left-hand side of domain.
 %       'rval'           - Value(s) of F at right-hand side of domain.
-%       'lval-local      - Value(s) of F's FUNs at left sides of their domains.
+%       'lval-local'     - Value(s) of F's FUNs at left sides of their domains.
 %       'rval-local'     - Value(s) of F's FUNs at right sides of their domains.
 %       'exps'           - Exponents in a CHEBFUN, a two vector.
 %       'exponents'

--- a/@chebfun/rdivide.m
+++ b/@chebfun/rdivide.m
@@ -201,8 +201,9 @@ if ( isa(f, 'chebfun') )
         (isinf(hpv) & (abs(fpv) < 100*chebfuneps*vscale(f)));
     if ( any(idx) )
         pvavg = (feval(h, h.domain, 'left') + feval(h, h.domain, 'right'))/2;
+        h.pointValues(idx) = pvavg(idx);
     end
-    h.pointValues(idx) = hpv(idx);
+    
     
 else
 

--- a/@chebfun/rdivide.m
+++ b/@chebfun/rdivide.m
@@ -195,6 +195,15 @@ if ( isa(f, 'chebfun') )
     % Divide the pointValues:
     h.pointValues = f.pointValues./g.pointValues;
     
+    % Avoid NaN or Inf from divide by zero where possible:
+    hpv = h.pointValues; fpv = f.pointValues; gpv = g.pointValues;
+    idx = (isnan(hpv) & ~(isnan(fpv) | isnan(gpv))) | ...
+        (isinf(hpv) & (abs(fpv) < 100*chebfuneps*vscale(f)));
+    if ( any(idx) )
+        pvavg = (feval(h, h.domain, 'left') + feval(h, h.domain, 'right'))/2;
+    end
+    h.pointValues(idx) = hpv(idx);
+    
 else
 
     % Copy g to h in preparation for output:

--- a/tests/chebfun/test_rdivide.m
+++ b/tests/chebfun/test_rdivide.m
@@ -6,6 +6,8 @@ if ( nargin < 1 )
     pref = chebfunpref();
 end
 
+%%
+
 % Generate a few random points to use as test values.
 seedRNG(6178);
 x = 2 * rand(100, 1) - 1;
@@ -203,6 +205,14 @@ pass(22) = strcmpi(func2str(get(h1(:,2).funs{1}.onefun, 'tech')), ...
 h2 = chebfun(@(x) [cos(x)./(2+x), sin(x)./(2+x.^3)], dom, pref);
 pass(23) = norm(h1-h2, inf) < 1e2*eps*get(h2,'vscale');
 
+%% Avoid introducing NaNs/Infs when dividing by zero:
+
+y1 = chebfun('abs(sin(5*x))','splitting','on');
+y2 = chebfun('abs(sin(4*x))','splitting','on');
+y3 = y2 - y1;
+g = (exp(2*y3) - exp(y3))./y3;
+mg = merge(g);
+pass(24) = (vscale(g) < inf) && (numel(g.funs) == 6);
 
 %%
 % #1111


### PR DESCRIPTION
Avoid spurious NaNs and Infs from removable singularities in `@chebfun/rdivide`.