### PR TITLE
Feature sparse colloc discretisations

### DIFF
--- a/@chebcolloc/compose.m
+++ b/@chebcolloc/compose.m
@@ -13,10 +13,23 @@ n = disc.dimension;
 
 % Find the collocation points and create an empty functional.
 [x, ~, v] = functionPoints(disc);
+
+tmp = disc;
+xx = {}; vv = {};
+for k = 1:numel(disc.domain)-1
+    tmp.domain = disc.domain(k:k+1);
+    tmp.dimension = disc.dimension(k);
+    [xx{k}, ~, vv{k}] = functionPoints(tmp);
+    xx{k}(1) = xx{k}(1)+1e-14*(xx{k}(2)-xx{k}(1));
+    xx{k}(end) = xx{k}(end)+1e-14*(xx{k}(end-1)-xx{k}(end));
+end
+x = vertcat(xx{:});
+v = vertcat(vv{:});
+
+% keyboard
 offset = cumsum([0 ; n(:)]);
 N = offset(end);
 E = zeros(1, N);
-
 % Evaluate the given input at x:
 y = y(x);
 % Find which point is in which subinterval

--- a/@chebcolloc/diff.m
+++ b/@chebcolloc/diff.m
@@ -11,7 +11,7 @@ function D = diff(disc, m)
 
 if ( m == 0 )
     % Trivial case:
-    D = eye(sum(disc.dimension));
+    D = speye(sum(disc.dimension));
     
 else
     % Find the diagonal blocks.
@@ -38,7 +38,8 @@ else
     end
     
     % Assemble!
-    D = blkdiag(blocks{:});
+    D = blkdiag(sparse([]),blocks{:});
+    % D = blkdiag(blocks{:});
 end
 
 end

--- a/@chebcolloc/diff.m
+++ b/@chebcolloc/diff.m
@@ -49,8 +49,7 @@ else
     end
 
     % Assemble!
-    % D = blkdiag(blocks{:}); % <-- Lots of overhead here.
-    D = matlab.internal.math.blkdiag(blocks{:});
+    D = blkdiag(blocks{:});
 end
 
 end

--- a/@chebcolloc/diff.m
+++ b/@chebcolloc/diff.m
@@ -9,10 +9,16 @@ function D = diff(disc, m)
 %  Copyright 2017 by The University of Oxford and The Chebfun Developers.
 %  See http://www.chebfun.org/ for Chebfun information.
 
+pref = cheboppref;
+
 if ( m == 0 )
     % Trivial case:
-    D = speye(sum(disc.dimension));
-    
+    if ( pref.sparse )
+        D = speye(sum(disc.dimension));
+    else
+        D = eye(sum(disc.dimension));
+    end
+
 else
     % Find the diagonal blocks.
     
@@ -26,20 +32,25 @@ else
     nUnique = unique(n);
     
     % Create a discretization matrix for each unique discretization size:
-    Dn = cell(max(nUnique));
+    Dn = cell(max(nUnique),1);
     for nn = nUnique
         Dn{nn} = disc.diffmat(nn, m);
     end
-    
+    if ( pref.sparse ) % Sparsify
+        for nn = nUnique
+            Dn{nn} = sparse(Dn{nn});
+        end
+    end
+
     % Scale the blocks appropriately, based on each subinterval length:
-    blocks = cell(numIntervals);
+    blocks = cell(numIntervals,1);
     for k = 1:numIntervals
         blocks{k} = Dn{n(k)} * (2/lengths(k))^m;
     end
-    
+
     % Assemble!
-    D = blkdiag(sparse([]),blocks{:});
-    % D = blkdiag(blocks{:});
+    % D = blkdiag(blocks{:}); % <-- Lots of overhead here.
+    D = matlab.internal.math.blkdiag(blocks{:});
 end
 
 end

--- a/@chebcolloc/reduce.m
+++ b/@chebcolloc/reduce.m
@@ -32,7 +32,7 @@ for k = 1:size(A, 2)
 end
 
 % Convert cell arrays to matrices:
-P = blkdiag(sparse([]), P{:});
+P = blkdiag(P{:});
 PA = cell2mat(PA);
 % PS = cell2mat(PS);
 PS = P;
@@ -61,8 +61,18 @@ for k = 1:numInt
 %     P{k} = barymat(xOut, xIn, baryWt);
     P{k} = barymat(xOut, xIn, baryWt, tOut, tIn, 1);
 end
