### PR TITLE
Feature conformal2

### DIFF
--- a/VAeval.m
+++ b/VAeval.m
@@ -1,0 +1,33 @@
+function [R0,R1] = VAeval(Z,Hes,varargin)  % Vand.+Arnoldi basis construction
+%VAEVAL  Vandermonde with Arnoldi evaluation.
+%
+% This code comes from Brubeck and Trefethen, "Lightning Stokes solver", arXiv 2020.
+% For the mathematics, see Brubeck, Nakatsukasa, and Trefethen, "Vandermonde with
+% Arnoldi", SIAM Review, 2021.
+%
+%  Input:   Z = column vector of sample points
+%         Hes = cell array of Hessenberg matrices
+%         Pol = cell array of vectors of poles, if any
+% Output:  R0 = matrix of basis vectors for functions
+%          R1 = matrix of basis vectors for derivatives
+M = length(Z); Pol = []; if nargin == 3, Pol = varargin{1}; end
+% First construct the polynomial part of the basis
+H = Hes{1}; Hes(1) = []; n = size(H,2); 
+Q = ones(M,1); D = zeros(M,1);
+for k = 1:n
+   hkk = H(k+1,k);
+   Q(:,k+1) = ( Z.*Q(:,k) - Q(:,1:k)*H(1:k,k)          )/hkk;
+   D(:,k+1) = ( Z.*D(:,k) - D(:,1:k)*H(1:k,k) + Q(:,k) )/hkk;
+end
+R0 = Q; R1 = D;
+% Next construct the pole parts of the basis, if any
+while ~isempty(Pol)
+   pol = Pol{1}; Pol(1) = [];
+   H = Hes{1}; Hes(1) = []; np = length(pol); Q = ones(M,1); D = zeros(M,1);
+   for k = 1:np
+      Zpki = 1./(Z-pol(k)); hkk = H(k+1,k);
+      Q(:,k+1) = ( Q(:,k).*Zpki - Q(:,1:k)*H(1:k,k)                   )/hkk;
+      D(:,k+1) = ( D(:,k).*Zpki - D(:,1:k)*H(1:k,k) - Q(:,k).*Zpki.^2 )/hkk;
+   end
+   R0 = [R0 Q(:,2:end)]; R1 = [R1 D(:,2:end)];
+end

--- a/VAorthog.m
+++ b/VAorthog.m
@@ -1,0 +1,32 @@
+function [Hes,R] = VAorthog(Z,n,varargin)  % Vand.+Arnoldi orthogonalization
+%VAORTHOG  Vandermonde with Arnoldi orthogonalization.
+%
+% This code comes from Brubeck and Trefethen, "Lightning Stokes solver", arXiv 2020.
+% For the mathematics, see Brubeck, Nakatsukasa, and Trefethen, "Vandermonde with
+% Arnoldi", SIAM Review, 2021.
+%
+%  Input:   Z = column vector of sample points
+%           n = degree of polynomial (>= 0)
+%         Pol = cell array of vectors of poles (optional)
+% Output: Hes = cell array of Hessenberg matrices (length 1+length(Pol))
+%           R = matrix of basis vectors
+M = length(Z); Pol = []; if nargin == 3, Pol = varargin{1}; end
+% First orthogonalize the polynomial part
+Q = ones(M,1); H = zeros(n+1,n);
+for k = 1:n       
+   q = Z.*Q(:,k);
+   for j = 1:k, H(j,k) = Q(:,j)'*q/M; q = q - H(j,k)*Q(:,j); end 
+   H(k+1,k) = norm(q)/sqrt(M); Q(:,k+1) = q/H(k+1,k);
+end
+Hes{1} = H; R = Q;
+% Next orthogonalize the pole parts, if any
+while ~isempty(Pol)
+   pol = Pol{1}; Pol(1) = [];
+   np = length(pol); H = zeros(np,np-1); Q = ones(M,1);
+   for k = 1:np       
+      q = Q(:,k)./(Z-pol(k));
+      for j = 1:k, H(j,k) = Q(:,j)'*q/M; q = q - H(j,k)*Q(:,j); end 
+      H(k+1,k) = norm(q)/sqrt(M); Q(:,k+1) = q/H(k+1,k);
+   end
+   Hes{length(Hes)+1} = H; R = [R Q(:,2:end)];
+end

--- a/conformal.m
+++ b/conformal.m
@@ -37,7 +37,9 @@ function [f, finv, pol, polinv] = conformal(C, varargin)
 % rational functions, Numer. Math. 142 (2019), 359--382.
 %
 % L. N. Trefethen, Numerical conformal mapping with rational 
