### PR TITLE
Implement contour3 for separableApprox objects

### DIFF
--- a/@chebfun2/contour3.m
+++ b/@chebfun2/contour3.m
@@ -1,0 +1,35 @@
+function varargout = contour3(varargin)
+%CONTOUR3  3-D contour plot of a CHEBFUN2.
+%   CONTOUR3(F) is a contour plot of F treating the values of F as heights
+%   above a plane. A contour plot shows the level curves of F for some
+%   values V. The values V are chosen automatically.
+%
+%   CONTOUR3(F, N) draws N contour lines, overriding the automatic number.
+%   The values V are still chosen automatically.
+%
+%   CONTOUR3(F, V) draws LENGTH(V) contour lines at the values specified in
+%   vector V. Use CONTOUR3(F, [V V]) to compute a single contour at the
+%   level V.
+%
+%   CONTOUR3(X, Y, F, ...), CONTOUR3(X, Y, F, N, ...), and
+%   CONTOUR3(X, Y, F, V, ...) use matrices X and Y to specify the plotting
+%   grid.
+%
+%   [C, H] = CONTOUR3(...) returns contour matrix C as described in
+%   CONTOURC and a handle H to a contour object. This handle can be used as
+%   input to CLABEL.
+%
+%   CONTOUR3(F, 'NUMPTS', N) plots the contour lines on a N by N uniform
+%   grid. If NUMPTS is not given then we plot on a 200 by 200 grid.
+%
+%   CONTOUR3(F, 'PIVOTS', STR) plots the contour lines with the pivot
+%   locations used during construction.
+%
+% See also CONTOUR, CONTOURF.
+
+% Copyright 2020 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+[varargout{1:nargout}] = contour3@separableApprox(varargin{:});
+
+end

--- a/@chebfun2/contour3.m
+++ b/@chebfun2/contour3.m
@@ -8,7 +8,7 @@ function varargout = contour3(varargin)
 %   The values V are still chosen automatically.
 %
 %   CONTOUR3(F, V) draws LENGTH(V) contour lines at the values specified in
-%   vector V. Use CONTOUR3(F, [V V]) to compute a single contour at the
+%   the vector V. Use CONTOUR3(F, [V V]) to compute a single contour at the
 %   level V.
 %
 %   CONTOUR3(X, Y, F, ...), CONTOUR3(X, Y, F, N, ...), and
@@ -19,7 +19,7 @@ function varargout = contour3(varargin)
 %   CONTOURC and a handle H to a contour object. This handle can be used as
 %   input to CLABEL.
 %
-%   CONTOUR3(F, 'NUMPTS', N) plots the contour lines on a N by N uniform
+%   CONTOUR3(F, 'NUMPTS', N) plots the contour lines on an N by N uniform
 %   grid. If NUMPTS is not given then we plot on a 200 by 200 grid.
 %
 %   CONTOUR3(F, 'PIVOTS', STR) plots the contour lines with the pivot

--- a/@diskfun/contour3.m
+++ b/@diskfun/contour3.m
@@ -8,7 +8,7 @@ function varargout = contour3( f, varargin )
 %   The values V are still chosen automatically.
 %   
 %   CONTOUR3(F, V) draws LENGTH(V) contour lines at the values specified in
-%   vector V. Use CONTOUR3(F, [V V]) to compute a single contour at the
+%   the vector V. Use CONTOUR3(F, [V V]) to compute a single contour at the
 %   level V.
 %
 %   CONTOUR3(X, Y, F, ...), CONTOUR3(X, Y, F, N, ...), and
@@ -19,7 +19,7 @@ function varargout = contour3( f, varargin )
 %   CONTOURC and a handle H to a contour object. This handle can be used as
 %   input to CLABEL.
 %
-%   CONTOUR3(F, 'NUMPTS', N) plots the contour lines on a N by N uniform
+%   CONTOUR3(F, 'NUMPTS', N) plots the contour lines on an N by N uniform
 %   grid. If NUMPTS is not given then we plot on a 200 by 200 grid.
 %
 %   CONTOUR3(F, 'PIVOTS', STR) plots the contour lines with the pivot

