### PR TITLE
Fix periodic case in `odeFun` of `pdeSolve`

### DIFF
--- a/@chebfun/pdeSolve.m
+++ b/@chebfun/pdeSolve.m
@@ -828,6 +828,7 @@ clear global
             F = double(pdeFun(t, x, myU));
             
             if ( ISPERIODIC )
+                F = F(:);
                 return
             end
             


### PR DESCRIPTION
When an periodic boundary conditions are used with a system, the
`odeFun` in `@chebfun/pdeSolve` should return a column vector (as
opposed to a row vector as it currently does).

Minimal example:
```matlab
dom = [0, 1];
t = [0, 1];
bc = 'periodic';
pdefun = @(t,x,u,v) [diff(v); diff(u)];
x = chebfun(@(x) x, dom);
ic = [sin(2*pi*x), 0];
[t, u, v] = pde23t(pdefun, t, ic, bc);
```