### PR TITLE
Feature-Gauss-Jacobi-Lobatto-quad

### DIFF
--- a/lobpts.m
+++ b/lobpts.m
@@ -10,7 +10,7 @@ function [x, w, v] = lobpts(n, alp, bet)
 %  scaled so that max(abs(V)) = 1.
 %
 %  [...] = LOBPTS(N, ALP, BET) is similar, but for the Gauss-Jacobi-Lobatto
-%  nodes and weights. Here ALP and BET should be scalars > -1/2.
+%  nodes and weights. Here ALP and BET should be scalars > -1.
 %
 %  In each case, N should be an integer greater than or equal to 2.
 %

--- a/radaupts.m
+++ b/radaupts.m
@@ -10,7 +10,7 @@ function [x, w, v] = radaupts(n, alp, bet)
 %  so that max(abs(V)) = 1.
 %
 %  [...] = RADUAPTS(N, ALP, BET) is similar, but for the Gauss-Jacobi-Radau
-%  nodes and weights. Here ALP and BET should be scalars > -1/2.
+%  nodes and weights. Here ALP and BET should be scalars > -1.
 %
 %  In each case, N should be a positive integer.
 %
@@ -65,7 +65,7 @@ if ( alp == 0 && bet == 0 )
 else
     % See Walter Gautschi, "Gauss–Radau formulae for Jacobi and Laguerre
     % weight functions", Mathematics and Computers in Simulation, (2000).
-    w = [2^(alp+bet+1)*beta(alp+1,n)*beta(bet+n,alp+1)*(alp+1), wi];
+    w = [2^(alp+bet+1)*beta(bet+1,n)*beta(alp+n,bet+1)*(bet+1), wi];
 end
 
 %% Barycentric weights:

--- a/radaupts.m
+++ b/radaupts.m
@@ -1,6 +1,6 @@
-function [x, w, v] = radaupts(n, varargin)
-%RADAUPTS   Gauss-Legendre-Radau quadrature nodes and weights.
-%  RADAUPTS(N) returns N Legendre-Radau points X in (-1,1).
+function [x, w, v] = radaupts(n, alp, bet)
+%RADAUPTS   Gauss-Jacobi-Radau quadrature nodes and weights.
+%  RADAUPTS(N) returns N Legendre-Radau points X in [-1,1).
 %
 %  [X, W] = RADAUPTS(N) returns also a row vector W of weights for
 %  Gauss-Legendre-Lobatto quadrature.
@@ -9,9 +9,12 @@ function [x, w, v] = radaupts(n, varargin)
 %  the barycentric formula corresponding to the points X. The weights are scaled
 %  so that max(abs(V)) = 1.
 %
+%  [...] = RADUAPTS(N, ALP, BET) is similar, but for the Gauss-Jacobi-Radau
+%  nodes and weights. Here ALP and BET should be scalars > -1/2.
+%
 %  In each case, N should be a positive integer.
 %
-% See also CHEBPTS, LEGPTS, JACPTS, LEGPOLY, LOBPTS.
+% See also CHEBPTS, LEGPTS, JACPTS, LEGPOLY, JACPOLY, LOBPTS.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
@@ -36,32 +39,39 @@ function [x, w, v] = radaupts(n, varargin)
 
 % TODO: Scaled domains?
 
+if ( nargin < 3 )
+    % Default to Gauss-Legendre-Lobatto:
+    alp = 0; bet = 0;
+end
+
 %% Trivial cases:
 if ( n == 1 )
     x = -1;
-    w = 2;
+    w = 2^(1+alp+bet)*beta(1+alp,1+bet);
     v = 1;
-    return
-elseif ( n == 1 )
-    x = [-1, 1/3];
-    w = [.5 ; 1.5];
-    v = [-1 ; 1];
     return
 end
 
 %% Call JACPTS():
-[x, w, v] = jacpts(n - 1, 0, 1, varargin{:});
+[xi, w, v] = jacpts(n-1, alp, bet+1);
 
 %% Nodes:
-x = [-1 ; x];
+x = [-1 ; xi];
 
 %% Quadrature weights:
-w = [2/n^2, w./(1 + x(2:end).')];
+wi = w./(1 + xi.');
+if ( alp == 0 && bet == 0 )
+    w = [2/n^2, wi];
+else
+    % See Walter Gautschi, "Gauss–Radau formulae for Jacobi and Laguerre
+    % weight functions", Mathematics and Computers in Simulation, (2000).
+    w = [2^(alp+bet+1)*beta(alp+1,n)*beta(bet+n,alp+1)*(alp+1), wi];
+end
 
 %% Barycentric weights:
-v = v./(1 + x(2:end));
+v = v./(1 + xi);
 v = v/max(abs(v));
-v1 = -abs(sum(x(2:end).*v));
+v1 = -sum(v);
 v = [v1 ; v];
 
 end

--- a/tests/misc/test_lobpts.m
+++ b/tests/misc/test_lobpts.m
@@ -14,4 +14,18 @@ pass(5) = abs(w(37) - 0.029306411216166) < tol;
 pass(6) = abs(v(37) + 0.622355798366776) < tol;
 pass(7) = ( x(1) == -1 && x(n) == 1 );
 
+n = 8;
+alp = 0.3; bet = 1.2;
+[x,w,v] = lobpts(n, alp, bet);
+xc = chebfun('x');
+err = zeros(2*n-1-1,1);
+for k = 0:2*n-1-2
+    Tk = chebpoly(k);
+    F = (1-xc)^alp*(1+xc)^bet*Tk;
+    err(k+1) = sum(F)-w*Tk(x);
+end
+pass(8) = norm(err, inf) < tol;
+v2 = baryWeights(x);
+pass(9) = norm(v-v2,inf) < tol | norm(v+v2,inf) < tol;
+
 end

--- a/tests/misc/test_radaupts.m
+++ b/tests/misc/test_radaupts.m
@@ -1,4 +1,4 @@
-function pass = test_lobpts(pref)
+function pass = test_radaupts(pref)
 
 % Choose a tolerance:
 tol = 1e-14;
@@ -13,5 +13,19 @@ pass(4) = abs(x(37) - 0.908847278001044) < tol;
 pass(5) = abs(w(37) - 0.031190846817016) < tol;
 pass(6) = abs(v(37) + 0.171069152683909) < tol;
 pass(7) = x(1) == -1;
+
+n = 8;
+alp = 0.3; bet = 1.2;
+[x,w,v] = radaupts(n, alp, bet);
+xc = chebfun('x');
+err = [];
+for k = 0:2*n-1-1
+    Tk = chebpoly(k);
+    F = (1-xc)^alp*(1+xc)^bet*Tk;
+    err(k+1) = sum(F)-w*Tk(x);
+end
+pass(8) = norm(err, inf) < tol;
+v2 = baryWeights(x);
+pass(9) = norm(v-v2,inf) < tol | norm(v+v2,inf) < tol;
 
 end


### PR DESCRIPTION
The approach we use to compute the Gauss-Legendre-Lobatto nodes in `lobpts` extends to the Jacobi-Lobatto case. The same is true for Gauss-Jacobi-Radau points.

One could solve for the missing weights at the end(s), but there are even explicit formulas (due to Gautschi).

```
>> [x, w, v] = lobpts(4, .2, .7)
x =
  -1.000000000000000
  -0.338147393222043
   0.483074929453927
   1.000000000000000
w =
  Columns 1 through 2
   0.052000500524441   0.644040571638338
  Columns 3 through 4
   0.859532535973245   0.148340882172585
v =
  -0.320698598703037
   0.865616354236654
  -1.000000000000000
   0.455082244466383
```