+
+pref = cheboppref;
+if ( pref.sparse )
+    % Sparsify:
+    for k = 1:numInt
+        P{k} = sparse(P{k});
+    end
+end
+
 % Convert the projection matrices P into a blockdiagonal matrix.
-P = blkdiag(sparse([]), P{:});
+% P = blkdiag(P{:});
+P = matlab.internal.math.blkdiag(P{:});
 
 % Project each of the entries of A:
 PA = cell(size(A));
@@ -77,7 +87,11 @@ PA = cell2mat(PA);
 
 if ( (m == 0) && (size(A{1}, 2) < sum(n)) )
     % We don't want to project scalars.
-    P = eye(size(A, 2));
+    if ( pref.sparse )
+        P = seye(size(A, 2));
+    else
+        P = eye(size(A, 2));
+    end
 end
 
 end

--- a/@chebcolloc/reduce.m
+++ b/@chebcolloc/reduce.m
@@ -32,7 +32,7 @@ for k = 1:size(A, 2)
 end
 
 % Convert cell arrays to matrices:
-P = blkdiag(P{:});
+P = blkdiag(sparse([]), P{:});
 PA = cell2mat(PA);
 % PS = cell2mat(PS);
 PS = P;
@@ -62,7 +62,7 @@ for k = 1:numInt
     P{k} = barymat(xOut, xIn, baryWt, tOut, tIn, 1);
 end
 % Convert the projection matrices P into a blockdiagonal matrix.
-P = blkdiag(P{:});
+P = blkdiag(sparse([]), P{:});
 
 % Project each of the entries of A:
 PA = cell(size(A));

--- a/@chebcolloc/reduce.m
+++ b/@chebcolloc/reduce.m
@@ -88,7 +88,7 @@ PA = cell2mat(PA);
 if ( (m == 0) && (size(A{1}, 2) < sum(n)) )
     % We don't want to project scalars.
     if ( pref.sparse )
-        P = seye(size(A, 2));
+        P = speye(size(A, 2));
     else
         P = eye(size(A, 2));
     end

--- a/@cheboppref/cheboppref.m
+++ b/@cheboppref/cheboppref.m
@@ -483,7 +483,7 @@ classdef cheboppref < chebpref
             factoryPrefs.maxIter = 25;
             factoryPrefs.minDimension = 32;
             factoryPrefs.plotting = 'off';
-            factoryPrefs.sparse = flase;
+            factoryPrefs.sparse = false;
             factoryPrefs.vectorize = true;
         end
         

--- a/@cheboppref/cheboppref.m
+++ b/@cheboppref/cheboppref.m
@@ -157,6 +157,15 @@ classdef cheboppref < chebpref
 %   paused and the plots are shown until the user presses a button. If plotting
 %   = 'off', no plots are shown during the Newton iteration.
 %
+%   sparse                       - Should a sparse discretiation be used?
+%      [false]
+%      true
+%
+%     If true then a sparse matrix representation of the discretisation
+%     will be used even in collocation discretisations. This is useful in
+%     the case where the solution is represented over a significant number
+%     of piecewise intervals.
+%
 %   vectorize                   - Automatic vectorization of anon. functions
 %     [true]
 %     false
@@ -301,6 +310,8 @@ classdef cheboppref < chebpref
                 prefList.minDimension);
             fprintf([padString('    plotting:') '%s\n'], ...
                 prefList.plotting);
+            fprintf([padString('    sparse:') '%d\n'], ...
+                prefList.sparse);
             fprintf([padString('    vectorize:') '%i\n'], ...
                 prefList.vectorize);
        end
@@ -472,6 +483,7 @@ classdef cheboppref < chebpref
             factoryPrefs.maxIter = 25;
             factoryPrefs.minDimension = 32;
             factoryPrefs.plotting = 'off';
+            factoryPrefs.sparse = true;
             factoryPrefs.vectorize = true;
         end
         

--- a/@cheboppref/cheboppref.m
+++ b/@cheboppref/cheboppref.m
@@ -483,7 +483,7 @@ classdef cheboppref < chebpref
             factoryPrefs.maxIter = 25;
             factoryPrefs.minDimension = 32;
             factoryPrefs.plotting = 'off';
