### PR TITLE
Keep colormap modifications local

### DIFF
--- a/+cheb/gallerysphere.m
+++ b/+cheb/gallerysphere.m
@@ -256,7 +256,7 @@ else
 end
 
 view(viewAngle);
-colormap(clrmap);
+colormap(gca, clrmap);
 
 % Set the color axis if required.
 if ( ~isempty(clraxis) )

--- a/@chebfun3/plot.m
+++ b/@chebfun3/plot.m
@@ -40,7 +40,7 @@ if ( nargin <= 2 )
         h = slice(xx, yy, zz, angle(-v), xSlices, ySlices, zSlices);
         set(h, 'EdgeColor','none')
         caxis([-pi pi])
-        colormap('hsv')
+        colormap(gca, 'hsv')
         axis('equal') 
     end
     return

--- a/@chebfun3/scan.m
+++ b/@chebfun3/scan.m
@@ -64,7 +64,7 @@ if ( ( dim == 3 ) && ~isHold )
             h = slice(xx, yy, zz, angle(-vv), [], [], zslices(i));
             set(h, 'EdgeColor', 'none');
             caxis([-pi pi])
-            colormap('hsv')
+            colormap(gca, 'hsv')
             axis('equal')
         end
         axis(dom)
@@ -82,7 +82,7 @@ elseif ( ( dim == 3 ) && isHold )
         else
             h = slice(xx, yy, zz, angle(-vv), [], [], zslices(i));
             caxis([-pi pi])
-            colormap('hsv')
+            colormap(gca, 'hsv')
             axis('equal')            
         end
         axis(dom)
@@ -102,7 +102,7 @@ elseif ( ( dim == 2 ) && ~isHold )
         else
             h = slice(xx, yy, zz, angle(-vv), [], yslices(i), []);
             caxis([-pi pi])
-            colormap('hsv')
+            colormap(gca, 'hsv')
             axis('equal')
         end
         set(h, 'EdgeColor', 'none')
@@ -121,7 +121,7 @@ elseif ( ( dim == 2 ) && isHold )
         else
             h = slice(xx, yy, zz, angle(-vv), [], yslices(i), []);
             caxis([-pi pi])
-            colormap('hsv')
+            colormap(gca, 'hsv')
             axis('equal')            
         end
         axis(dom)
@@ -140,7 +140,7 @@ elseif ( ( dim == 1 ) && ~isHold )
         else
             h = slice(xx, yy, zz, angle(-vv), xslices(i), [], []);
             caxis([-pi pi])
-            colormap('hsv')
+            colormap(gca, 'hsv')
             axis('equal')            
         end
         set(h, 'EdgeColor', 'none');
@@ -159,7 +159,7 @@ elseif ( ( dim == 1 ) && isHold )
         else
             h = slice(xx, yy, zz, angle(-vv), xslices(i), [], []);
             caxis([-pi pi])
-            colormap('hsv')
+            colormap(gca, 'hsv')
             axis('equal')            
         end
         set(h, 'EdgeColor', 'none')

--- a/@chebfun3/slice.m
+++ b/@chebfun3/slice.m
@@ -60,7 +60,7 @@ if ( nargin == 2 && strcmp(varargin, 'noslider'))
         h = slice(xx, yy, zz, angle(-v), xslice, yslice, zslice); 
         set(h, 'EdgeColor','none')
         caxis([-pi pi]),
-        colormap('hsv')
+        colormap(gca, 'hsv')
         axis('equal') 
     end
     str = sprintf('Three slices: x = %2.1g, y = %2.1g, z = %2.1g', ...
@@ -88,7 +88,7 @@ elseif ( nargin == 4 )
         h = slice(xx, yy, zz, angle(-v), xslice, yslice, zslice); 
         set(h, 'EdgeColor','none')
         caxis([-pi pi]),
-        colormap('hsv')
+        colormap(gca, 'hsv')
         axis('equal')         
     end    
     if ( ~holdState )
@@ -157,7 +157,7 @@ else
     hh = slice(xx, yy, zz, angle(-v), xslice, yslice, zslice); 
     set(hh, 'EdgeColor','none')
     caxis([-pi pi]),
-    colormap('hsv')
+    colormap(gca, 'hsv')
     axis('equal')     
 end
 
@@ -238,7 +238,7 @@ else
         xslice, yslice, zslice); 
     set(handles.slice, 'EdgeColor','none')
     caxis([-pi pi]),