--- a/@diskfun/contour3.m
+++ b/@diskfun/contour3.m
@@ -1,0 +1,175 @@
+function varargout = contour3( f, varargin )
+%CONTOUR3   3-D contour plot of a DISKFUN.
+%   CONTOUR3(F) is a contour plot of F treating the values of F as heights
+%   above the disk. A contour plot shows the level curves of F for some
+%   values V. The values V are chosen automatically.
+%
+%   CONTOUR3(F, N) draws N contour lines, overriding the automatic number.
+%   The values V are still chosen automatically.
+%   
+%   CONTOUR3(F, V) draws LENGTH(V) contour lines at the values specified in
+%   vector V. Use CONTOUR3(F, [V V]) to compute a single contour at the
+%   level V.
+%
+%   CONTOUR3(X, Y, F, ...), CONTOUR3(X, Y, F, N, ...), and
+%   CONTOUR3(X, Y, F, V, ...) use matrices X and Y to specify the plotting
+%   grid.
+%
+%   [C, H] = CONTOUR3(...) returns contour matrix C as described in
+%   CONTOURC and a handle H to a contour object. This handle can be used as
+%   input to CLABEL.
+%
+%   CONTOUR3(F, 'NUMPTS', N) plots the contour lines on a N by N uniform
+%   grid. If NUMPTS is not given then we plot on a 200 by 200 grid.
+%
+%   CONTOUR3(F, 'PIVOTS', STR) plots the contour lines with the pivot
+%   locations used during construction.
+%
+% See also CONTOUR, CONTOURF.
+
+% Copyright 2020 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+if ( isempty( f ) )  % Empty check.
+    contour3( [] );
+    return
+end
+
+% Minimum number of plotting points.
+minplotnum = 200;
+doPivotPlot = 0; 
+
+% Extract from the inputs the user defined options.
+j = 1; 
+argin = {};
+while ( ~isempty( varargin ) )
+    if ( strcmpi( varargin{1}, 'numpts') ) % If given numpts then use them.
+        minplotnum = varargin{2};
+        varargin(1:2) = [];
+    elseif ( strcmpi(varargin{1}, 'pivots') ) % Should we plot the pivots?
+        doPivotPlot = 1;
+        if ( length( varargin ) < 2 ) 
+            error('CHEBFUN:DISKFUN:contour3:pivotStyle', ...
+                'Pivot style undefined.')
+        end
+        argin{j} = varargin{2};
+        varargin(1:2) = [];
+    else
+        argin{j} = varargin{1};
+        varargin(1) = [];
+        j = j+1;
+    end
+end
+numargs = numel(argin);
+
+% Did the user want a plot of the pivot locations?
+if ( doPivotPlot )
+    if ( ( ~isempty(argin) ) && ( length(argin{1}) < 5 ) )
+        % Column, row, pivot plot
+        holdState = ishold;
+        plot( f, argin{:} ), hold on
+        argin(1) = [];
+        contour3( f, argin{:} )
+        if ( ~holdState )
+            hold off
+        end
+        return
+    end
+end
+
+if ( isa(f, 'double') )
+    % CONTOUR3(xx, yy, F,...)
+
+    if ( (numargs >= 2) && isa(argin{1}, 'double') && isa(argin{2}, 'diskfun') )
+        % Extract inputs:
+        xx = f; 
+        yy = argin{1}; 
+        f = argin{2};
+        argin(1:2) = [];
+        % Evaluate diskfun: 
+        vals = feval(f, xx, yy, 'polar');
+
+    else
+        error('CHEBFUN:DISKFUN:contour3:badInputs', ...
+            'Unrecognised input arguments.');
+    end
+
+elseif ( isa(f, 'diskfun') )
+
+    dom = f.domain;
+    if ( (numargs >= 2) && isa(argin{1}, 'diskfun') && isa(argin{2}, 'diskfun') )
+        % CONTOUR3 plot on a surface.
+
+        % Extract inputs:
+        xx = f; 
+        yy = argin{1}; 
+        f = argin{2};
+        argin(1:2) = [];
+
+        % Check CONTOUR3 objects are on the same domain.
+        if ( ~domainCheck(xx, yy) )
+            error('CHEBFUN:DISKFUN:contour3:domains', ...
+                'Domains of DISKFUN objects are not consistent.');
+        end
+
+        % Evaluate f on equally spaced grid:
+        x = linspace( dom(1), dom(2), minplotnum );
+        y = linspace( dom(3), dom(4), minplotnum );
+        [mxx, myy] = meshgrid(x, y);
+        xx = feval(xx, mxx, myy, 'polar'); 
+        yy = feval(yy, mxx, myy, 'polar');
+        [xx,yy] = cart2pol(xx,yy);
+        vals = feval(f, xx, yy, 'polar');
+
+    elseif ( (numargs == 2) || ((numargs > 2) && ~isa(argin{1}, 'diskfun')) ) 
+        % CONTOUR3(xx, yy, f)
+
+        % Evaluate f at equally spaced points.
+        x = linspace( dom(1), dom(2), minplotnum );
+        y = linspace( dom(3), dom(4), minplotnum );
+        [xx, yy] = meshgrid(x, y);
+        vals = feval(f, xx, yy, 'polar');
+
+    elseif ( (numargs == 0) || ((numargs > 0) && isa(argin{1}, 'double')) )
+        % CONTOUR3(f) 
+
+        % Evaluate at equally spaced grid: 
+        x = linspace( dom(1), dom(2), minplotnum );
+        y = linspace( dom(3), dom(4), minplotnum );
+        [xx, yy] = meshgrid(x, y);
+        vals = feval(f, xx, yy, 'polar');
+
+    else
+        error('CHEBFUN:DISKFUN:contour3:inputs1', ...
+            'Unrecognised input arguments.');
+    end
+
+else
+
+    error('CHEBFUN:DISKFUN:contour3:inputs2', ...
+        'Unrecognised input arguments.');
+
+end
+
+[X, Y] = pol2cart(xx, yy);
+% CONTOUR3 plot:
+[c, h] = contour3( X, Y, vals, argin{:} );
+axis square
+
+% Add unit circle
+holdState = ishold;
+circ = exp(1i*pi*linspace(-1,1,101));
+hold on
+plot(real(circ), imag(circ), 'k-', 'Linewidth', .3)
+if ( ~holdState )
+    hold off
+end
+
+% Return plot handle if appropriate.
+if ( nargout == 1 )
+    varargout = {h};
+elseif ( nargout == 2 )
+    varargout = {c, h};
+end
+
+end

