### PR TITLE
change prz to remove zero weights to avoid spurious poles

### DIFF
--- a/prz.m
+++ b/prz.m
@@ -10,6 +10,8 @@ function [pol, res, zer] = prz(zj, fj, wj)
 % Copyright 2018 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
+ix = find(wj==0); % indices w/ zero weights; to be removed to avoid spurious poles
+wj(ix) = []; fj(ix) = []; zj(ix) = [];
 m = length(wj);
 
 % Compute poles via generalized eigenvalue problem:


### PR DESCRIPTION
The prz.m code, when the input vector wj contains an entry that is exactly 0, outputs a spurious pole that is not a pole of the rational function. This is because the generalized eigenvalue problem that the prz code is based on proceeds by multiplying the node polynomial to each partial fraction in the barycentric form, then finding the roots of that polynomial. This fix remedies this issue. 
