### PR TITLE
Changes several files to UTF-8 encoding

### DIFF
--- a/@chebfun/mldivide.m
+++ b/@chebfun/mldivide.m
@@ -27,7 +27,7 @@ elseif ( A(1).isTransposed )
     % [M x INF] * [INF x N] = [M x N]:
     % AX = B
     % X^* A^* = B^*
-    % X^* QR = B^*
+    % X^* QR = B^*
     % R^* Q^* X = B
     % X = Q(R^{-*} B)
     

--- a/@chebfun/mrdivide.m
+++ b/@chebfun/mrdivide.m
@@ -55,7 +55,7 @@ else
     % [M x N] * [N x INF] = [M x INF]:
     % XA = B
     % A^* X^* = B^*
-    % QR X^*  = B^*
+    % QR X^* = B^*
     % X R^* Q^* = B
     % X = (BQ)R^{-*}
     [Q, R] = qr(A', 0);

--- a/tests/chebop/test_eigs_schrodinger.m
+++ b/tests/chebop/test_eigs_schrodinger.m
@@ -13,12 +13,12 @@ end
 %
 %    V(x) = 1.5 for x in [-.2,.3],  0 otherwise.
 %
-% We seek eigenmodes of the steady-state ShrÃ¶dinger equation associated
+% We seek eigenmodes of the steady-state Schrödinger equation associated
 % with this potential, specifically, functions u(x) satisfying
 %
 %     -0.007u"(x) + V(x)*u(x) = lam*u(x),    u(-1) = u(1) = 0.
 %
-% for some constant lam. 
+% for some constant lam.
 
 x = chebfun(@(x) x);
 V = 1.5*(abs(x-0.05) < 0.25);

--- a/tests/chebop/test_linearizationDimensions.m
+++ b/tests/chebop/test_linearizationDimensions.m
@@ -21,17 +21,17 @@ L = chebop(@(x,u,v) diff(u) + v);
 LL = linop(L); LLB = LL.blocks;
 % Should expect both the first block to be an OPERATORBLOCK, the second to be a
 % chebfun.
-pass(3) = isa(LLB{1}, 'operatorBlock') && isa(LLB{2}, 'chebfun'); 
+pass(3) = isa(LLB{1}, 'operatorBlock') && isa(LLB{2}, 'chebfun');
 %% Example 4:
 L = chebop(@(x,u,v) u + diff(v));
 LL = linop(L); LLB = LL.blocks;
 % Here, we should expect both the first block to be an OPERATORBLOCK, the second
 % to be a chebfun.
-pass(4) = isa(LLB{1}, 'chebfun') && isa(LLB{2}, 'operatorBlock'); 
+pass(4) = isa(LLB{1}, 'chebfun') && isa(LLB{2}, 'operatorBlock');
 %% Example 5:
 L = chebop(@(x,u,v) diff(u) + diff(v));
 LL = linop(L); LLB = LL.blocks;
-% Here, we should expect both blocks to be an ç.
+% Here, we should expect both blocks to be an OPERATORBLOCK.
 pass(5) = isa(LLB{1}, 'operatorBlock') && isa(LLB{2}, 'operatorBlock');
 %% Example 6:
 L = chebop(@(x,u,v) [u + diff(v); diff(u) + v]);

--- a/trigBary.m
+++ b/trigBary.m
@@ -12,8 +12,8 @@ function fx = trigBary(x, fvals, xk, dom)
 %   [F_1(X), F_2(X), ...], where size(F_k(X)) = size(X) for each k.
 %
 % REFERENCES:
-%   [1] Berrut, Jean-Paul. "Baryzentrische Formeln zur trigonometrischen 
-%   Interpolation (I)." Zeitschrift für angewandte Mathematik und Physik 
+%   [1] Berrut, Jean-Paul. "Baryzentrische Formeln zur trigonometrischen
+%   Interpolation (I)." Zeitschrift fÃ¼r angewandte Mathematik und Physik
 %   ZAMP 35.1 (1984): 91-105.
 % 
 %   [2] Henrici, Peter. "Barycentric formulas for interpolating trigonometric 

--- a/trigBaryWeights.m
+++ b/trigBaryWeights.m
@@ -5,8 +5,8 @@ function w = trigBaryWeights(x)
 %   weights are scaled such that norm(W, inf) == 1.
 % 
 % REFERENCES:
-%   [1] Berrut, Jean-Paul. "Baryzentrische Formeln zur trigonometrischen 
-%   Interpolation (I)." Zeitschrift für angewandte Mathematik und Physik 
+%   [1] Berrut, Jean-Paul. "Baryzentrische Formeln zur trigonometrischen
+%   Interpolation (I)." Zeitschrift fÃ¼r angewandte Mathematik und Physik
 %   ZAMP 35.1 (1984): 91-105.
 % 
 %   [2] Henrici, Peter. "Barycentric formulas for interpolating trigonometric 


### PR DESCRIPTION
Most of the source is plain ol' ASCII.  There are several existing UTF-8 files.

But there were several files in other encodings, including one or two that looked possibly broken to me (but I'm not expert on encodings).

I think I've changed everything to UTF-8 in this PR.  My rationale:
  - life is too short to bother with anything other than UTF-8
  - According to [1], "As of R2020a, the MATLAB Editor will default to saving new files using UTF-8".  Thus, it seems like Matlab has first-class support for utf-8  so its a sensible choice for all our files.
  - Octave has always done UTF-8 as its basically the standard on Unix.

[1] https://www.mathworks.com/matlabcentral/answers/482380-how-to-set-the-encoding-of-matlab-m-files-to-be-utf8

