### PR TITLE
CI: fix 2021b-no-toolbox job

### DIFF
--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -43,6 +43,10 @@ jobs:
         uses: matlab-actions/setup-matlab@v2
         with:
           release: R2021b
+      - name: Run commands
+        uses: matlab-actions/run-command@v2
+        with:
+          command: addpath('.'); results = chebtest; assert(all([results{:,3}] > 0))
 
   r2025a-matlab-chebtest:
     name: R2025a Matlab chebtest


### PR DESCRIPTION
The main payload of the R2021b job without toolboxes was lost.  Perhaps I messed up during a bunch of debugging.

This adds it back.  No more false sense of security: this job should fail like all the others until #2468 is fixed.