--- a/@diskfun/contour3.m
+++ b/@diskfun/contour3.m
@@ -156,15 +156,6 @@ end
 [c, h] = contour3( X, Y, vals, argin{:} );
 axis square
 
-% Add unit circle
-holdState = ishold;
-circ = exp(1i*pi*linspace(-1,1,101));
-hold on
-plot(real(circ), imag(circ), 'k-', 'Linewidth', .3)
-if ( ~holdState )
-    hold off
-end
-
 % Return plot handle if appropriate.
 if ( nargout == 1 )
     varargout = {h};

--- a/@separableApprox/contour3.m
+++ b/@separableApprox/contour3.m
@@ -8,7 +8,7 @@ function varargout = contour3( f, varargin )
 %   The values V are still chosen automatically.
 %   
 %   CONTOUR3(F, V) draws LENGTH(V) contour lines at the values specified in
-%   vector V. Use CONTOUR3(F, [V V]) to compute a single contour at the
+%   the vector V. Use CONTOUR3(F, [V V]) to compute a single contour at the
 %   level V.
 %
 %   CONTOUR3(X, Y, F, ...), CONTOUR3(X, Y, F, N, ...), and
@@ -19,7 +19,7 @@ function varargout = contour3( f, varargin )
 %   CONTOURC and a handle H to a contour object. This handle can be used as
 %   input to CLABEL.
 %
