### PR TITLE
feature-improved-chebtest-display

### DIFF
--- a/chebtest.m
+++ b/chebtest.m
@@ -168,8 +168,8 @@ else
         fprintf('The following tests failed or crashed:\n');
         for k = indx(:)'
             loc = fullfile(testsDir, allResults{k,1});
-            fprintf('   %s %s\n', printTestFilename(allResults{k,1:2}, loc), ...
-                errorMessages{-durations(k)})
+            fprintf('   %s %s %s\n', printTestFilename(allResults{k,1:2}, loc), ...
+                errorMessages{-durations(k)}, allResults{k,4})
         end
     end
 
@@ -224,7 +224,7 @@ maxLength = max(cellfun(@length, testFiles));
 % Allocate pass and timing variables:
 numFiles  = numel(testFiles);
 durations = zeros(numFiles, 1);
-fails = cell(numFiles,1);
+fails = cell(numFiles,1); failsStr = cell(numFiles,1);
 errorMessages = {'FAILED', 'CRASHED'};
 
 % TODO: Eventually this should be removed.
@@ -257,10 +257,10 @@ try % Note, we try-catch as we've CD'd and really don't want to end up elsewhere
                 % Success message.
                 message = sprintf('passed in %.4fs', durations(k));
             elseif ( durations(k) == -1 ) % FAIL
-                % Print failing subtests
-                fails{k} = strrep(int2str(fails{k}), '  ', ',');
+                % Print failing subtests string
+                failsStr{k} = ['{' strrep(int2str(fails{k}), '  ', ',')  '}'];
                 % Error flags are negative indices.
-                message = [errorMessages{-durations(k)}, ' {' fails{k} '}'];
+                message = [errorMessages{-durations(k)}, ' ' , failsStr{k}];
             else % CRASH
                 message = [errorMessages{-durations(k)}];
             end
@@ -295,11 +295,13 @@ cd(currDir);
 
 % Dump all the test data into a cell array to pass back to the CHEBTEST
 % function. This data is what is written to a .CSV file if logging is on.
+% TODO: This would be better as a struct.
 testResults = cell(numFiles,3);
 for k = 1:numFiles
     testResults{k,1} = testDir;               % directory name
     testResults{k,2} = testFiles{k}(1:end-2); % test file name
     testResults{k,3} = durations(k);          % duration / error flag
+    testResults{k,4} = failsStr{k};           % failing subtests (string)
 end
 
 end

--- a/chebtest.m
+++ b/chebtest.m
@@ -132,7 +132,7 @@ cd(testsDir);
 
 % Initialise storage for which directories pass and the time they take.
 numDirs = length(testDirNames);
-allResults = cell(0, 3);
+allResults = cell(0, 4);
 
 % Loop over the test directories and run the tests in each one.
 for k = 1:numDirs
@@ -363,7 +363,7 @@ function [duration, fail] = runTest(testFile)
 %
 %   If each of these are logical true (or 1) then the test passes and RUNTEST
 %   returns DURATION as a double > 0 corresponding to the time it took the test
-%   to execute in seconds anf FAIL returns empty.
+%   to execute in seconds and FAIL returns empty.
 %
 %   If any of the entries returned by TESTFILE are logical false (or 0), then
 %   DURATION = -1 and FAIL contains an integer list of those entries which

--- a/chebtest.m
+++ b/chebtest.m
@@ -18,11 +18,13 @@ function varargout = chebtest(varargin)
 %
 %   CHEBTEST will time each of the tests, and print the time for each test
 %   that passes. If any of the values returned by a test m-file are logical
-%   false (or zero) then the test is deemed to have 'failed'. If a test
-%   results in an error being thrown it is reported as 'crashed'. Therefore,
-%   an output from CHEBTEST might take the form:
+%   false (or zero) then the test is deemed to have 'failed'. In this case,
+%   the number in the braces following the 'FAILED' text indicates which entry 
+%   in the matrix of logical values (and hence which subtest) failed. If a
+%   test results in an error being thrown it is reported as 'crashed'.
+%   Therefore, an output from CHEBTEST might take the form:
 %   | Test #001: chebtech1/test_alias.m ...          passed in 0.0094s
-%   | Test #002: chebtech1/test_bary.m ...           FAILED
+%   | Test #002: chebtech1/test_bary.m ...           FAILED {1,7}
 %   | Test #003: chebtech1/test_cell2mat.m ...       CRASHED
 %   | ...
 %
