### PR TITLE
AAA Lawson damping

### DIFF
--- a/aaa.m
+++ b/aaa.m
@@ -101,7 +101,7 @@ if ( needZ )
     % Z was not provided.  Try to resolve F on its domain.
     [r, pol, res, zer, zj, fj, wj, errvec] = ...
         aaa_autoZ(F, dom, tol, mmax, cleanup_flag, cleanup_tol, mmax_flag, ...
-            nlawson, degree_flag, degree);
+            nlawson, dampratio, degree_flag, degree, sign_flag);
     return
 end
 
@@ -586,7 +586,7 @@ end  % End of CLEANUP2.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%   AAA_AUTOZ   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function [r, pol, res, zer, zj, fj, wj, errvec] = ...
     aaa_autoZ(F, dom, tol, mmax, cleanup_flag, cleanup_tol, mmax_flag, ...
-               nlawson, degree_flag, degree)
+               nlawson, dampratio, degree_flag, degree, sign_flag)
 % Automated choice of sample set
 
 % Flag if function has been resolved:
@@ -600,11 +600,12 @@ for n = 5:14
     if degree_flag
        [r, pol, res, zer, zj, fj, wj, errvec] = aaa(F, Z, 'tol', tol, ...
           'mmax', mmax, 'cleanup', cleanup_flag, 'cleanuptol', cleanup_tol, ...
-          'lawson', nlawson, 'degree', degree);
+          'lawson', nlawson, 'sign', sign_flag, 'damping', dampratio, ...
+          'degree', degree);
     else
        [r, pol, res, zer, zj, fj, wj, errvec] = aaa(F, Z, 'tol', tol, ...
           'mmax', mmax, 'cleanup', cleanup_flag, 'cleanuptol', cleanup_tol, ...
-          'lawson', nlawson);
+          'lawson', nlawson, 'sign', sign_flag, 'damping', dampratio);
     end
     % Test if rational approximant is accurate:
     abstol = tol * norm(F(Z), inf);

--- a/tests/chebfun/test_aaa.m
+++ b/tests/chebfun/test_aaa.m
@@ -127,6 +127,17 @@ F = [1 0 0];
 r = aaa(F,X);
 pass(28) = (norm(F-r(X)) == 0);
 
+X = chebpts(200); F = max(X,0);
+deg = 4;
+r = aaa(F,X,'degree',4,'lawson',100,'damping',0.2);
+err = norm(F-r(X),inf); pass(29) = abs(err-.006) < .002;
+r = aaa(F,X,'degree',4,'lawson',100,'damping',0.2,'sign',1);
+err = norm(F-r(X),inf); pass(30) = abs(err-.006) < .002;
+
+X = chebpts(1000,[0 10]); F = 1./(1+exp(50./(X-2)));   % Fermi-Dirac
+r = aaa(F,X,'degree',12,'lawson',100,'damping',0.85,'sign',1);
+err = norm(F-r(X),inf), pass(30) = abs(err-.000317) < .0001;
+
 warning('on', 'AAA:Froissart');
 
 end

--- a/tests/chebfun/test_aaa.m
+++ b/tests/chebfun/test_aaa.m
@@ -131,12 +131,17 @@ X = chebpts(200); F = max(X,0);
 deg = 4;
 r = aaa(F,X,'degree',4,'lawson',100,'damping',0.2);
 err = norm(F-r(X),inf); pass(29) = abs(err-.006) < .002;
-r = aaa(F,X,'degree',4,'lawson',100,'damping',0.2,'sign',1);
+r = aaa(F,X,'degree',4,'lawson',100,'damping',0.5,'sign',1);
 err = norm(F-r(X),inf); pass(30) = abs(err-.006) < .002;
 
 X = chebpts(1000,[0 10]); F = 1./(1+exp(50./(X-2)));   % Fermi-Dirac
 r = aaa(F,X,'degree',12,'lawson',100,'damping',0.85,'sign',1);
-err = norm(F-r(X),inf), pass(31) = abs(err-.000317) < .0001;
+err = norm(F-r(X),inf); pass(31) = abs(err-.000317) < .0001;
+
+f = @(x) max(x,0);
+r = aaa(f,'degree',8,'damping',.5,'lawson',200);
+xx = linspace(-1,1,300);
+err = norm(f(xx)-r(xx),inf); pass(32) = abs(err-.0006) < .001;
 
 warning('on', 'AAA:Froissart');
 

--- a/tests/chebfun/test_aaa.m
+++ b/tests/chebfun/test_aaa.m
@@ -136,7 +136,7 @@ err = norm(F-r(X),inf); pass(30) = abs(err-.006) < .002;
 
 X = chebpts(1000,[0 10]); F = 1./(1+exp(50./(X-2)));   % Fermi-Dirac
 r = aaa(F,X,'degree',12,'lawson',100,'damping',0.85,'sign',1);
-err = norm(F-r(X),inf), pass(30) = abs(err-.000317) < .0001;
+err = norm(F-r(X),inf), pass(31) = abs(err-.000317) < .0001;
 
 warning('on', 'AAA:Froissart');
 


### PR DESCRIPTION
This change to AAA adds a new feature to improve performance in difficult AAA-Lawson cases: `'damping',d` to introduce a damping ratio other than the default of 1.  There will be no effect on codes that do not specify `'damping'`....

...with one small exception: the `'sign'` flag now only affects AAA iteration as before, not AAA-Lawson iteration, since its rather mysterious action in that case is now supplanted by this less mysterious damping option.

See Trefethen unpublished memo Rat348 for illustrations.  This change is likely to be improved upon the future, but for the moment, it increases AAA's ability to get minimax approximations in difficult cases, like the Fermi-Dirac example from Fig. 5 of Nakatsukasa & Trefethen 2020.

Hopefully @heatherw3521 can take a look, and @nakatsukasayuji will also be interested.