### PR TITLE
Vectorize chebfun3/feval in the case of unstructured evaluation points

### DIFF
--- a/@chebfun3/feval.m
+++ b/@chebfun3/feval.m
@@ -113,14 +113,14 @@ if ( (m == 1) && (n>1) ) % Row vector instead of column vector
     zVec = zVec.';
 end
 
-outVec = zeros(size(xVec));
 colsVals = f.cols(xVec); % So, colsVals(:,j) = feval(f.cols(:,j),xVec).
 rowsVals = f.rows(yVec);
 tubesVals = f.tubes(zVec);
-for i = 1:size(xVec, 1) % TODO: How to vectorize this?
-    outVec(i) = chebfun3.txm(chebfun3.txm(chebfun3.txm(f.core,...
-        colsVals(i,:), 1), rowsVals(i,:), 2), tubesVals(i,:), 3);
-end
+
+txm1 = chebfun3.txm(f.core, colsVals, 1);
+txm2 = pagemtimes(permute(txm1, [3 2 1]), permute(rowsVals, [2 3 1]));
+txm3 = sum(txm2 .* permute(tubesVals, [2 3 1]), 1);
+outVec = reshape(txm3, size(xVec));
 
 if ( (m == 1) && (n > 1) )
     outVec = outVec.';


### PR DESCRIPTION
This pull request significantly speeds up `chebfun3`'s `feval` when the evaluation points are unstructured (i.e. not a tensor-product grid). See below for a comparison:

```
f = chebfun3(@(x,y,z) sin(x.*y.*z));

n = 50000;
x = 2*rand(n,1)-1;
y = 2*rand(n,1)-1;
z = 2*rand(n,1)-1;

tic
ff = f(x,y,z);
toc

% Before this PR: 2.247853s
% After this PR:  0.028487s
```