### PR TITLE
fix-minandmax-complex-local

### DIFF
--- a/@chebfun/max.m
+++ b/@chebfun/max.m
@@ -103,12 +103,20 @@ f = mat2cell(f); % Convert f into a cell of scalar-valued CHEBFUNs.
 
 % Loop over the FUNs:
 for k = 1:numel(f)
+    
     % Compute 1st and 2nd derivatives.
-    dfk = diff(f{k});
+    if ( isreal(f{k}) )
+        dfk = diff(f{k});
+    else
+        % Note: If F is complex-valued, absolute values are taken to determine 
+        % extrema, but the resulting values correspond to those of the original 
+        % function. To achieve this we athr computer the extrema of |f|^2:
+        dfk = diff(real(f{k}).^2 + imag(f{k}).^2);
+    end
     dfk2 = diff(dfk);
 
     % For interior extrema, look at 2nd derivative:
-    maximaLoc = feval(diff(f{k}, 2), x(:,k)) < 0;
+    maximaLoc = feval(dfk2, x(:,k)) < 0;
 
     % For end-points, look at 1st derivative:
     dfk_ends = feval(dfk, ends);

--- a/@chebfun/min.m
+++ b/@chebfun/min.m
@@ -103,12 +103,20 @@ f = mat2cell(f); % Convert f into a cell of scalar-valued CHEBFUNs.
 
 % Loop over the columns:
 for k = 1:numel(f)
+    
     % Compute 1st and 2nd derivatives.
-    dfk = diff(f{k});
+    if ( isreal(f{k}) )
+        dfk = diff(f{k});
+    else
+        % Note: If F is complex-valued, absolute values are taken to determine 
+        % extrema, but the resulting values correspond to those of the original 
+        % function. To achieve this we athr computer the extrema of |f|^2:
+        dfk = diff(real(f{k}).^2 + imag(f{k}).^2);        
+    end
     dfk2 = diff(dfk);
 
     % For interior extrema, look at 2nd derivative:
-    minimaLoc = feval(diff(f{k}, 2), x(:,k)) > 0;
+    minimaLoc = feval(dfk2, x(:,k)) > 0;
 
     % For end-points, look at 1st derivative:
     dfk_ends = feval(dfk, ends);

--- a/@chebfun/minandmax.m
+++ b/@chebfun/minandmax.m
@@ -143,7 +143,14 @@ function [y, x] = localMinAndMax(f)
 %LOCALMINANDMAX   Compute local extrema of f.
 
 % Compute the turning points:
-df = diff(f);
+if ( isreal(f) )
+    df = diff(f);
+else
+    % Note: If F is complex-valued, absolute values are taken to determine 
+    % extrema, but the resulting values correspond to those of the original 
+    % function. To achieve this we athr computer the extrema of |f|^2:
+    df = diff(real(f).^2 + imag(f).^2);
+end
 % Ensure endpoints are included:
 for k = 1:numel(df)
     df(k).pointValues([1,end],:) = 0;

--- a/tests/chebfun/test_max.m
+++ b/tests/chebfun/test_max.m
@@ -195,5 +195,11 @@ errY = y - yExact;
 errX = x - xExact;
 pass(23) = norm([errY errX], inf) < 1e3*eps*vscale(f);
 
+%% Test local maxima of complex-values functions:
+f = chebfun('sin(x)+1i*exp(-x)',[0 2*pi]);
+[y,x] = max(f, 'local');
+[~,xa] = max(abs(f), 'local');
+pass(24) = (numel(x) == 3) && ( norm(x-xa) < 100*eps*hscale(f)) && ...
+    (norm(f(x)-y) < 100*eps*vscale(f));
 
 end

--- a/tests/chebfun/test_min.m
+++ b/tests/chebfun/test_min.m
@@ -183,4 +183,11 @@ errX = x - xExact;
 pass(21) = ( norm(errX, inf) < eps*vscale(f) ) && ...
     ( y == yExact );
 
+%% Test local maxima of complex-values functions:
+f = chebfun('sin(x)+1i*exp(-x)',[0 2*pi]);
+[y,x] = min(f, 'local');
+[~,xa] = min(abs(f), 'local');
+pass(22) = (numel(x) == 3) && ( norm(x-xa) < 100*eps*hscale(f)) && ...
+    (norm(f(x)-y) < 100*eps*vscale(f));
+
 end

--- a/tests/chebfun/test_minandmax.m
+++ b/tests/chebfun/test_minandmax.m
@@ -144,5 +144,11 @@ gam = chebfun('gamma(x)',[-4 4],'blowup','on','splitting','on');
 mm = minandmax(1./gam);
 pass(14) = norm(mm - [-1.125953228398760;4.079508980001102]) < 1e4*eps;
 
+%% Test local extrema of complex-valued function
+f = chebfun('sin(x)+1i*exp(-x)',[0 2*pi]);
+[y,x] = minandmax(f, 'local');
+[ya,xa] = minandmax(abs(f), 'local');
+pass(15) = (numel(x) == 6) && ( norm(x-xa) < 100*eps*hscale(f)) && ...
+    (norm(f(x)-y) < 100*eps*vscale(f));
 
 end


### PR DESCRIPTION
Fix a bug in local min and max for complex-valued chebfuns.

Michael Overton pointed this out some time ago:
"max(f,'local') seems to be buggy when f has complex values. 
Instead of finding the local max's of the absolute value, 
it finds the ***global minimum*** of the absolute value."

```
>> % Behaviour on master branch:
>> f = chebfun('sin(x)+1i*exp(-x)',[0 2*pi])
>> max(f, 'local')
ans =
-0.000000000000000 + 0.001867442731708i

>> % Behaviour on this pull request:
>> max(f, 'local')
ans =
0.000000000000000 + 1.000000000000000i
0.998867231339625 + 0.218014398179368i
-0.999999996742742 + 0.008984016114680i```