-%   CONTOUR3(F, 'NUMPTS', N) plots the contour lines on a N by N uniform
+%   CONTOUR3(F, 'NUMPTS', N) plots the contour lines on an N by N uniform
 %   grid. If NUMPTS is not given then we plot on a 200 by 200 grid.
 %
 %   CONTOUR3(F, 'PIVOTS', STR) plots the contour lines with the pivot

--- a/@separableApprox/contour3.m
+++ b/@separableApprox/contour3.m
@@ -1,0 +1,163 @@
+function varargout = contour3( f, varargin )
+%CONTOUR3   3-D contour plot of a SEPARABLEAPPROX.
+%   CONTOUR3(F) is a contour plot of F treating the values of F as heights
+%   above a plane. A contour plot shows the level curves of F for some
+%   values V. The values V are chosen automatically.
+%
+%   CONTOUR3(F, N) draws N contour lines, overriding the automatic number.
+%   The values V are still chosen automatically.
+%   
+%   CONTOUR3(F, V) draws LENGTH(V) contour lines at the values specified in
+%   vector V. Use CONTOUR3(F, [V V]) to compute a single contour at the
+%   level V.
+%
+%   CONTOUR3(X, Y, F, ...), CONTOUR3(X, Y, F, N, ...), and
+%   CONTOUR3(X, Y, F, V, ...) use matrices X and Y to specify the plotting
+%   grid.
+%
+%   [C, H] = CONTOUR3(...) returns contour matrix C as described in
+%   CONTOURC and a handle H to a contour object. This handle can be used as
+%   input to CLABEL.
+%
+%   CONTOUR3(F, 'NUMPTS', N) plots the contour lines on a N by N uniform
+%   grid. If NUMPTS is not given then we plot on a 200 by 200 grid.
+%
+%   CONTOUR3(F, 'PIVOTS', STR) plots the contour lines with the pivot
+%   locations used during construction.
+%
+% See also CONTOUR, CONTOURF.
+
+% Copyright 2020 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+if ( isempty( f ) )  % Empty check.
+    contour3( [] );
+    return
+end
+
+% Minimum number of plotting points:
+minplotnum = 200;
+doPivotPlot = 0;
+
+% Extract from the inputs the user defined options:
+j = 1;
+argin = {};
+while ( ~isempty( varargin ) )
+    if ( strcmpi( varargin{1}, 'numpts') ) % If given numpts then use them.
+        minplotnum = varargin{2};
+        varargin(1:2) = [];
+    elseif ( strcmpi(varargin{1}, 'pivots') ) % Should we plot the pivots?
+        doPivotPlot = 1;
+        if ( length( varargin ) < 2 ) 
+            error('CHEBFUN:SEPARABLEAPPROX:contour3:pivotStyle', ...
+                'Pivot style undefined.')
+        end
+        argin{j} = varargin{2};
+        varargin(1:2) = [];
+    else
+        argin{j} = varargin{1};
+        varargin(1) = [];
+        j = j+1;
+    end
+end
+numargs = numel(argin);
+
+% Did the user want a plot of the pivot locations?
+if ( doPivotPlot )
+    if ( ( ~isempty(argin) ) && ( length(argin{1}) < 5 ) )
+        % Column, row, pivot plot
+        holdState = ishold;
+        plot( f, argin{:} ), hold on
+        argin(1) = [];
+        contour3( f, argin{:} )
+        if ( ~holdState )
+            hold off;
+        end
+        return
+    end
+end
+
+if ( isa(f, 'double') )
+    % CONTOUR3(xx, yy, F,...)
+
+    if ( (numargs >= 2) && isa(argin{1}, 'double') && isa(argin{2}, 'separableApprox') )
+        % Extract inputs:
+        xx = f; 
+        yy = argin{1}; 
+        f = argin{2};
+        argin(1:2) = [];
+        % Evaluate separableApprox: 
+        vals = feval(f, xx, yy);
+
+    else
+        error('CHEBFUN:SEPARABLEAPPROX:contour3:badInputs', ...
+            'Unrecognised input arguments.');
+    end
+
+elseif ( isa(f, 'separableApprox') ) 
+
+    dom = f.domain;
+    if ( (numargs >= 2) && isa(argin{1}, 'separableApprox') && isa(argin{2}, 'separableApprox') )
+        % CONTOUR3 plot on a surface.
+
+        % Extract inputs:
+        xx = f; 
+        yy = argin{1}; 
+        f = argin{2};
+        argin(1:2) = [];
+
+        % Check CONTOUR3 objects are on the same domain.
+        if ( ~domainCheck(xx, yy) )
+            error('CHEBFUN:SEPARABLEAPPROX:contour3:domains', ...
+                'Domains of SEPARABLEAPPROX objects are not consistent.');
+        end
+
+        % Evaluate f on equally spaced grid:
+        x = linspace( dom(1), dom(2), minplotnum );
+        y = linspace( dom(3), dom(4), minplotnum );
+        [mxx, myy] = meshgrid(x, y);
+        xx = feval(xx, mxx, myy); 
+        yy = feval(yy, mxx, myy);
+        vals = feval(f, xx, yy);
+
+    elseif ( (numargs == 2) || ((numargs > 2) && ~isa(argin{1}, 'separableApprox')) )
+        % CONTOUR3(xx, yy, f)
+
+        % Evaluate f at equally spaced points.
+        x = linspace( dom(1), dom(2), minplotnum );
+        y = linspace( dom(3), dom(4), minplotnum );
+        [xx, yy] = meshgrid(x, y);
+        vals = feval(f, xx, yy);
+
+    elseif ( (numargs == 0) || ((numargs > 0) && isa(argin{1}, 'double')) )
+        % CONTOUR3(f) 
+        
+        % Evaluate at equally spaced grid: 
+        x = linspace( dom(1), dom(2), minplotnum );
+        y = linspace( dom(3), dom(4), minplotnum );
+        [xx, yy] = meshgrid(x, y);
+        vals = feval(f, xx, yy);
+
+    else
+        error('CHEBFUN:SEPARABLEAPPROX:contour3:inputs1', ...
+            'Unrecognised input arguments.');
+    end
+
+else
+
+    error('CHEBFUN:SEPARABLEAPPROX:contour3:inputs2', ...
+        'Unrecognised input arguments.');
+
+end
+
+% CONTOUR3 plot:
+[c, h] = contour3( xx, yy, vals, argin{:} );
+
+% Return plot handle if appropriate.
+if ( nargout == 1 )
+    varargout = {h};
+elseif ( nargout == 2 )
+    varargout = {c, h};
+end
+
+end