-% functions, Computational Methods and Function Theory, 2020.
+% functions, Comp. Meth. Funct. Th. 20 (2020), 369-387.
+%
+% See also CONFORMAL2.
 
 %%
 %   Default algorithm:

--- a/conformal.m
+++ b/conformal.m
@@ -1,19 +1,21 @@
 function [f, finv, pol, polinv] = conformal(C, varargin)
 %% CONFORMAL  Conformal map to unit disk
-%   CONFORMAL(C, ctr) computes a conformal map F of the region bounded by the
-%   complex periodic chebfun C to the unit disk and its inverse FINV, with
-%   F(ctr) = 0 and F'(ctr) > 0.  Both maps are represented by function
-%   handles evaluating rational functions, whose poles are optionally returned
-%   in the vectors POL and POLINV.  If ctr is omitted it is set to 0.
+%   [F, FINV] = CONFORMAL(C, ctr) computes a conformal map F of the region
+%   bounded by the complex periodic chebfun C to the unit disk and its inverse
+%   FINV, with F(ctr) = 0 and F'(ctr) > 0.  Both maps are represented by
+%   function handles evaluating rational functions.  If ctr is omitted it is
+%   set to 0.
 %
 %   CONFORMAL(..., 'tol', tol) uses tolerance tol instead of the default 1e-5.
 %
-%   CONFORMAL(..., 'plots') produces plots of the map and its inverse
+%   CONFORMAL(..., 'plots') produces plots of the map and its inverse.
 %
-%   CONFORMAL(..., 'numbers') prints various quantities
+%   CONFORMAL(..., 'numbers') prints various quantities.
 %
 %   CONFORMAL(..., 'poly') uses a less robust algorithm based on polynomials
-%                          instead of the Kerzman-Stein integral equation
+%                          instead of the Kerzman-Stein integral equation.
+%
+%   [F, FINV, POL, POLINV] = CONFORMAL(...) returns the poles of F and FINV.
 %
 %   This experimental code is good for smooth simple regions, but easy to break.
 %

