### PR TITLE
Fix newline in chebop.disp() for systems.

### DIFF
--- a/@chebop/disp.m
+++ b/@chebop/disp.m
@@ -204,7 +204,7 @@ else
         % Replace ; with the ASCII character for new line. Add indentation to
         % make it look nice
         wSpace = repmat(' ', 1, length(args) + 12);
-        op = strrep(op, ';', [char(13), wSpace]);
+        op = strrep(op, ';', [sprintf('\n'), wSpace]);
     end
 
     % Output string


### PR DESCRIPTION
`char(13)` is the ASCII code for a carriage return (CR).  The Command
Window in the MATLAB GUI interprets this as a newline, but most terminal
emulators for Unix-based platforms do not, including xterm, the most
basic and standard terminal emulator that ships with every distribution
of Linux.  This results in a malformed display of chebops for systems of
ODEs when running MATLAB with -nodesktop -nosplash in such environments,
e.g.,
```
>> L = chebop(@(t, y1, y2) [diff(y1) - y1 ; diff(y2) - y2])
L =
   Linear operator:
                 diff(y2)-y2
   operating on chebfun objects defined on:
      [-1,1]
```
The correct output is:
```
>> L = chebop(@(t, y1, y2) [diff(y1) - y1 ; diff(y2) - y2])
L =
   Linear operator:
      y1,y2 |--> diff(y1)-y1
                 diff(y2)-y2
   operating on chebfun objects defined on:
      [-1,1]
```
Instead of CR, the line-feed (LF) character, `char(10)`, is the
appropriate thing to use here, but rather than this, we've opted to use
`sprintf('\n')` instead on the theory that if some poor soul tries to run
MATLAB inside a Windows DOS prompt (is that even possible?),
`sprintf('\n')` is more likely to produce the CR-LF sequence needed for a
newline on that platform.

(I can't test this latter theory, but this is such an edge case that I'm
not sure it's worth worrying about.  I don't know a single person
running MATLAB on Windows who does so from a DOS prompt.)

Since R2016b, MATLAB has provided a `newline()` function for inserting
newline characters.  We do not use this here to avoid problems with
backward compatibility.