@@ -161,11 +163,13 @@ else
     % Note that we don't display this in quiet mode, as the failed tests are
     % already easily seen.
     if ( ~quietMode )
+        errorMessages = {'FAILED', 'CRASHED'};
         indx = find(durations < 0);
         fprintf('The following tests failed or crashed:\n');
         for k = indx(:)'
             loc = fullfile(testsDir, allResults{k,1});
-            fprintf('   %s\n', printTestFilename(allResults{k,1:2}, loc))
+            fprintf('   %s %s\n', printTestFilename(allResults{k,1:2}, loc), ...
+                errorMessages{-durations(k)})
         end
     end
 
@@ -220,6 +224,7 @@ maxLength = max(cellfun(@length, testFiles));
 % Allocate pass and timing variables:
 numFiles  = numel(testFiles);
 durations = zeros(numFiles, 1);
+fails = cell(numFiles,1);
 errorMessages = {'FAILED', 'CRASHED'};
 
 % TODO: Eventually this should be removed.
@@ -247,13 +252,17 @@ try % Note, we try-catch as we've CD'd and really don't want to end up elsewhere
         else
             % --verbose mode
             printTestInfo(testDir, testFile, k, maxLength);
-            durations(k) = runTest(testFile);
+            [durations(k), fails{k}] = runTest(testFile);
             if ( durations(k) > 0 )
                 % Success message.
                 message = sprintf('passed in %.4fs', durations(k));
-            else
+            elseif ( durations(k) == -1 ) % FAIL
+                % Print failing subtests
+                fails{k} = strrep(int2str(fails{k}), '  ', ',');
                 % Error flags are negative indices.
-                message = errorMessages{-durations(k)};
+                message = [errorMessages{-durations(k)}, ' {' fails{k} '}'];
+            else % CRASH
+                message = [errorMessages{-durations(k)}];
             end
             fprintf([message '\n']);
 
@@ -345,17 +354,18 @@ end
 end
 
 
-function duration = runTest(testFile)
+function [duration, fail] = runTest(testFile)
 %RUNTEST Runs the given test file.
-%   DURATION = RUNTEST(TESTFILE) executes the file TESTFILE.
+%   [DURATION, FAIL] = RUNTEST(TESTFILE) executes the file TESTFILE.
 %   TESTFILE should return a vector or matrix of logical values. 
 %
 %   If each of these are logical true (or 1) then the test passes and RUNTEST
 %   returns DURATION as a double > 0 corresponding to the time it took the test
-%   to execute in seconds.
+%   to execute in seconds anf FAIL returns empty.
 %
-%   If any of the entries returned by TESTFILE are logcial false (or 0), then
-%   DURATION = -1.
+%   If any of the entries returned by TESTFILE are logical false (or 0), then
+%   DURATION = -1 and FAIL contains an integer list of those entries which
+%   returned false.
 %
 %   If executing TESTFILE crashes, this is caught in a try-catch statement, and
 %   RUNTTEST returns DURATION = -2.
@@ -366,17 +376,21 @@ prefState2 = cheboppref();
 % Close any open windows:
 close all
 
+% Store failing subtests:
+fail = [];
+
 % Attempt to run the test:
 try
     tstart = tic();
     pass = feval(testFile);
     duration = toc(tstart);
 
-    pass = all(pass(:));
-    if ( ~pass )
+    if ( ~all(pass(:)) )
         % The test failed, so return FAILED flag.
         duration = -1;
+        fail = find(~pass);
     end
+
 
 catch ME %#ok<NASGU>
     % We crashed. This is bad. Return CRASHED flag.

--- a/tests/chebfun/test_aaa.m
+++ b/tests/chebfun/test_aaa.m
@@ -174,7 +174,6 @@ rr = aaa(F, Z, 'degree', 6, 'deriv_deg', 1);
 r = rr{1};
 err = abs( norm(F-r(Z),inf) - 1.19e-11 ); pass(39) = abs(err) < 1e-12;
 rp = rr{2};
-rp(1)
 pass(40) = abs(rp(1)+0.5) < 1e-6;
 
 warning('on', 'AAA:Froissart');


### PR DESCRIPTION
Chebtest will now display which subtests are failing. This makes it easier to diagnose failures that occur on the CI but are not easily reproduced locally.