--- a/conformal2.m
+++ b/conformal2.m
@@ -1,0 +1,201 @@
+function [f, finv, rho, pol, polinv] = conformal2(C1, C2, varargin)
+%% CONFORMAL2  Doubly-connected conformal map to annulus
+%   [F, FINV] = CONFORMAL2(C1, C2) computes a conformal map F of the smooth
+%   annular region bounded by the two complex periodic chebfuns C1 (outer
+%   boundary) and C2 (inner) to a circular annulus and its inverse FINV.  Both
+%   maps are represented by function handles evaluating rational functions.
+%   The circular annulus has radii 1 and RHO < 1, the conformal modulus, which
+%   is determined as part of the calculation.
+%
+%   CONFORMAL2(..., 'tol', tol) uses tolerance tol instead of the default 1e-5.
+%
+%   CONFORMAL2(..., 'plots') produces plots of the map and its inverse.
+%
+%   CONFORMAL2(..., 'numbers') prints various quantities.
+%
+%   [F, FINV, RHO, POL, POLINV] = CONFORMAL2(...) returns the conformal modulus
+%   and the poles of F and FINV.
+%
+%   This experimental code is only good for very simple regions.  Easy to break.
+%
+%   Examples:
+%
+%   z = chebfun('exp(1i*pi*z)','trig');
+%   C1 = z.*abs(1+.1*z^4); C2 = .5*z.*abs(1+.2*z^3);
+%   conformal2(C1, C2, 'plots');        
+%
+%   z = chebfun('exp(pi*1i*t)','trig');
+%   C1 = z*(1+.1*randnfun(.5,'trig'));
+%   C2 = z*(.5+.1*randnfun(1,'trig'));
+%   [f, finv, rho] = conformal2(C1, C2, 'plots', 'numbers'); 
+%
+% See also CONFORMAL.
+
+%%
+%   Algorithm:
+%     (1) Use least-squares to find constant rho < 1 and harmonic u s.t.
+%         u(z) = -log(abs(z)) on C1 and  u(z) = -log(abs(z)) + log(rho) on C2
+%     (2) Set f = z*exp(u(z)+iv(z));
+%     (3) Use AAA to approximate f and its inverse by rational functions
+%
+%   Although in principle these algorithms should be imbedded in the
+%   Chebfun constructor, for simplicity in this numerically challenging
+%   area we have not done that.
+%
+% This code was written by L. N. Trefethen in October 2019.  For
+% information about the use of AAA approximation, see Gopal and Trefethen,
+% Representation of conformal maps by rational functions, Numer. Math.
+% 142 (2019), 359-382.  See also Trefethen, Numerical conformal mapping
+% with rational functions, Comp. Meth. Funct. Thy. 20 (2020), 369-387.
+
+t1 = tic;
+[tol, plots, numbers, poly] = parseinputs(C1, C2, varargin{:});
+err = Inf;
+
+w1 = warning('off', 'MATLAB:rankDeficientMatrix');
+logn = 4;
+dom1 = domain(C1); dom1 = dom1([1 end]);    % endpoints of parameter range
+dom2 = domain(C2); dom2 = dom2([1 end]);
+errvec = [];
+while err > tol
+    n = round(2^logn);                      % degree of polynomial
+    M = 8*n;                                % # of sample points on each curve
+    MM = (1:M)';
+    logn = logn + 1/2;
+    Z1 = C1(dom1(1) + MM*diff(dom1)/M);     % sample points, outer curve
+    Z2 = C2(dom2(1) + MM*diff(dom2)/M);     % sample points, inner curve
+    Z = [Z1; Z2];
+    H = -log(abs(Z));                       % RHS for Dirichlet problem
+    H(M+MM) = H(M+MM)+1;
+    n1 = 0:n;                               % exponents for real part
+    n2 = 1:n;                               % exponents for imag part
+    rvec = [zeros(M,1); ones(M,1)];
+ %  A = [real(Z.^n1) imag(Z.^n2) ...
+ %       real(Z.^-n2) imag(Z.^-n2) rvec];   % matrix for least-squares problem
+    [Hes, P] = VAorthog(Z,n);               % orthogonalize nonnegative powers
+    [Hes2, P2] = VAorthog(Z.^(-1),n);       % orthogonalize negative powers
+    A = [real(P) real(P2) -imag(P) -imag(P2) rvec];
+    N = size(A,2);
+    c = A\H;                                % soln of least-squares problem
+    logrho = 1 - c(end);
+    rho = exp(logrho)                       % conformal modulus
+    err = norm(A*c-H, inf);                 % max error
+    errvec = [errvec err];
+    c(end) = [];
+    c = reshape(A\H, [], 2)*[1; 1i];
+    F = [P P2]*c;
+    U = real(F);
+    V = imag(F);
+    W = Z.*(exp(U+1i*V));
+    if (err > tol) && (logn >= 7)
+        warning('CONFORMAL2 did not converge')
+        break
+    end
+end
+warning(w1.state, 'MATLAB:rankDeficientMatrix')
+semilogy(errvec,'.-','linewidth',1,'markersize',10), grid on, pause %%%
+
+w2 = warning('off', 'CHEBFUN:aaa:Froissart');
+[f, pol] = aaa(W, Z, 'tol', tol);           % forward map
+[finv, polinv] = aaa(Z, W, 'tol', tol);     % inverse map
+warning(w2.state, 'CHEBFUN:aaa:Froissart')
+
+%inC = inpolygon(real(pol), imag(pol), ...  % check for poles of f in region
+%                real(Z), imag(Z));
+%if max(inC) > 0
+%    warning('CONFORMAL: pole in region')
+%end
+%if min(abs(polinv)) < 1                    % check for poles of finv in disk
+%    warning('CONFORMAL: pole in disk')
+%end
+tcomp = toc(t1);
+
+% Plot solution if requested
+if plots
+    t2 = tic;
+    clf
+    LW = 'linewidth'; PO = 'position'; MS = 'markersize';
+    FW = 'fontweight'; NO = 'normal'; XT = 'xtick'; YT = 'ytick';
+    circ = exp(2i*pi*(0:300)'/300);
+  
+    h1 = axes(PO, [.04 .38 .45 .53]);       % plot C1, C2 and poles of f
+    plot([C1 C2], 'b', LW, 1)
+    axis(1.3*norm(C1,inf)*[-1 1 -1 1])
+    axis square, hold on, plot(pol, '.r', MS, 8)
+    title([num2str(length(pol)) ' poles'],FW,NO)
+  
+    h2 = axes(PO, [.52 .38 .45 .53]);       % plot annulus and poles of finv
+    plot([circ rho*circ], 'b', LW, 1), axis(1.5*[-1 1 -1 1])
+    axis square, hold on, set(gca,XT,-1:1,YT,-1:1)
+    plot(polinv, '.r', MS, 8)
+    title([num2str(length(polinv)) ' poles'],FW,NO)
+  
+    ncirc = 8;                  % plot concentric circles and their images
+    for r = rho + (1-rho)*(1:ncirc-1)/ncirc
+        axes(h1), plot(finv(r*circ), '-k', LW, .5)
+        axes(h2), plot(r*circ, '-k', LW, .5)
+    end
+
+    nrad = 16;                  % plot radii and their images
+    ray = chebpts(101,[rho 1]);
+    for k = 1:nrad
+        axes(h1), plot(finv(ray*exp(2i*pi*k/nrad)), '-k', LW, .5)
+        axes(h2), plot(ray*exp(2i*pi*k/nrad), '-k', LW, .5)
+    end
+
+    axes(h1), hold off
+    axes(h2), hold off
+    tplot = toc(t2);
+
+end
+
+% Print various quantities if requested
+if numbers
+    disp(' ')
+    fprintf('                 computation time in seconds:%6.2f\n', tcomp)
+    if plots
+        fprintf('                    plotting time in seconds:%6.2f\n', tplot)
+    end
+    fprintf('umber of sample points Z on each boundary, M:  %d\n', M)
+    fprintf('              numbers of poles of f and finv:  %d, %d\n', ...
+        length(pol), length(polinv))
+    fprintf('       boundary error norm(Z-finv(f(Z)),inf):  %6.1e\n',...
+        norm(Z-finv(f(Z)), inf))
+    fprintf('        inverse error norm(W-f(finv(W)),inf):  %6.1e\n',...
+        norm(W-f(finv(W)), inf))
+    fprintf('                 interior inverse error norm:  %6.1e\n',...
+    norm(sqrt(rho)*W(1:M)-f(finv(sqrt(rho)*W(1:M))), inf))
+    fprintf('     max error of least-squares problem, err:  %6.1e\n', err)
+    fprintf('                        polynomial degree, n:  %d\n', n)
+    fprintf('        number of real degrees of freedom, N:  %d\n', 2*n+1)
+    fprintf('condition number of least-squares matrix A:  %6.1e\n', cond(A))
+    disp(' ')
+end
+
+end   % end of conformal2
+
+function [tol, plots, numbers, poly] = parseinputs(C1, C2, varargin)
+tol = 1e-5; 
+plots = 0;
+numbers = 0;
+poly = 0;
+j = 2;
+while j < nargin
+    j = j+1;
+    v = varargin{j-2};
+    if strcmp(v, 'tol')
+        j = j+1;
+        tol = varargin{j-2};
+    elseif strcmp(v, 'plots')
+        plots = 1;
+    elseif strcmp(v, 'numbers')
+        numbers = 1;
+    elseif strcmp(v, 'poly')
+        poly = 1;
+    end
+end
+%winding_number = sum(diff(C)/C)/(2i*pi);
+%if abs(winding_number - 1) > tol
+%    error('CONFORMAL:parseinputs','C must wind once counterclockwise around 0')
+%end
+end   % end of parseinputs

--- a/tests/misc/test_conformal2.m
+++ b/tests/misc/test_conformal2.m
@@ -1,0 +1,20 @@
+% Test file for conformal2.m.
+
+function pass = test_conformal2(pref)
+
+if ( nargin < 1 )
+    pref = chebfunpref();
+end
+
+% Save the current warning state and then clear it
+[lastmsg, lastid] = lastwarn();
+lastwarn('');
+
+% First example from help text:
+z = chebfun('exp(1i*pi*z)','trig');
+C1 = z.*abs(1+.1*z^4); C2 = .5*z.*abs(1+.2*z^3);
+[f,finv,rho] = conformal2(C1, C2);        
+
+pass(1) = (abs(rho-.539197)<1e-3) && (abs(finv(f(1+0.1i))-(1+0.1i))<1e-3);
+
+end


### PR DESCRIPTION
This introduces a command `conformal2` for conformal mapping of a smooth doubly-connected annular domain onto a circular annulus.  The method is Laurent series implemented with Vandermonde-with-Arnoldi orthogonalization, followed by representation of the conformal maps in both directions by rational functions computed with AAA.

This code was promised in the paper "Numerical conformal mapping with rational functions" by me in _Computational Methods and Function Theory_, 20 (2020), 369-387.  Actually, there it was said to be an option in the `conformal` code, but I've decided to make it a separate code instead.