### PR TITLE
Feature aaa cleanup

### DIFF
--- a/aaa.m
+++ b/aaa.m
@@ -83,7 +83,7 @@ function [r, pol, res, zer, zj, fj, wj, errvec, wt] = aaa(F, varargin)
 %   complex rational minimax approximation, SIAM J. Sci. Comp. 42 (2020),
 %   A3157-A3179.
 %
-% See also CF, CHEBPADE, MINIMAX, PADEAPPROX, RATINTERP.
+% See also AAATRIG, CF, CHEBPADE, MINIMAX, PADEAPPROX, RATINTERP.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.

--- a/aaa.m
+++ b/aaa.m
@@ -417,7 +417,7 @@ Zdistances = NaN(size(pol));
 for j = 1:length(Zdistances);
    Zdistances(j) = min(abs(pol(j)-Z));
 end
-ii = find(abs(res).*Zdistances < cleanup_tol * geometric_mean_of_absF);
+ii = find(abs(res)./Zdistances < cleanup_tol * geometric_mean_of_absF);
 ni = length(ii);
 if ( ni == 0 )
     % Nothing to do.

--- a/aaa.m
+++ b/aaa.m
@@ -30,9 +30,9 @@ function [r, pol, res, zer, zj, fj, wj, errvec, wt] = aaa(F, varargin)
 %   - 'cleanup', 'off' or 0: turns off automatic removal of numerical Froissart
 %       doublets
 %   - 'cleanuptol', CLEANUPTOL: cleanup tolerance (default CLEANUPTOL = TOL).
-%       Poles with residues less than this number times the maximum absolute
-%       component of F and times the maximum distance to Z are deemed spurious
-%       by the cleanup procedure. If TOL = 0, then CLEANUPTOL defaults to 1e-13.
+%       Poles with residues less than this number times the geometric mean size
+%       of F times the maximum distance to Z are deemed spurious by the cleanup
+%       procedure. If TOL = 0, then CLEANUPTOL defaults to 1e-13.
 %   - 'lawson', NLAWSON: take NLAWSON iteratively reweighted least-squares steps
 %       to bring approximation closer to minimax; specifying NLAWSON = 0 
 %       ensures there is no Lawson iteration.  See next paragraph.
@@ -408,11 +408,16 @@ function [r, pol, res, zer, z, f, w] = ...
 % Remove spurious pole-zero pairs.
 
 % Find negligible residues:
+if any(F)
+   geometric_mean_of_absF = exp(mean(log(abs(F(F~=0)))));
+else
+   geometric_mean_of_absF = 0;
+end
 Zdistances = NaN(size(pol));
 for j = 1:length(Zdistances);
    Zdistances(j) = min(abs(pol(j)-Z));
 end
-ii = find(abs(res).*Zdistances < cleanup_tol * norm(F, inf));
+ii = find(abs(res).*Zdistances < cleanup_tol * geometric_mean_of_absF);
 ni = length(ii);
 if ( ni == 0 )
     % Nothing to do.

--- a/aaa.m
+++ b/aaa.m
@@ -31,8 +31,8 @@ function [r, pol, res, zer, zj, fj, wj, errvec, wt] = aaa(F, varargin)
 %       doublets
 %   - 'cleanuptol', CLEANUPTOL: cleanup tolerance (default CLEANUPTOL = TOL).
 %       Poles with residues less than this number times the maximum absolute
-%       component of F are deemed spurious by the cleanup procedure. If TOL = 0,
-%       then CLEANUPTOL defaults to 1e-13.
+%       component of F and times the maximum distance to Z are deemed spurious
+%       by the cleanup procedure. If TOL = 0, then CLEANUPTOL defaults to 1e-13.
 %   - 'lawson', NLAWSON: take NLAWSON iteratively reweighted least-squares steps
 %       to bring approximation closer to minimax; specifying NLAWSON = 0 
 %       ensures there is no Lawson iteration.  See next paragraph.
@@ -400,14 +400,19 @@ end
 end % End of PARSEINPUT().
 
 
-%% Cleanup
+%% Cleanup.  In June 2022 the residue size test was changed to be relative to 
+%            the distance to the approximation set Z.
 
 function [r, pol, res, zer, z, f, w] = ...
     cleanup(r, pol, res, zer, z, f, w, Z, F, cleanup_tol) 
 % Remove spurious pole-zero pairs.
 
 % Find negligible residues:
