### PR TITLE
fix-idct-help-text

### DIFF
--- a/@chebfun/idct.m
+++ b/@chebfun/idct.m
@@ -12,7 +12,7 @@ function y = idct(u, type)
 %   Note that the above means that CHEBFUN.IDCT(U) is not the same as IDCT(U),
 %   where IDCT(U) is the implementation in the Matlab signal processing toolbox.
 %   The two are related by 
-%       IDCT(U) = CHEBFUN.DCT(E*U)
+%       IDCT(U) = CHEBFUN.IDCT(E*U)
 %   where E = sqrt(n/2)*eye(n); E(1,1) = sqrt(n);
 %
 % See also CHEBFUN.DCT, CHEBFUN.DST, CHEBFUN.IDST.

--- a/@chebfun/idct.m
+++ b/@chebfun/idct.m
@@ -13,7 +13,7 @@ function y = idct(u, type)
 %   where IDCT(U) is the implementation in the Matlab signal processing toolbox.
 %   The two are related by 
 %       IDCT(U) = CHEBFUN.DCT(E*U)
-%   where E = sqrt(2)*eye(n); E(1,1) = 2;
+%   where E = sqrt(n/2)*eye(n); E(1,1) = sqrt(n);
 %
 % See also CHEBFUN.DCT, CHEBFUN.DST, CHEBFUN.IDST.
 


### PR DESCRIPTION
Fix an inaccuracy in the chebfun.idct help text (specifically how it relates to the idct in the Signal Processing Toolbox).

```
% Note that the above means that chebfun.idct(U) is not the same as idct(U),
% where idct(U) is the implementation in the Matlab signal processing toolbox.
%    The two are related by 
%        idct(U) = CHEBFUN.DCT(E*U)
%    where E = sqrt(n/2)*eye(n); E(1,1) = sqrt(n);

U = rand(5);
n = size(U,1);
E = sqrt(n/2)*eye(n); E(1,1) = sqrt(n);
norm(chebfun.idct(E*U) - idct(U))
ans =
   3.9607e-16
```