### PR TITLE
CI: try to make chebtest jobs run from a fork

### DIFF
--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -1,4 +1,10 @@
-name: chebfun Tests
+# This file specifies the "GitHub Actions" CI workflows related to running
+# the testsuite on various versions of Matlab.
+# It is expected that those versions will change over time, but the general
+# idea is to at the very least, to ensure Chebfun works on some older version
+# of Matlab, as well as the most recent version(s) of Matlab.
+
+name: Matlab tests
 
 on:
   push:


### PR DESCRIPTION
I think this change will CI run for PRs *from forks* (here from cbm755/chebfun) into this central chebfun/chebfun repo.

It may in some cases, perhaps most cases involving devs pushing to the main repo, cause two runs of the CI, which seems wasteful.  Potentially worth cleaning up..