### PR TITLE
Feature smoothie

### DIFF
--- a/smoothie.m
+++ b/smoothie.m
@@ -54,7 +54,7 @@ c(1,:) = sqrt(2)*real(c(1,:));
 c = (exp(-sqrt((1:m)'/L)).*c)/sqrt(L);  % root-expoential decay
 c = [conj(c(end:-1:2,:)); c];           % symmetrize for real result
 if cmplx
-disp('not implemented');                 
+    disp('not implemented');                 
 end
 f = chebfun(c, dom, 'trig', 'coeffs');
 

--- a/smoothie.m
+++ b/smoothie.m
@@ -53,9 +53,12 @@ c = randn(m,n) + 1i*randn(m,n);         % random coeffs
 c(1,:) = sqrt(2)*real(c(1,:));
 c = (exp(-sqrt((1:m)'/L)).*c)/sqrt(L);  % root-expoential decay
 c = [conj(c(end:-1:2,:)); c];           % symmetrize for real result
+
 if cmplx
-    disp('not implemented');                 
+    error('CHEBFUN:smoothie:UnknownOption',...
+        'Unknown input parameter.')
 end
+
 f = chebfun(c, dom, 'trig', 'coeffs');
 
 end


### PR DESCRIPTION
This pull request is created so we have official comments and tracking of the new `smoothie` function introduced by @trefethen.  Here are my comments and questions after reviewing the code:

- Where does the name "smoothie" come from?   My first thought when hearing this name was about a blended frozen fruit beverage.

- There is not a test for smoothie.  It looks like most functions in the chebfun directory have tests.

- The code is quite slow when not using 'trig' mode when the domain is increased.  Here's an example:
```
tic, f = smoothie([-10 10]); toc
Elapsed time is 5.797423 seconds.
tic, f = smoothie([-10 10],'trig'); toc
Elapsed time is 0.057221 seconds.
```
The issue is with line 47, which involves evaluating a trigfun at a very large number of chebyshev points.  This evaluation is done via Horner's method. So according to the definitions in the code, the cost scales like O(diff(domain)^2), with a very large constant here (>1e7).   It seems like the NUFFT could be used to speed things up, or perhaps there is a more direct approach to obtaining a smoothie using Chebyshev coefficients directly.