--- a/@spherefun/contour3.m
+++ b/@spherefun/contour3.m
@@ -1,0 +1,136 @@
+function varargout = contour3( f, varargin )
+%CONTOUR3   3-D contour plot of a SPHEREFUN.
+%   CONTOUR3(F) is a contour plot of F treating the values of F as heights
+%   above the sphere. A contour plot shows the level curves of F for some
+%   values V. The values V are chosen automatically.
+%
+%   CONTOUR3(F, N) draws N contour lines, overriding the automatic number.
+%   The values V are still chosen automatically.
+%   
+%   CONTOUR3(F, V) draws LENGTH(V) contour lines at the values specified in
+%   the vector V. Use CONTOUR3(F, [V V]) to compute a single contour at the
+%   level V.
+%
+%   CONTOUR3(F, 'NUMPTS', N) plots the contour lines on an N by N uniform
+%   grid. If NUMPTS is not given then we plot on a 200 by 200 grid.
+%
+% See also CONTOUR, CONTOURF.
+
+% Copyright 2020 by The University of Oxford and The Chebfun Developers.
+% See http://www.chebfun.org/ for Chebfun information.
+
+if ( isempty(f) )  % Empty check.
+    contour3([]);
+    return
+end
+
+holdState = ishold;
+
+% Minimum number of plotting points:
+minplotnum = 200;
+
+% Extract from the inputs the user defined options: 
+j = 1; 
+argin = {};
+while ( ~isempty(varargin) )
+    if ( strcmpi(varargin{1}, 'numpts') ) % If given numpts then use them.
+        minplotnum = varargin{2};
+        varargin(1:2) = [];
+    else
+        argin{j} = varargin{1};
+        varargin(1) = [];
+        j = j+1;
+    end
+end
+
+if ( isa(f, 'spherefun') )
+    dom = f.domain;
+    % Evaluate at equally spaced grid: 
+    x = linspace(dom(1), dom(2), minplotnum);
+    y = linspace(dom(3), dom(4), minplotnum);
+    vals = sample(f, minplotnum-1, minplotnum);
+    vals = [vals vals(:,1)];
+else
+    error('CHEBFUN:SPHEREFUN:contour3:inputs', ...
+        'Input must be a spherefun.');
+end
+
+if ( iscolat(f) )
+    xc = @(ll,tt,rr) rr.*cos(ll).*sin(tt);
+    yc = @(ll,tt,rr) rr.*sin(ll).*sin(tt);
+    zc = @(tt,rr) rr.*cos(tt);
+else
+    xc = @(ll,tt,rr) rr.*cos(ll).*cos(tt);
+    yc = @(ll,tt,rr) rr.*sin(ll).*cos(tt);
+    zc = @(tt,rr) rr.*sin(tt);
+end
+
+% Use contour rather than contourc so that it can handle parsing the inputs
+% correctly.
+[c, h] = contour( x', y', vals, argin{:} );
+
+% Extract out the options we need to plot the contours with plot3.
+LW = 'LineWidth'; 
+lw = h.LineWidth;
+LS = 'LineStyle'; 
+ls = h.LineStyle;
+LC = 'Color'; 
+lc = h.LineColor;
+levelList = h.LevelList;
+clrmap = parula(numel(levelList));
+
+% Remove the contour plot that was generated.
+delete(h);
+
+scl = 0.15;           % Match the bumpy parameter in SPHEREFUN/SURF().
+lim = [-1-scl 1+scl]; % Pad the axis limits.
+m = minandmax2(f);
+
+% If the plot is not being added to another, then set the axis properties.
+if ( ~holdState )
+    xlim(lim), ylim(lim), zlim(lim)
+    daspect([1 1 1])
+    grid on, box off
+    hold on
+end
+view(3)
+
+cl = size(c,2);
+k = 1;
+while ( k < cl )
+    kl = c(2,k);
+    v = k+1:k+kl;
+
+    % Bump out the radial components according to the function values.
+    rr = rescale(c(1,k), 1-scl, 1+scl, 'InputMin', m(1), 'InputMax', m(2));
+    xv = xc(c(1,v), c(2,v), rr);
+    yv = yc(c(1,v), c(2,v), rr);
+    zv = zc(c(2,v), rr);
+
+    % If the line color is a float then we are plotting all contours in a
+    % single color.
+    if ( isfloat(lc) )
+        plot3(xv, yv, zv, LW, lw, LC, lc, LS, ls);
+    else
+        % We need to plot each contour in a color using the default 
+        % colormap.
+        % Determine the color for the level being plotted.
+        clr = clrmap(abs(c(1, k) - levelList) < 10*eps, :);
+        plot3(xv, yv, zv, LW, lw, LC, clr, LS, ls);
+    end
+
+    k = k+kl+1;
+end
+
+if ( ~holdState )
+    hold off
+end
+
+% Return plot handle if appropriate.
+if ( nargout >= 1 )
+    warning('CHEBFUN:SPHEREFUN:contour3:outputs', ...
+        'Outputs from contour3 are not supported');
+    varargout = { [], [] };
+end
+
+end