-    colormap('hsv')
+    colormap(gca, 'hsv')
     axis('equal')
 end
 title(titText)
@@ -276,7 +276,7 @@ else
         xslice, yslice, zslice); 
     set(handles.slice, 'EdgeColor','none')
     caxis([-pi pi]),
-    colormap('hsv')
+    colormap(gca, 'hsv')
     axis('equal')    
 end
 title(titText)
@@ -314,7 +314,7 @@ else
         xslice, yslice, zslice); 
     set(handles.slice, 'EdgeColor','none')
     caxis([-pi pi]),
-    colormap('hsv')
+    colormap(gca, 'hsv')
     axis('equal')    
 end
 title(titText)

--- a/@diskfun/plot.m
+++ b/@diskfun/plot.m
@@ -176,7 +176,7 @@ if ( ~isempty(varargin) )
         if strcmp(varargin{1}, 'zebra')
             h = surf(f);
             caxis(norm(caxis,inf)*[-1 1])
-            colormap([0 0 0; 1 1 1])
+            colormap(gca, [0 0 0; 1 1 1])
        
             % Add unit circle to zebra plot
             holdState = ishold; 

--- a/@separableApprox/plot.m
+++ b/@separableApprox/plot.m
@@ -116,7 +116,7 @@ if ( ~isempty(varargin) )
             h = surf(f);
             view(0,90)
             caxis(norm(caxis,inf)*[-1 1])
-            colormap([0 0 0; 1 1 1])
+            colormap(gca, [0 0 0; 1 1 1])
         else
             h = surf(f, varargin{:});
         end
@@ -124,8 +124,6 @@ if ( ~isempty(varargin) )
 else
     if ( isreal( f ) )
         h = surf( f );
-        colormap default
-        
     else
         %% Phase Protrait plot 
         % The following is a slightly modified version of Wegert's code from
@@ -140,7 +138,7 @@ else
         f = feval(f, xx, yy);
         h = surf( real(zz), imag(zz), 0*zz, angle(-f) );
         set(h, 'EdgeColor', 'none');
-        caxis([-pi pi]), colormap hsv(600)
+        caxis([-pi pi]), colormap(gca, hsv(600))
         view(0, 90), axis equal, axis off  
         
     end

--- a/@spherefun/plot.m
+++ b/@spherefun/plot.m
@@ -194,7 +194,7 @@ if ( ~isempty(varargin) )
         if strcmp(varargin{1}, 'zebra')
             h = surf(f);
             caxis(norm(caxis,inf)*[-1 1])
-            colormap([0 0 0; 1 1 1])
+            colormap(gca, [0 0 0; 1 1 1])
         else
             h = surf(f, varargin{:});
         end

--- a/cheb2logo.m
+++ b/cheb2logo.m
@@ -40,7 +40,7 @@ ff = [f(xx) f2(xx)];
 close all
 surf(repmat([0 1], length(xx), 1), -[xx xx], ff)
 shading interp
-colormap winter
+colormap(gca, winter)
 
 fs = 18;
 
@@ -71,7 +71,7 @@ plot3(0*xx, -xx, f(xx), LW, lw, 'Color', C)
 plot3(0*xx + 1, -xx, f2(xx), 'b', LW, lw, 'Color', C)
 plot3([0 1], -dom(2)*[1 1], f(xx(end)) + [0 2], 'b', LW, lw, 'Color', C)
 plot3([0 1], [1 1], [1 3], 'b', LW, lw, 'Color', C)
-colormap([1 1 1 ; .5 .5 .5]);
+colormap(gca, [1 1 1 ; .5 .5 .5]);
 
 flist = listfonts;
 k = strmatch('Rockwell', flist);  % 1st choice

--- a/chebsnake2.m
+++ b/chebsnake2.m
@@ -98,7 +98,7 @@ while (d ~= 0), % until quit
     
     clf
     plot(f)
-    colormap hsv, alpha(.2)
+    colormap(gca, hsv), alpha(.2)
     hold on
     s = linspace(res*(1-len), 0, len) + 1i*eps;
     hs1 = plot3(real(s(1:end-1)), imag(s(1:end-1)), ...


### PR DESCRIPTION
Fixes `colormap` issues in #2074 and #2151, where specific a `colormap` used in `'zebra'` plots or phase portrait plots would persist in subsequent plots.