### PR TITLE
fix randnfun lambda

### DIFF
--- a/randnfun.m
+++ b/randnfun.m
@@ -77,7 +77,8 @@ if trig    % periodic case: finite Fourier-Wiener series.
 
 else       % nonperiodic case: call periodic case and restrict
 
-    dom2 = dom(1) + [0 1.2*diff(dom)];
+    dx = max(0.2,2*lambda/diff(dom));
+    dom2 = dom(1) + [0 (1+dx)*diff(dom)];
     m = round(diff(dom)/lambda);
 
     if lambda == inf


### PR DESCRIPTION
For large wavelength lambda, randnfun should give results that are nearly constant, but not exactly constant.  For example, this is wrong:
```
>> rng(1), svd(randnfun(100,3))
ans =
   2.187063552007912
   0.000000000000000
   0.000000000000000
```
I've made a change so that now we get more reasonable results:
```
>> rng(1), svd(randnfun(100,3))
ans =
   1.033145328179523
   0.067353879945334
   0.000180359044226
```
The problem was in the "circulant embedding" part of the computation.  randnfun uses a subset of an interval on which a periodic random function is constructed.  It was defining the subset by
```
     dom2 = dom(1) + [0 1.2*diff(dom)];
```
but I've changed this to
```

    dx = max(0.2,2*lambda/diff(dom));
   dom2 = dom(1) + [0 (1+dx)*diff(dom)];
```