### PR TITLE
spin:  Recurse on SUBSREF when accessing properties.

### DIFF
--- a/@spinoperator/subsref.m
+++ b/@spinoperator/subsref.m
@@ -15,8 +15,15 @@ switch index(1).type
     case '.'
         
         % Allow access to any of the properties of S:
-        varargout = {S.(idx)};
-        
+        out = S.(idx);
+
+        % Recurse on SUBSREF:
+        if ( numel(index) > 1)
+            out = subsref(out, index(2:end));
+        end
+
+        varargout = {out};
+
     case '()'
         
         % Evaluate the operator, i.e., wrapper for SPINOPERATOR/FEVAL:

--- a/tests/spinop/test_spinop.m
+++ b/tests/spinop/test_spinop.m
@@ -14,4 +14,7 @@ S = spinop(dom, tspan);
 pass(2) = isequal(S.domain, dom);
 pass(3) = isequal(S.tspan, tspan);
 
+% Test recursive SUBSREF:
+pass(4) = isequal(S.domain(2), 2*pi);
+
 end

--- a/tests/spinop2/test_spinop2.m
+++ b/tests/spinop2/test_spinop2.m
@@ -14,4 +14,7 @@ S = spinop2(dom, tspan);
 pass(2) = isequal(S.domain, dom);
 pass(3) = isequal(S.tspan, tspan);
 
+% Test recursive SUBSREF:
+pass(4) = isequal(S.domain([2 4]), [2*pi 2*pi]);
+
 end

--- a/tests/spinop3/test_spinop3.m
+++ b/tests/spinop3/test_spinop3.m
@@ -14,4 +14,7 @@ S = spinop3(dom, tspan);
 pass(2) = isequal(S.domain, dom);
 pass(3) = isequal(S.tspan, tspan);
 
+% Test recursive SUBSREF:
+pass(4) = isequal(S.domain([2 4 6]), [2*pi 2*pi 2*pi]);
+
 end


### PR DESCRIPTION
If we don't do this, we can't further index properties that are returned without storing them in a separate variable.  This results in unexpected behavior, e.g.,

    >> S = spinop('ks');
    >> S.domain(2)
    ans =
       1.0e+02 *
                       0   1.005309649148734

With this fix in place, we get the expected result:

    >> S = spinop('ks');
    >> S.domain(2)
    ans =
         1.005309649148734e+02