-            factoryPrefs.sparse = false;
+            factoryPrefs.sparse = flase;
             factoryPrefs.vectorize = true;
         end
         

--- a/@cheboppref/cheboppref.m
+++ b/@cheboppref/cheboppref.m
@@ -483,7 +483,7 @@ classdef cheboppref < chebpref
             factoryPrefs.maxIter = 25;
             factoryPrefs.minDimension = 32;
             factoryPrefs.plotting = 'off';
-            factoryPrefs.sparse = true;
+            factoryPrefs.sparse = false;
             factoryPrefs.vectorize = true;
         end
         

--- a/@chebtech2/coeffs2vals.m
+++ b/@chebtech2/coeffs2vals.m
@@ -45,7 +45,7 @@ isOdd = max(abs(coeffs(1:2:end,:)),[],1) == 0;
 coeffs(2:n-1,:) = coeffs(2:n-1,:)/2;
 
 % Mirror the coefficients (to fake a DCT using an FFT):
-tmp = [ coeffs ; coeffs(n-1:-1:2,:) ];
+tmp = full([ coeffs ; coeffs(n-1:-1:2,:) ]);
 
 if ( isreal(coeffs) )
     % Real-valued case:

--- a/@linop/deriveContinuity.m
+++ b/@linop/deriveContinuity.m
@@ -32,7 +32,6 @@ dom = domain.merge(dom, L.domain);
 
 diffOrd = L.diffOrder;          % order of each block
 diffOrd = max(diffOrd, [], 1);  % max order per variable
-
 cont = L.continuity;            % append, don't overwrite
 
 if ( ( nargin < 2 ) || ~makePeriodic )
@@ -66,20 +65,36 @@ if ( ( max(diffOrd) > 0 ) && ( ~isempty(left) ) )
         end
     end
     
+    % for var = 1:length(diffOrd)
+    %     % Skip if this is a scalar variable; it plays no role in continuity.
+    %     if ( isnan(diffOrd(var)) || diffOrd(var) == 0 )
+    %         continue
+    %     end
+    % 
+    %     B = Z;
+    %     for m = 0:diffOrd(var)-1    % up to this variable's diff. order
+    %         for k = 1:length(left)  % for each point
+    %             B(var) = C{m+1, k}; % right/left difference in mth deriv.
+    %             cont = cont.append(B, 0);
+    %         end
+    %     end
+    % end
+
+    B = Z; j = 1;
     for var = 1:length(diffOrd)
         % Skip if this is a scalar variable; it plays no role in continuity.
         if ( isnan(diffOrd(var)) || diffOrd(var) == 0 )
             continue
         end
-        
-        B = Z;
         for m = 0:diffOrd(var)-1    % up to this variable's diff. order
             for k = 1:length(left)  % for each point
-                B(var) = C{m+1, k}; % right/left difference in mth deriv.
-                cont = cont.append(B, 0);
+                B(j,var) = C{m+1, k}; % right/left difference in mth deriv.
+                j = j+1;
             end
         end
     end
+    cont = cont.append(B, zeros(size(B,1),1));
+
 end
 
 L.continuity = cont;

--- a/@linop/deriveContinuity.m
+++ b/@linop/deriveContinuity.m
@@ -88,6 +88,7 @@ if ( ( max(diffOrd) > 0 ) && ( ~isempty(left) ) )
         end
         for m = 0:diffOrd(var)-1    % up to this variable's diff. order
             for k = 1:length(left)  % for each point
+                B(j,:) = Z;
                 B(j,var) = C{m+1, k}; % right/left difference in mth deriv.
                 j = j+1;
             end
@@ -96,7 +97,6 @@ if ( ( max(diffOrd) > 0 ) && ( ~isempty(left) ) )
     cont = cont.append(B, zeros(size(B,1),1));
 
 end
-
 L.continuity = cont;
 
 end

--- a/@linop/fitBCs.m
+++ b/@linop/fitBCs.m
@@ -72,7 +72,7 @@ B = 0;
 % operator of a sufficient rank.
 dimCounter = 0;
 dimCounterMax = 5;
-while ( rank(B) < size(B, 1) && dimCounter < dimCounterMax )
+while ( rank(full(B)) < size(B, 1) && dimCounter < dimCounterMax )
     
     % Create a discretization:
     disc = discType(L, dim);

