### PR TITLE
resetPointValue: rename function to match filename

### DIFF
--- a/@chebfun/resetPointValues.m
+++ b/@chebfun/resetPointValues.m
@@ -1,5 +1,5 @@
-function f = clearPointValues(f)
-%   F = CLEARPOINTVALS(F) sets the .POINTVALS(j) to the average of the right and
+function f = resetPointValues(f)
+%   F = RESETPOINTVALUES(F) sets the .POINTVALS(j) to the average of the right and
 %   left limits of its neighbouring funs for interior breaks and the limits from
 %   the left and right for the POINTVALS(1) and VALS(end), respectively.
 for k = 1:numel(f)


### PR DESCRIPTION
Silences an Octave warning.  "resetPointValues" is the correct name b/c its the one mentioned in chebfun.m (and used elsewhere).