### PR TITLE
tweak to Lawson, only when sign on is specified

### DIFF
--- a/aaa.m
+++ b/aaa.m
@@ -213,6 +213,9 @@ if ( nlawson > 0 )                         % Lawson iteration
         end
         err = F - R; abserr = abs(err);
         wt_new = wt.*abserr; wt_new = wt_new/norm(wt_new,inf);
+        if (sign_flag == 1) & (stepno > 5)
+           wt_new = (wt_new + wt)/2;       % experimental tweak added July 2024
+        end
         maxerrold = maxerr;
         maxerr = max(abserr);
     end


### PR DESCRIPTION
This is a tweak to AAA-Lawson (namely, underrelaxation) that seems to make a nice difference in suppressing oscillations that stop convergence.  It needs to be explored thoroughly, and may certainly evolve as we do that.  For the moment it's desirable to have it in Chebfun since we're doing a lot of approximation of sign functions for Zolotarev purposes, and the risk is negligible since the tweak only applies to a non-default Lawson option that was introduced just two days ago.