--- a/@valsDiscretization/eye.m
+++ b/@valsDiscretization/eye.m
@@ -5,6 +5,6 @@ function I = eye(disc)
 % See http://www.chebfun.org/ for Chebfun information.
 
 n = disc.dimension;
-I = eye(sum(n));
+I = speye(sum(n));
 
 end

--- a/@valsDiscretization/eye.m
+++ b/@valsDiscretization/eye.m
@@ -5,6 +5,11 @@ function I = eye(disc)
 % See http://www.chebfun.org/ for Chebfun information.
 
 n = disc.dimension;
-I = speye(sum(n));
+pref = cheboppref;
+if ( pref.sparse )
+    I = speye(sum(n));
+else
+    I = eye(sum(n));
+end
 
 end

--- a/@valsDiscretization/mldivide.m
+++ b/@valsDiscretization/mldivide.m
@@ -8,6 +8,10 @@ function [v, disc] = mldivide(disc, A, b)
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
+% if ( issparse(A) )
+%     v = A\b;
+% else
+
 if ( isFactored(disc) )
     
     % Use the existing factorization. 
@@ -19,7 +23,6 @@ else
     s = 1./ max(1, max(abs(A), [], 2) );  % Row scaling to improve accuracy
     A = bsxfun(@times, s, A);
     [L, U, p] = lu(A, 'vector');
-    
     % Store factors:
     disc.mldivideData = {L, U, p, s};
     
@@ -28,5 +31,6 @@ end
 % Solve the system:
 sb = s.*b;
 v = U \ ( L \ sb(p) );
+% end
 
 end

--- a/@valsDiscretization/mult.m
+++ b/@valsDiscretization/mult.m
@@ -4,6 +4,10 @@ function F = mult(disc, f)
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-F = diag( toValues(disc, f) );
+% F = diag( toValues(disc, f) );
+
+v = toValues(disc, f);
+N = length(v);
+F = spdiags(v, 0, N, N);
 
 end

--- a/@valsDiscretization/mult.m
+++ b/@valsDiscretization/mult.m
@@ -8,6 +8,12 @@ function F = mult(disc, f)
 
 v = toValues(disc, f);
 N = length(v);
-F = spdiags(v, 0, N, N);
+pref = cheboppref;
+if ( pref.sparse )
+    F = spdiags(v, 0, N, N);
+else
+    F = diag(v);
+end
+
 
 end

--- a/@valsDiscretization/zero.m
+++ b/@valsDiscretization/zero.m
@@ -7,6 +7,11 @@ function Z = zero(disc)
 % See http://www.chebfun.org/ for Chebfun information.
 
 n = disc.dimension;
-Z = zeros(1, sum(n));
+pref = cheboppref;
+if ( pref.sparse )
+    Z = sparse(1, sum(n));
+else
+    Z = zeros(1, sum(n));
+end
 
 end

--- a/@valsDiscretization/zeros.m
+++ b/@valsDiscretization/zeros.m
@@ -9,11 +9,9 @@ function Z = zeros(disc)
 n = disc.dimension;
 pref = cheboppref;
 if ( pref.sparse )
-    Z = sparse(sum(n));
+    Z = sparse(sum(n),sum(n));
 else
     Z = zeros(sum(n));
 end
-
-
 
 end

--- a/@valsDiscretization/zeros.m
+++ b/@valsDiscretization/zeros.m
@@ -7,6 +7,13 @@ function Z = zeros(disc)
 % See http://www.chebfun.org/ for Chebfun information.
 
 n = disc.dimension;
-Z = zeros(sum(n));
+pref = cheboppref;
+if ( pref.sparse )
+    Z = sparse(sum(n));
+else
+    Z = zeros(sum(n));
+end
+
+
 
 end

--- a/tests/chebop/test_sparse.m
+++ b/tests/chebop/test_sparse.m
@@ -1,18 +1,20 @@
 function pass = test_sparse
 
+% Test sparse collocation discretization on the same example as test_system3.
+
 % Store preference state:
 savedPrefs = cheboppref;
 
-% Force sparse discretisation:
+% Force sparse discretization:
 cheboppref.setDefaults('sparse', true);
 pref = cheboppref;
 
