### PR TITLE
Fix prz

### DIFF
--- a/aaa.m
+++ b/aaa.m
@@ -230,7 +230,7 @@ fj(I) = [];
 r = @(zz) reval(zz, zj, fj, wj);
 
 % Compute poles, residues and zeros:
-[pol, res, zer] = prz(r, zj, fj, wj);
+[pol, res, zer] = prz(zj, fj, wj);
 
 if ( cleanup_flag & nlawson == 0)       % Remove Froissart doublets
     [r, pol, res, zer, zj, fj, wj] = ...
@@ -445,7 +445,7 @@ w = V(:,m);
 
 % Build function handle and compute poles, residues and zeros:
 r = @(zz) reval(zz, z, f, w);
-[pol, res, zer] = prz(r, z, f, w);
+[pol, res, zer] = prz(z, f, w);
 
 end % End of CLEANUP().
 

--- a/aaatrig.m
+++ b/aaatrig.m
@@ -298,7 +298,7 @@ fj(I) = [];
 r = @(zz) revaltrig(zz, zj, fj, wj, form);
 
 % Compute poles, residues and zeros:
-[pol, res, zer] = prztrig(r, zj, fj, wj, form);
+[pol, res, zer] = prztrig(zj, fj, wj, form);
 
 if ( cleanup_flag & nlawson == 0)       % Remove Froissart doublets
     [r, pol, res, zer, zj, fj, wj] = ...
@@ -543,7 +543,7 @@ w = V(:,m);
 
 % Build function handle and compute poles, residues and zeros:
 r = @(zz) revaltrig(zz, z, f, w, form);
-[pol, res, zer] = prztrig(r, z, f, w, form);
+[pol, res, zer] = prztrig(z, f, w, form);
 
 end % End of CLEANUPTRIG().
 

--- a/prz.m
+++ b/prz.m
@@ -1,12 +1,11 @@
-function [pol, res, zer] = prz(r, zj, fj, wj)
-%PRZ   Computes poles, residues, and zeros of rational function in barycentric
-%      form.
-%   [POL, RES, ZER] = PRZ(R, ZJ, FJ, WJ) returns vectors of poles POL,
-%   residues RES, and zeros ZER of R, where R is a function handle, ZJ are
-%   the support points, FJ are the function values, and WJ are the
-%   barycentric weights.
+function [pol, res, zer] = prz(zj, fj, wj)
+%PRZ   Computes poles, residues, and zeros of a rational function in
+%      barycentric form.
+%   [POL, RES, ZER] = PRZ(ZJ, FJ, WJ) returns vectors of poles POL,
+%   residues RES, and zeros ZER of the rational function defined by
+%   support points ZJ, function values FJ, and barycentric weights WJ.
 %
-% See also AAA, MINIMAX, REVAL.
+% See also AAA, PRZTRIG, REVAL.
 
 % Copyright 2018 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.

--- a/prztrig.m
+++ b/prztrig.m
@@ -1,10 +1,9 @@
-function [pol, res, zer] = prztrig(r, zj, fj, wj, form)
-%PRZTRIG   Computes poles, residues, and zeros of a periodic rational function in 
-% trigonometric barycentric form.
-%   [POL, RES, ZER] = PRZTRIG(R, ZJ, FJ, WJ) returns vectors of poles POL,
-%   residues RES, and zeros ZER of R, where R is a function handle, ZJ are
-%   the support points, FJ are the function values, and WJ are the
-%   trigonometric barycentric weights.
+function [pol, res, zer] = prztrig(zj, fj, wj, form)
+%PRZTRIG   Computes poles, residues, and zeros of a periodic rational function
+%          in trigonometric barycentric form.
+%   [POL, RES, ZER] = PRZTRIG(ZJ, FJ, WJ) returns vectors of poles POL,
+%   residues RES, and zeros ZER of the periodic rational function defined by
+%   support points ZJ, function values FJ, and barycentric weights WJ.
 %
 % See also AAATRIG, PRZ, REVALTRIG.
 


### PR DESCRIPTION
The `prz` and `prztrig` methods are usable by users, but not advertised since they are basically tools for `aaa` and `aatrig` (curiously not for `minimax`, which uses its own code to compute poles, residues, and zeros of rational functions).  For historical reasons, `prz` and `prztrig` have an argument "r" that is never used.  This has now been deleted and the help text and `aaa` and `aaatrig` codes updated accordingly.