-ii = find(abs(res) < cleanup_tol * norm(F, inf));
+Zdistances = NaN(size(pol));
+for j = 1:length(Zdistances);
+   Zdistances(j) = min(abs(pol(j)-Z));
+end
+ii = find(abs(res).*Zdistances < cleanup_tol * norm(F, inf));
 ni = length(ii);
 if ( ni == 0 )
     % Nothing to do.

--- a/aaa.m
+++ b/aaa.m
@@ -31,7 +31,7 @@ function [r, pol, res, zer, zj, fj, wj, errvec, wt] = aaa(F, varargin)
 %       doublets
 %   - 'cleanuptol', CLEANUPTOL: cleanup tolerance (default CLEANUPTOL = TOL).
 %       Poles with residues less than this number times the geometric mean size
-%       of F times the maximum distance to Z are deemed spurious by the cleanup
+%       of F times the minimum distance to Z are deemed spurious by the cleanup
 %       procedure. If TOL = 0, then CLEANUPTOL defaults to 1e-13.
 %   - 'lawson', NLAWSON: take NLAWSON iteratively reweighted least-squares steps
 %       to bring approximation closer to minimax; specifying NLAWSON = 0 
@@ -406,7 +406,7 @@ end % End of PARSEINPUT().
 function [r, pol, res, zer, z, f, w] = ...
     cleanup(r, pol, res, zer, z, f, w, Z, F, cleanup_tol) 
 % Remove spurious pole-zero pairs.
-
+keyboard
 % Find negligible residues:
 if any(F)
    geometric_mean_of_absF = exp(mean(log(abs(F(F~=0)))));

--- a/aaatrig.m
+++ b/aaatrig.m
@@ -36,8 +36,8 @@ function [r, pol, res, zer, zj, fj, wj, errvec, wt] = aaatrig(F, varargin)
 %       doublets
 %   - 'cleanuptol', CLEANUPTOL: cleanup tolerance (default CLEANUPTOL = TOL).
 %       Poles with residues less than this number times the maximum absolute
-%       component of F are deemed spurious by the cleanup procedure. If TOL = 0,
-%       then CLEANUPTOL defaults to 1e-13.
+%       component of F and times the maximum distance to Z are deemed spurious
+%       by the cleanup procedure. If TOL = 0, then CLEANUPTOL defaults to 1e-13.
 %   - 'lawson', NLAWSON: take NLAWSON iteratively reweighted least-squares steps
 %       to bring approximation closer to minimax; specifying NLAWSON = 0 
 %       ensures there is no Lawson iteration.  See next paragraph.
@@ -473,13 +473,19 @@ end
 end % End of PARSEINPUT().
 
 
-%% Cleanup
+%% Cleanup.  In June 2022 the residue size test was changed to be relative to
+%            the distance to the approximation set Z.
 
 function [r, pol, res, zer, z, f, w] = ...
     cleanuptrig(r, form, finfP, finfM, pol, res, zer, z, f, w, Z, F, cleanup_tol) 
 % Remove spurious pole-zero pairs.
 
 % Find negligible residues:
+Zdistances = NaN(size(pol));
+for j = 1:length(Zdistances);
+   Zdistances(j) = min(abs(pol(j)-Z));
+end
+ii = find(abs(res).*Zdistances < cleanup_tol * norm(F, inf));
 ii = find(abs(res) < cleanup_tol * norm(F, inf));
 ni = length(ii);
 if ( ni == 0 )

--- a/aaatrig.m
+++ b/aaatrig.m
@@ -490,7 +490,7 @@ Zdistances = NaN(size(pol));
 for j = 1:length(Zdistances);
    Zdistances(j) = min(abs(pol(j)-Z));
 end
-ii = find(abs(res).*Zdistances < cleanup_tol * geometric_mean_of_absF);
+ii = find(abs(res)./Zdistances < cleanup_tol * geometric_mean_of_absF);
 ni = length(ii);
 if ( ni == 0 )
     % Nothing to do.

--- a/aaatrig.m
+++ b/aaatrig.m
@@ -86,11 +86,11 @@ function [r, pol, res, zer, zj, fj, wj, errvec, wt] = aaatrig(F, varargin)
 %   [1] Yuji Nakatsukasa, Olivier Sete, Lloyd N. Trefethen, "The AAA algorithm
 %   for rational approximation", SIAM J. Sci. Comp. 40 (2018), A1494-A1522.
 %