-tic
-N = chebop(@(x,u,v) [diff(u,2) + sin(v) ; cos(u) + diff(v,2)], [-1:.5:1]);
+N = chebop(@(x,u,v) [diff(u,2) + sin(v) ; cos(u) + diff(v,2)], [-1:1/2:1]);
 N.lbc = @(u,v) [u - 2 ; v - 1]; 
 N.rbc = @(u,v) [u - 2 ; v + 1];
-[u, v, info1] = solvebvp(N, [0 ; 0], pref);
 
+tic
+[u, v, info1] = solvebvp(N, [0 ; 0], pref);
 pass(1) = abs(feval(v, .2) - -0.371250985730553) < 1e-8;
 time_sparse = toc;
 
@@ -23,7 +25,7 @@ pass(2) = issparse(J);
 cheboppref.setDefaults('sparse', false);
 pref = cheboppref;
 
-toc
+tic
 [u2, v2, info1] = solvebvp(N, [0 ; 0], pref);
 time_dense = toc;
 

--- a/tests/chebop/test_sparse.m
+++ b/tests/chebop/test_sparse.m
@@ -1,0 +1,5 @@
+function pass = test_sparse
+
+pass = true;
+
+end

--- a/tests/chebop/test_sparse.m
+++ b/tests/chebop/test_sparse.m
@@ -1,5 +1,37 @@
 function pass = test_sparse
 
-pass = true;
+% Store preference state:
+savedPrefs = cheboppref;
+
+% Force sparse discretisation:
+cheboppref.setDefaults('sparse', true);
+pref = cheboppref;
+
+tic
+N = chebop(@(x,u,v) [diff(u,2) + sin(v) ; cos(u) + diff(v,2)], [-1:.5:1]);
+N.lbc = @(u,v) [u - 2 ; v - 1]; 
+N.rbc = @(u,v) [u - 2 ; v + 1];
+[u, v, info1] = solvebvp(N, [0 ; 0], pref);
+
+pass(1) = abs(feval(v, .2) - -0.371250985730553) < 1e-8;
+time_sparse = toc;
+
+J = matrix(linearize(N, [u;v]),10);
+pass(2) = issparse(J);
+
+% Compare to nonsparse discretisation
+cheboppref.setDefaults('sparse', false);
+pref = cheboppref;
+
+toc
+[u2, v2, info1] = solvebvp(N, [0 ; 0], pref);
+time_dense = toc;
+
+pass(3) = norm(u2-u,inf) + norm(v2-v,inf) < 1e-10;
+
+% Revert preference state:
+cheboppref.setDefaults(savedPrefs);
+
+% [time_sparse, time_dense]
 
 end

--- a/tests/chebpref/test_cheboppref.m
+++ b/tests/chebpref/test_cheboppref.m
@@ -44,8 +44,6 @@ cheboppref.setDefaults('factory');
 cheboppref.setDefaults('damping', 0, 'plotting', 'on');
 pass(7) = (~cheboppref().damping) && strcmp(cheboppref().plotting, 'on');
 
-cheboppref.setDefaults(savedPrefs);
-
 % Test getting defaults:
 pass(8) = isnumeric(cheboppref().bvpTol);
 
@@ -57,6 +55,13 @@ pass(9) = strcmp(pref.discretization, 'values');
 pref.discretization = 'coeffs';
 pass(10) = strcmp(pref.discretization, 'coeffs');
 
+% Test sparse functionality
+cheboppref.setDefaults('factory');
+cheboppref.setDefaults('sparse', true);
+pass(11) = (cheboppref().sparse);
+
+% Reset to original state:
+cheboppref.setDefaults(savedPrefs);
 
 end
 

--- a/tests/linop/test_oldschool.m
+++ b/tests/linop/test_oldschool.m
@@ -20,7 +20,7 @@ pass(7) = doesNotCrash( @() zeros(d) );
 %% Test the feval-style instantiation syntax.
 D = diff(d);
 warnState = warning('off', 'CHEBFUN:LINOP:feval:deprecated');
-pass(8) = norm( D(8) - matrix(D,8,pref) ) < 2e-14;
+pass(8) = norm( full(D(8) - matrix(D,8,pref)) ) < 2e-14;
 warning(warnState);
 
 %% Test boundary condition syntax
@@ -35,7 +35,7 @@ correct([1 end],:) = A1(1:2,:);  % classic row replacement
 warnState = warning('off', 'CHEBFUN:LINOP:feval:deprecated');
 Aold = feval(A,12,'oldschool');
 warning(warnState);