--- a/@spherefun/contour3.m
+++ b/@spherefun/contour3.m
@@ -1,8 +1,9 @@
 function varargout = contour3( f, varargin )
 %CONTOUR3   3-D contour plot of a SPHEREFUN.
 %   CONTOUR3(F) is a contour plot of F treating the values of F as heights
-%   above the sphere. A contour plot shows the level curves of F for some
-%   values V. The values V are chosen automatically.
+%   above the sphere, analagous to SURF(F, 'projection', 'bumpy'). A
+%   contour plot shows the level curves of F for some values V. The values
+%   V are chosen automatically.
 %
 %   CONTOUR3(F, N) draws N contour lines, overriding the automatic number.
 %   The values V are still chosen automatically.

--- a/tests/chebfun2/test_contour3.m
+++ b/tests/chebfun2/test_contour3.m
@@ -1,0 +1,26 @@
+function pass = test_contour3( pref )
+% Test contour3
+
+if ( nargin == 0 )
+    pref = chebfunpref;
+end
+
+f = chebfun2(@(x,y) cos(x.*y));
+x = -1:.1:1;
+[xx, yy] = meshgrid(x);
+
+pass = 1;
+try
+   contour3(f)
+   contour3(f, 5)
+   contour3(f, [0.8 0.8])
+   contour3(f, 'numpts', 100)
+   contour3(f, 'pivots', 'r.-')
+   contour3(xx, yy, f)
+catch ME
+    pass = 0;
+end
+
+close all
+
+end

