### PR TITLE
Fix incorrect sizing in chebop2 when X and Y discretizations differ

### DIFF
--- a/@chebop2/denseSolve.m
+++ b/@chebop2/denseSolve.m
@@ -85,7 +85,7 @@ else
     else  
         % Do full n^2 by n^2 matrix kronecker product.
         % Make massive mn by mn matrix.
-        sz = size(CC{1,1}, 1) * size(CC{2,1}, 2);
+        sz = size(CC{1,1}, 1) * size(CC{1,2}, 2);
         if sz > 65^2
             error('CHEBFUN:CHEBOP2:denseSolve:unresolved1', ...
                 'Solution was unresolved on a 65 by 65 grid.');
@@ -110,7 +110,7 @@ else
         end
 
         % Unvectorize.
-        X = reshape(X, size(CC{1,1}, 1), size(CC{2,1}, 2));
+        X = reshape(X, size(CC{1,1}, 1), size(CC{1,2}, 2));
 
         % Impose linear constraints:
         X = imposeBoundaryConditions(X,bb,gg,Px,Py,m,n);


### PR DESCRIPTION
`chebop2` can fail when the discretization sizes in X and Y are not the same, due to a bug in the sizing of Kronecker products. This PR fixes that bug.

The following test was failing, but now passes:
https://github.com/chebfun/chebfun/blob/5fde1a4ab57847c1a0843e88c2b3145bc5410fc9/tests/chebop2/test_generalVariableCoefficients.m#L61-L70