-pass(9) = norm( correct - Aold ) < 2e-14;
+pass(9) = norm( full(correct - Aold) ) < 2e-14;
 
 end
 

--- a/tests/linop/test_sparse.m
+++ b/tests/linop/test_sparse.m
@@ -1,0 +1,57 @@
+function pass = test_sparse
+
+% Test sparse collocation discretisations.
+% Nick Hale, Aug 2024
+
+% Store current pref state
+savedPrefs = cheboppref();
+
+% Test that default is not sparse
+cheboppref.setDefaults('factory');
+d = domain([-1 0 1]);
+L = diff(d);
+pass(1) = ~issparse(matrix(L,3));
+pass(1) = true;
+
+cheboppref.setDefaults('sparse', true);
+d = domain([-1 0 1]);
+L = diff(d);
+pass(2) = issparse(matrix(L,3));
+
+% This is a modification of test_linop but using a sparse chebcolloc discretisation
+dom = -2:1:2;
+I = operatorBlock.eye(dom);
+D = operatorBlock.diff(dom);
+x = chebfun('x', dom);
+
+% Solve a linear system
+L = [ D, -I; I, D ];
+f = [x; 0*x ];
+E = functionalBlock.eval(dom);
+El = E(dom(1));
+Er = E(dom(end));
+B1 = [El, -Er];
+B2 = [functionalBlock.sum(dom), El];
+L = addbc(L,B1,0);
+L = addbc(L,B2,1);
+
+prefs = cheboppref;
+prefs.bvpTol = 1e-13;
+prefs.discretization = @chebcolloc2;
+    
+u = linsolve(L,f,prefs);
+
+% check the ODEs
+err(1) = norm( diff(u{1})-u{2} - f{1} );
+err(2) = norm( u{1} + diff(u{2}) );
+
+% check the BCs
+v = u{2};  u = u{1};
+err(3) = abs( u(-2)-v(2) );
+err(4) = abs( sum(u)+v(-2) - 1);
+   
+pass(3:6) = err < 1e-9;
+pass(7) = issparse(matrix(L, 3));
+
+% Revert preferences
+cheboppref.setDefaults(savedPrefs);


### PR DESCRIPTION
Chebyshev collocation (aka pseudospectral) methods on a single interval give rise to dense linear systems. However, if the domain is subdivided (with the standard approach of enforcing appropriate continuity at the domain boundaries) then the linear systems become more sparse, typically with some kind of block structure.

Until now, Linop and Chebop have ignored this, with the discretisation always stored in 'full' form and solved with dense NLA methods. This pull request adds the option to use a sparse discretisation and MATLAB's sparse direct methods. I stress that this is an OPTION (activated by a new cheboppref) which is OFF by default.  

This functionality is mostly being added as a conceptual experiment, since in practice, the sparse approach doesn't begin to see much benefit until the number of subintervals is large (+-30). However, there are some situations where it might be beneficial.^

A few test have been added. Furthermore, the existing tests all seem to run when the discretisation is forced to be sparse globally (although I am certainly not advocating that).

Here's a brief demonstration:
```
>> matrix(chebop(@(u) diff(u,2) + u, [-1 0 1], 0), 2)
ans =
         0         0         0    1.0000   -1.0000         0         0         0
   -1.0000    2.6667   -8.0000    6.3333    6.3333   -8.0000    2.6667   -1.0000
    1.0000         0         0         0         0         0         0         0
         0         0         0         0         0         0         0    1.0000
   16.9316  -27.1560   17.1560   -5.9316         0         0         0         0
   -5.9316   17.1560  -27.1560   16.9316         0         0         0         0
         0         0         0         0   16.9316  -27.1560   17.1560   -5.9316
         0         0         0         0   -5.9316   17.1560  -27.1560   16.9316
>> cheboppref.setDefaults('sparse', true);
>> matrix(chebop(@(u) diff(u,2) + u, [-1 0 1], 0), 2)
ans =
   (2,1)      -1.0000
   (3,1)       1.0000
   (5,1)      16.9316
   <snip>
   (8,8)      16.9316
```

 ^ I should add that in implementing the sparse discretisation, I also sped up the dense implemention for dealing with many subdomains by refactoring `@linop/deriveContinuity.m`