--- a/tests/diskfun/test_contour3.m
+++ b/tests/diskfun/test_contour3.m
@@ -1,0 +1,27 @@
+function pass = test_contour3( pref )
+% Test contour3
+
+if ( nargin == 0 )
+    pref = chebfunpref;
+end
+
+f = diskfun(@(x,y) cos(cos(4*x).^2 + sin(5*y).^2));
+x = -pi:.1:pi;
+y = -1:.1:1;
+[xx, yy] = meshgrid(x,y);
+
+pass = 1;
+try
+   contour3(f)
+   contour3(f, 5)
+   contour3(f, [0.4 0.4])
+   contour3(f, 'numpts', 100)
+   contour3(f, 'pivots', 'r.-')
+   contour3(xx, yy, f)
+catch ME
+    pass = 0;
+end
+
+close all
+
+end

--- a/tests/spherefun/test_contour3.m
+++ b/tests/spherefun/test_contour3.m
@@ -1,0 +1,22 @@
+function pass = test_contour3( pref )
+% Test contour3
+
+if ( nargin == 0 )
+    pref = chebfunpref;
+end
+
+f = spherefun.sphharm(4, 3);
+
+pass = 1;
+try
+   contour3(f)
+   contour3(f, 5)
+   contour3(f, [0.3 0.3])
+   contour3(f, 'numpts', 100)
+catch ME
+    pass = 0;
+end
+
+close all
+
+end


### PR DESCRIPTION
This PR implements `contour3` for 2D functions represented by a `separableApprox`.

For a `chebfun2`:
```
f = cheb.gallery2('peaks');
plot(f), hold on, contour3(f, 10, 'k', 'Linewidth', 1)
```
<img width="517" alt="Screenshot 2020-04-16 17 28 30" src="https://user-images.githubusercontent.com/878034/79508553-c36c4300-8007-11ea-87a2-46ecda7c2294.png">

For a `diskfun`:
```
f = cheb.gallerydisk('yinyang');
surf(f), hold on, contour3(f, 10, 'k', 'Linewidth', 1)
```
<img width="408" alt="Screenshot 2020-04-16 17 33 16" src="https://user-images.githubusercontent.com/878034/79508895-75a40a80-8008-11ea-9b96-1ddac5f23027.png">

For a `spherefun` (based on `spherefun`'s "bumpy" plot):
```
f = cheb.gallerysphere('peaks');
subplot(121)
contour3(f, 'Linewidth', 1)
subplot(122)
surf(f, 'projection', 'bumpy'), hold on
contour3(f, 'k', 'Linewidth', 1)
```
<img width="765" alt="Screenshot 2020-04-17 15 14 49" src="https://user-images.githubusercontent.com/878034/79605655-4fd93d00-80be-11ea-91f8-0e1a8cdc8015.png">
