### PR TITLE
minor fixes for the chebfun3f constructor

### DIFF
--- a/@chebfun3/chebfun3f.m
+++ b/@chebfun3/chebfun3f.m
@@ -327,14 +327,12 @@ while ~happy
         [K, QWK] = DEIM(QW);
 
         % Simplification:
-        % (Take a linear combination of the columns = faster)
         lenU = standardChop(chebvals2chebcoeffs(sum(Uf,2)), pref.chebfuneps);
         lenV = standardChop(chebvals2chebcoeffs(sum(Vf,2)), pref.chebfuneps);
         lenW = standardChop(chebvals2chebcoeffs(sum(Wf,2)), pref.chebfuneps);
-%         % (Full simplify = slower)
-%         lenU = length(simplify(chebfun(Uf, [dom(1),dom(2)], pref), pref.chebfuneps));
-%         lenV = length(simplify(chebfun(Vf, [dom(3),dom(4)], pref), pref.chebfuneps));
-%         lenW = length(simplify(chebfun(Wf, [dom(5),dom(6)], pref), pref.chebfuneps));
+        lenU = max(lenU,size(Uf,2));
+        lenV = max(lenV,size(Vf,2));
+        lenW = max(lenW,size(Wf,2));
 
         % Convert to coefficients and simplify:
         QU = chebvals2chebcoeffs(QU); QU = QU(1:lenU,:);
@@ -417,7 +415,11 @@ if ( vectorize == 0 ) % we can use the efficient evaluations
     z = zeros([1,1,n(3)]);
     z(1,1,:) = K;
     Z = repmat(z,n(1),n(2),1);
-    T = ff(X,Y,Z);
+    if numel(X) > 0
+        T = ff(X,Y,Z);
+    else
+        T = []; 
+    end
 else % we need for loops as f is not vectorizable
     T = zeros(size(I,2),size(J,2),size(K,2));
     for i = 1:size(I,2)

--- a/@chebfun3/constructor.m
+++ b/@chebfun3/constructor.m
@@ -63,7 +63,15 @@ end
 
 % Use alternative chebfun3f constructor:
 if ( strcmpi(prefStruct.constructor, 'chebfun3f') )
+    if isa(tech,'trigtech')
+        error('CHEBFUN:CHEBFUN3:constructor:chebfun3f', ...
+            'The chebfun3f constructor is not compatible with the trig flag.');
+    end
     f = chebfun3.chebfun3f(f, op, pref, dom, vectorize);
+    if ( fixedRank )
+        % Simplify the rank if requested.
+        f = fixTheRank(f , fixedRank);
+    end
     return
 end
 


### PR DESCRIPTION
ensured that the chebfun3f constructor accepts chebfun3 objects as input functions

prevented collapsing dimensions in phase 3 of the chebfun3f constructor

ensured that the fixedRank setting works with the chebfun3f constructor 

now throws an error when the non-compatible flags 'trig' and 'chebfun3f' are set simultaneously