### PR TITLE
periodic quantumstates

### DIFF
--- a/tests/misc/test_quantumstates.m
+++ b/tests/misc/test_quantumstates.m
@@ -33,4 +33,10 @@ op = @(u) -h^2*diff(u,2) + repmat(V, 1, n).*u;
 % Did quantumstates() return eigenfunctions and eigenvalues?
 err = norm( op(efuns) - efuns*evals );
 pass(2) = err < 5e-8;
+
+% A periodic problem:
+V = chebfun('sin(pi*x/2)^2','trig');
+e = quantumstates(V,'noplot');
+pass(3) = abs(e(3)-.68934055) < 1e-3;
+
 end


### PR DESCRIPTION
This enables `quantumstates` to work with periodic as well as nonperiodic potentials.  Note however (and this is mentioned in the help text): only eigenfunctions that have the same periodicity as the potential are computed.