-%   [2] Yuji Nakasukasa and Lloyd N. Trefethen, "An algorithm for real and
+%   [2] Yuji Nakatsukasa and Lloyd N. Trefethen, "An algorithm for real and
 %   complex rational minimax approximation", SIAM J. Sci. Comp. (2020).
 %   
 %   [3] Peter J. Baddoo, "The AAAtrig algorithm for rational approximation 
-%   of periodic functions", arXiv (2020).
+%   of periodic functions", SIAM J. Sci. Comp. (2021).
 %
 % See also AAA, TRIGRATINTERP, CHEBPADE, MINIMAX, PADEAPPROX.
 

--- a/aaatrig.m
+++ b/aaatrig.m
@@ -35,9 +35,9 @@ function [r, pol, res, zer, zj, fj, wj, errvec, wt] = aaatrig(F, varargin)
 %   - 'cleanup', 'off' or 0: turns off automatic removal of numerical Froissart
 %       doublets
 %   - 'cleanuptol', CLEANUPTOL: cleanup tolerance (default CLEANUPTOL = TOL).
-%       Poles with residues less than this number times the maximum absolute
-%       component of F and times the maximum distance to Z are deemed spurious
-%       by the cleanup procedure. If TOL = 0, then CLEANUPTOL defaults to 1e-13.
+%       Poles with residues less than this number times the geometric mean size
+%       of F times the maximum distance to Z are deemed spurious by the cleanup
+%       procedure. If TOL = 0, then CLEANUPTOL defaults to 1e-13.
 %   - 'lawson', NLAWSON: take NLAWSON iteratively reweighted least-squares steps
 %       to bring approximation closer to minimax; specifying NLAWSON = 0 
 %       ensures there is no Lawson iteration.  See next paragraph.
@@ -481,12 +481,16 @@ function [r, pol, res, zer, z, f, w] = ...
 % Remove spurious pole-zero pairs.
 
 % Find negligible residues:
+if any(F)
+   geometric_mean_of_absF = exp(mean(log(abs(F(F~=0)))));
+else
+   geometric_mean_of_absF = 0;
+end
 Zdistances = NaN(size(pol));
 for j = 1:length(Zdistances);
    Zdistances(j) = min(abs(pol(j)-Z));
 end
-ii = find(abs(res).*Zdistances < cleanup_tol * norm(F, inf));
-ii = find(abs(res) < cleanup_tol * norm(F, inf));
+ii = find(abs(res).*Zdistances < cleanup_tol * geometric_mean_of_absF);
 ni = length(ii);
 if ( ni == 0 )
     % Nothing to do.

--- a/aaatrig.m
+++ b/aaatrig.m
@@ -36,7 +36,7 @@ function [r, pol, res, zer, zj, fj, wj, errvec, wt] = aaatrig(F, varargin)
 %       doublets
 %   - 'cleanuptol', CLEANUPTOL: cleanup tolerance (default CLEANUPTOL = TOL).
 %       Poles with residues less than this number times the geometric mean size
-%       of F times the maximum distance to Z are deemed spurious by the cleanup
+%       of F times the minimum distance to Z are deemed spurious by the cleanup
 %       procedure. If TOL = 0, then CLEANUPTOL defaults to 1e-13.
 %   - 'lawson', NLAWSON: take NLAWSON iteratively reweighted least-squares steps
 %       to bring approximation closer to minimax; specifying NLAWSON = 0 


### PR DESCRIPTION
AAA has had a problem in approximating functions with singularities.  Poles should be exponentially clustered near the singularities with exponentially decreasing residues, but the "cleanup" procedure was removing them.  This has now been changed so that the test of size of residue is scaled by distance to the approximation set.  The same change was made in AAATRIG.

One complication came up.  Sometimes a pole is right on the boundary of the approximation set, and AAA is usually good at catching this.  To preserve this feature, the scaling of the residue test, which used to involve the maximum size of the function F on the set Z, is not based on the geometric mean size of F on Z.

Various tests have been run to confirm that this change in Cleanup should not have serious effects.  Of course the Chebfun tests have been run, and so have the examples in the AAA and AAATRIG test files.  Additionally, various AAA demonstration codes that I have in my files have been run.  These still work, and in some cases, the change has enabled me to remove "cleanup, off" instructions that never should have had to be there.