### PR TITLE
Draft: feature-chebtest-warnings

### DIFF
--- a/@chebfun3/chebfun3f.m
+++ b/@chebfun3/chebfun3f.m
@@ -387,7 +387,8 @@ while ~happy
     % Restart
     if ( ~happy )
         if ( restarts + 1 == maxRestarts )
-            warning('chebfun3f: max number of restarts reached')
+            warning('CHEBFUN:CHEBFUN3F:constructor:maxrestarts', ...
+                'chebfun3f: max number of restarts reached')
             return
         end
         

--- a/@singfun/cumsum.m
+++ b/@singfun/cumsum.m
@@ -203,9 +203,10 @@ function g = singIntegral(f)
     % If G is not blowing up, ensure G(-1) == 0.
     if ( g.exponents(1) >= 0 )
         % suppress the warning:
+        lw = lastwarn;
         warnState = warning('off', 'CHEBFUN:SINGFUN:plus:exponentDiff');
         g = g - get(g, 'lval');
-        warning(warnState)        
+        warning(warnState); lastwarn(lw);
     end
 
 end

--- a/tests/cheb/test_revolution.m
+++ b/tests/cheb/test_revolution.m
@@ -18,10 +18,10 @@ pass(4) = abs(result.momentOfInertia - exact.momentOfInertia) < 1e-15;
 
 %% Check results for a surface of revolution on an unbounded domain
 f = chebfun(@(x) exp(-x), [0,Inf]);
-warnstate = warning;
+warnstate = warning; lw = lastwarn;
 warning('off', 'CHEBFUN:UNBNDFUN:sum:slowDecay')
 result = cheb.revolution(f);
-warning(warnstate);
+warning(warnstate); lastwarn(lw);
 
 % Known exact results
 exact.surfaceArea = pi*(sqrt(2) + asinh(1));

--- a/tests/chebfun/test_chebpade.m
+++ b/tests/chebfun/test_chebpade.m
@@ -4,7 +4,7 @@
 function pass = test_chebpade(pref)
 
 % Turn off warnings and save the warning state.
-warnState = warning('off');
+warnState = warning('off'); lw = lastwarn;
 
 % An example which doesn't require degree-reduction.
 dom = [-1, 3];
@@ -46,6 +46,6 @@ pass(5) = norm([ratio1 ratio2] - [1i 1i], inf) < 1e-13;
 pass(6) = norm(f - p./q) < 2e-4;
 
 % Restore the warning state.
-warning(warnState);
+warning(warnState); lastwarn(lw);
 
 end

--- a/tests/chebfun/test_chebpoly.m
+++ b/tests/chebfun/test_chebpoly.m
@@ -7,6 +7,7 @@ if ( nargin == 0 )
 end
 
 warnState = warning('off', 'CHEBFUN:CHEBFUN:chebpoly:deprecated');
+lw = lastwarn;
 
 rev = @(A) flipud(A).';
 
@@ -70,6 +71,6 @@ c_exact = [c_exact c_exact];
 err = c - rev(c_exact);
 pass(8) = norm(err(:), inf) < 1e2*vscale(f)*eps;
 
-warning(warnState);
+warning(warnState); lastwarn(lw);
 
 end

--- a/tests/chebfun/test_compose_unary.m
+++ b/tests/chebfun/test_compose_unary.m
@@ -28,11 +28,11 @@ pass(4) = test_one_compose_unary(@(x) abs(x + 0.2) + abs(x - 0.3), ...
     [-1 -0.2 0.3 1], @(x) cos(x.^2), pref);
 
 % Non-smooth operator with smooth function, splitting disabled.
-warnstate = warning('off');
+warnstate = warning('off'); lw = lastwarn;
 test_one_compose_unary(@(x) sin(10*(x - 0.1)), [-1 1], @abs, pref);
 [warnmsg, warnid] = lastwarn();
 pass(5) = strcmp(warnid, 'CHEBFUN:CHEBFUN:compose:resolve');
-warning(warnstate);
+warning(warnstate); lastwarn(lw);
 
 % Non-smooth operator with smooth function, splitting enabled.
 pass(6) = test_one_compose_unary(@(x) sin(10*(x - 0.1)), [-1 1], @abs, ...

--- a/tests/chebfun/test_constructor_inputs.m
+++ b/tests/chebfun/test_constructor_inputs.m
@@ -99,18 +99,18 @@ f_op = @(x) sin(200*x);
 f = chebfun(f_op, 'resampling', 'on');
 pass(17) = ishappy(f);
 
-warnstate = warning('off','CHEBFUN:CHEBFUN:constructor:notResolved');
+warnstate = warning('off','CHEBFUN:CHEBFUN:constructor:notResolved'); lw = lastwarn;
 f = chebfun(f_op, 'maxdegree', 129, 'tech', @chebtech2);
 pass(18) = ~ishappy(f) && (length(f) == 129);
-warning(warnstate);
+warning(warnstate); lastwarn(lw);
 
 f = chebfun(f_op, 'splitting', 'on', 'splitdegree', 65);
 pass(19) = ishappy(f) && all(cellfun(@(fk) length(fk) <= 65, f.funs));
 
-warnstate = warning('off','CHEBFUN:CHEBFUN:constructor:funNotResolved');
+warnstate = warning('off','CHEBFUN:CHEBFUN:constructor:funNotResolved');  lw = lastwarn;
 f = chebfun(f_op, 'splitting', 'on', 'splitLength', 65, 'splitMaxLength', 200);
 pass(20) = ~ishappy(f) && (length(f) <= 65*4);
-warning(warnstate);
+warning(warnstate); lastwarn(lw);
 
 % Test construction with a mixture of preference object and keyword inputs.
 p = pref;

--- a/tests/chebfun/test_cumsum.m
+++ b/tests/chebfun/test_cumsum.m
@@ -109,9 +109,9 @@ opi = {opi1, opi2, opi3};
 f = chebfun(op, dom, 'exps', [0 0 -0.5 0 0 0]);
 
 % We temporarily disable this warning: 
-warning('off', 'CHEBFUN:SINGFUN:plus:exponentDiff');
+warning('off', 'CHEBFUN:SINGFUN:plus:exponentDiff'); lw = lastwarn;
 g = cumsum(f);
-warning('on', 'CHEBFUN:SINGFUN:plus:exponentDiff');
+warning('on', 'CHEBFUN:SINGFUN:plus:exponentDiff'); lastwarn(lw);
 
 % check values:
 result = zeros(1,3);
@@ -139,9 +139,9 @@ domCheck = [dom(1)+0.1 dom(2)-0.1];
 op = @(x) sin(100*x)./((x-dom(1)).^0.5.*(x-dom(2)).^0.5);
 f = chebfun(op, dom, 'exps', [-0.5 -0.5]);
 % We temporarily disable this warning: 1
-warning('off', 'CHEBFUN:SINGFUN:plus:exponentDiff');
+warning('off', 'CHEBFUN:SINGFUN:plus:exponentDiff'); lw = lastwarn;
 g = cumsum(f);
-warning('on', 'CHEBFUN:SINGFUN:plus:exponentDiff');
+warning('on', 'CHEBFUN:SINGFUN:plus:exponentDiff'); lastwarn(lw);
 
 %%
 % check values:

--- a/tests/chebfun/test_innerProduct.m
+++ b/tests/chebfun/test_innerProduct.m
@@ -51,9 +51,9 @@ opf = @(x) x;
 opg = @(x) exp(-x);
 f = chebfun(opf, dom, 'exps', [0 1]);
 g = chebfun(opg, dom);
-warning('off', 'CHEBFUN:UNBNDFUN:sum:slowDecay');
+warning('off', 'CHEBFUN:UNBNDFUN:sum:slowDecay'); lw = lastwarn;
 I = innerProduct(f, g);
-warning('on', 'CHEBFUN:UNBNDFUN:sum:slowDecay');
+warning('on', 'CHEBFUN:UNBNDFUN:sum:slowDecay'); lastwarn(lw);
 IExact = 2*exp(-1);
 err = abs(I - IExact);
 pass(3) = err < 1e9*max(eps*get(f,'vscale'), ...

--- a/tests/chebfun/test_norm.m
+++ b/tests/chebfun/test_norm.m
@@ -210,9 +210,9 @@ pass(32) = abs(err) < 1e-2;
 
 %% #578
 f = chebfun(@(x) cos(x)./(1e5+(x-30).^6),[0 inf]);
-warning('off', 'CHEBFUN:UNBNDFUN:sum:slowdecay')
+warning('off', 'CHEBFUN:UNBNDFUN:sum:slowdecay')'; lw = lastwarn;
 I = norm(f);
-warning('on', 'CHEBFUN:UNBNDFUN:sum:slowdecay')
+warning('on', 'CHEBFUN:UNBNDFUN:sum:slowdecay'); lastwarn(lw);
 % The following result is obtained using Mathematica:
 Iexact = 2.4419616835794597e-5;
 err = abs(I - Iexact);

--- a/tests/chebfun/test_roots.m
+++ b/tests/chebfun/test_roots.m
@@ -171,11 +171,12 @@ pass(18) = isempty(r);
 % Check that we don't miss roots for unresolved functions.  (See GitHub issue
 % #1146.)
 warnState = warning('off', 'CHEBFUN:CHEBFUN:constructor:funNotResolved');
+lw = lastwarn;
 p = pref;
 p.splitting = true;
 p.splitPrefs.splitMaxLength = 300;
 f = chebfun(@(x) sin(exp(2*(tanh(sin(10*x))))), [0 10], p);
 pass(19) = length(roots(f)) == 32;
-warning(warnState);
+warning(warnState); lastwarn(lw);
 
 end

--- a/tests/chebfun/test_sum.m
+++ b/tests/chebfun/test_sum.m
@@ -176,9 +176,9 @@ pass(28) = err1 < 2e5*eps*get(f,'vscale');
 
 x = chebfun('x', dom);
 g = x.*exp(-x);
-warning('off', 'CHEBFUN:UNBNDFUN:sum:slowDecay');
+warning('off', 'CHEBFUN:UNBNDFUN:sum:slowDecay'); lw = lastwarn;
 I2 = sum(g);
-warning('on', 'CHEBFUN:UNBNDFUN:sum:slowdDecay');
+warning('on', 'CHEBFUN:UNBNDFUN:sum:slowdDecay'); lastwarn(lw);
 err2 = abs(I2 - IExact);
 tol = 2e10*eps*get(f,'vscale');
 pass(29) = err2 < tol;
@@ -187,10 +187,10 @@ pass(29) = err2 < tol;
 f = chebfun('exp(-x.^2/16).*(1+.2*cos(10*x))',[-inf,inf]);
 
 % Suppress expected warnings which may occur on certain machines:
-warning('off','CHEBFUN:UNBNDFUN:sum:slowDecay'); 
+warning('off','CHEBFUN:UNBNDFUN:sum:slowDecay'); lw = lastwarn;
 I = sum(f);
 % Re-enable warnings:
-warning('on','CHEBFUN:UNBNDFUN:sum:slowDecay');  
+warning('on','CHEBFUN:UNBNDFUN:sum:slowDecay'); lastwarn(lw);
 IExact = 7.0898154036220641;
 err = abs(I - IExact);
 pass(30) = err < 1e9*eps*get(f,'vscale');

--- a/tests/chebfun/test_vectorCheck.m
+++ b/tests/chebfun/test_vectorCheck.m
@@ -4,7 +4,7 @@ if ( nargin == 0 )
     pref = chebfunpref();
 end
 
-warnState = warning();
+warnState = warning(); lw = lastwarn;
 warning('off', 'CHEBFUN:CHEBFUN:vectorcheck:vectorize');
 warning('off', 'CHEBFUN:CHEBFUN:vectorcheck:transpose');
     
@@ -59,11 +59,11 @@ try
     g = chebfun(@(x) x./cos(x), pref);
     pass(11) = norm(f - g) == 0;
     
-    warning(warnState);
+    warning(warnState); lastwarn(lw);
     
 catch ME
     
-    warning(warnState);
+    warning(warnState); lastwarn(lw);
     rethrow(ME);
     
 end

--- a/tests/chebfun3/test_battery.m
+++ b/tests/chebfun3/test_battery.m
@@ -118,4 +118,6 @@ for jj=1:1:length(Battery)
     
 end
 
+
+
 end

--- a/tests/chebfun3/test_techs.m
+++ b/tests/chebfun3/test_techs.m
@@ -10,9 +10,11 @@ tol = 100*pref.cheb3Prefs.chebfun3eps;
 pref.tech = @chebtech1;
 ff = @(x,y,z) cos(x.*y.*z);
 dom = [-1, 1, -1, 1 -1 1];
+warnstate = warning('off', 'CHEBFUN:CHEBFUN3F:constructor:maxrestarts'); lw = lastwarn;
 f = chebfun3(ff, dom, pref);
 pass(1) = isa(f.cols.funs{1}.onefun, 'chebtech1');
 pass(2) = abs(feval(f, 0, 0, 0) - ff(0, 0, 0)) < tol;
+warning(lastwarn); lastwarn(lw);
 
 %%
 pref.tech = @chebtech2;

--- a/tests/chebop/test_gmres.m
+++ b/tests/chebop/test_gmres.m
@@ -6,6 +6,7 @@ if ( nargin == 0 )
     pref = cheboppref;
 end
 tol = 1e2*pref.bvpTol;
+lw = lastwarn;
 
 %% Example 1: (-u_xx=f, bc=0, sum(f)==0, 0<x<1)
 dom = [0 1];
@@ -130,8 +131,9 @@ v = gmres(N, f);
 
 pass(7) = ( norm(u - v) < tol );
 
-if ( all(pass) == 1 )
-    pass = 1;
+[~, lwnew_ID] = lastwarn;
+if ( strcmp(lwnew_ID, 'MATLAB:rankDeficientMatrix'))
+    lastwarn(lw);
 end
 
 end

--- a/tests/chebop/test_minres.m
+++ b/tests/chebop/test_minres.m
@@ -6,6 +6,7 @@ if ( nargin == 0 )
     pref = cheboppref;
 end
 tol = 1e2*pref.bvpTol;
+lw = lastwarn;
 
 %% Example 1: (-u_xx=f, bc=0, sum(f)==0)
 a = @(x) 1+0*x;
@@ -89,8 +90,11 @@ v = minres(N, f, [], 40);
 
 pass(5) = ( norm(u - v) < tol );
 
-if ( all(pass) == 1 )
-    pass = 1;
+%%
+
+[~, lwnew_ID] = lastwarn;
+if ( strcmp(lwnew_ID, 'MATLAB:rankDeficientMatrix'))
+    lastwarn(lw);
 end
 
 end

--- a/tests/chebop/test_pcg.m
+++ b/tests/chebop/test_pcg.m
@@ -6,6 +6,7 @@ if ( nargin == 0 )
     pref = cheboppref;
 end
 tol = 1e2*pref.bvpTol;
+lw = lastwarn;
 
 %% Example 1: (-u_xx=f, bc=0, mean(f)==0)
 a = @(x) 1;
@@ -128,8 +129,11 @@ v = pcg(N, f);
 
 pass(7) = ( norm(u - v) < tol );
 
-if ( all(pass) == 1 )
-    pass = 1;
+%%
+
+[~, lwnew_ID] = lastwarn;
+if ( strcmp(lwnew_ID, 'MATLAB:rankDeficientMatrix'))
+    lastwarn(lw);
 end
 
 end

--- a/tests/chebop2/test_withoutAD.m
+++ b/tests/chebop2/test_withoutAD.m
@@ -7,7 +7,6 @@ if ( nargin < 1 )
 end 
 tol = 100*pref.cheb2Prefs.chebfun2eps;
 
-
 state = warning;
 warning('off','all')
 
@@ -50,5 +49,6 @@ x = linspace(-1,1,1000);
 A = abs(u(xx,yy) - exact(xx,yy));
 pass(2) = ( max( A(:) ) < tol ); 
 
-warning(state);
+warning(state); lastwarn("");
+
 end

--- a/tests/misc/test_blowup.m
+++ b/tests/misc/test_blowup.m
@@ -8,7 +8,8 @@ end
 p = chebfunpref();
 chebfunpref.setDefaults('factory')
 
-warnState = warning('off', 'CHEBFUN:blowup:deprecated');
+warnState = warning('off', 'CHEBFUN:blowup:deprecated'); lw = lastwarn;
+
 try
     % Testing takes place inside this TRY CATCH.
     
@@ -46,7 +47,7 @@ try
 catch ME
     % Reset preferences and warning state
     chebfunpref.setDefaults(p);
-    warning(warnState);
+    warning(warnState); lastwarn(lw);
     
     % Rethrow error:
     rethrow(ME)
@@ -54,6 +55,6 @@ end
 
 % Return to default settings:
 chebfunpref.setDefaults(p);
-warning(warnState);
+warning(warnState); lastwarn(lw);
 
 end

--- a/tests/misc/test_conformal2.m
+++ b/tests/misc/test_conformal2.m
@@ -7,13 +7,15 @@ if ( nargin < 1 )
 end
 
 % Save the current warning state and then clear it
-[lastmsg, lastid] = lastwarn();
-lastwarn('');
+lw = lastwarn; lastwarn("");
 
 % First example from help text:
 z = chebfun('exp(1i*pi*z)','trig');
 C1 = z.*abs(1+.1*z^4); C2 = .5*z.*abs(1+.2*z^3);
 [f,finv,rho] = conformal2(C1, C2);        
+
+% Reset warning state
+lastwarn(lw);
 
 pass(1) = (abs(rho-.539197)<1e-3) && (abs(finv(f(1+0.1i))-(1+0.1i))<1e-3);
 

--- a/tests/misc/test_minimax.m
+++ b/tests/misc/test_minimax.m
@@ -5,7 +5,6 @@ function pass = test_minimax( pref )
 % Generate a few random points to use as test values.
 seedRNG(6178);
 xx = 2 * rand(100, 1) - 1;
-
 x = chebfun(@(x) x, [-1 1]);
 
 % Test known exact answer.
@@ -55,7 +54,6 @@ pass(7) = (abs(err-.5) < 1e-10);
 err = norm(f-p./q,inf);
 pass(8) = (abs(err-.043689) < 1e-3);
 
-
 % Make sure that it works for m=0 and odd f.
 f = x.^3;
 try
@@ -65,12 +63,10 @@ catch ME
     pass(9) = false;
 end
 
-
 % A function with huge amplitude
 f1 = chebfun('exp(x)'); p1 = minimax(f1,7); err1 = norm(f1-p1,inf);
 f2 = chebfun('1e100*exp(x)'); p2 = minimax(f2,7); err2 = norm(f2-p2,inf);
 pass(10) = abs(err1-err2/1e100) < 1e-3;
-
 
 % A function with tiny amplitude
 f1 = chebfun('exp(x)');
@@ -78,7 +74,6 @@ f1 = chebfun('exp(x)');
 f2 = chebfun('1e-100*exp(x)');
 [~,~,r2] = minimax(f2,1,3); sample2 = r2(.3)-f2(.3);
 pass(11) = abs(sample1-sample2*1e100) < 1e-3;
-
 
 % A function on a big domain
 x = chebfun('x',1e30*[-1 2]);
@@ -89,7 +84,9 @@ pass(12) = (norm(f-p,inf)/1e30 - .0135210) < .01;
 % Higher degree abs(x) approximation
 x = chebfun('x');
 f = abs(x);
+warnState = warning('off', 'CHEBFUN:CHEBFUN:constructor:funNotResolved'); lw = lastwarn;
 [~, ~, ~,err,~] = minimax(f, 30, 30, 'silent');
+warning(warnState); lastwarn(lw);
 pass(13) = abs(err-2.1739878e-7)/2.1739878e-7 < 1e-3;
 
 % Check correct output formatting for polynomial Remez
@@ -111,6 +108,8 @@ xx = linspace(-1,1,10000);
 norme1 = max(abs(f(xx)-p(xx)));
 pass(16) = (abs(err - norme1)/err < 1e-4);
 
+
+
 [~,~,r,err,~] = minimax(f,4,4,'silent');
 norme2 = max(abs(f(xx)-r(xx)));
 pass(17) = (abs(err - norme2)/err < 1e-4);
@@ -120,7 +119,6 @@ x = chebfun('x'); f = 1e40*abs(x);
 pass(18) = (err < 1e38);
 
 % Test poles and zeros of the best approximation
-
 [p,q,~,~,status] = minimax(@(x) sqrt(x), [0,1], 4,4);
 zer1 = roots(p,'all'); zer1 = sort(zer1); zer2 = sort(status.zer);
 pol1 = roots(q,'all'); pol1 = sort(pol1); pol2 = sort(status.pol);

--- a/tests/misc/test_ratinterp.m
+++ b/tests/misc/test_ratinterp.m
@@ -91,9 +91,9 @@ pass(19) = abs(pol - 0.1) < 1e-10;
 
 % Check that ratinterp accepts a domain input: (#841)
 [p1,q1] = ratinterp([-1,1], @exp, 1, 1);
-warnState = warning('off', 'CHEBFUN:ratinterp:domainDeprecated');
+warnState = warning('off', 'CHEBFUN:ratinterp:domainDeprecated'); lw = lastwarn;
 [p2,q2] = ratinterp(domain(-1,1), @exp, 1, 1);
-warning(warnState);
+warning(warnState); lastwarn(lw);
 pass(20) = norm(p1-p2) == 0 && norm(q1-q2) == 0;
 
 %% Test the examples from the m-file:

--- a/tests/misc/test_splitting.m
+++ b/tests/misc/test_splitting.m
@@ -8,7 +8,7 @@ end
 p = chebfunpref();
 chebfunpref.setDefaults('factory')
 
-warnState = warning('off', 'CHEBFUN:splitting:deprecated');
+warnState = warning('off', 'CHEBFUN:splitting:deprecated'); lw = lastwarn;
 
 try
     % Testing takes place inside this TRY CATCH.
@@ -33,7 +33,7 @@ try
 catch ME
     % Reset preferences and warning state
     chebfunpref.setDefaults(p);
-    warning(warnState);
+    warning(warnState); lastwarn(lw);
     
     % Rethrow error:
     rethrow(ME)
@@ -41,6 +41,6 @@ end
 
 % Return to default settings:
 chebfunpref.setDefaults(p);
-warning(warnState);
+warning(warnState); lastwarn(lw);
 
 end

--- a/tests/singfun/test_plus.m
+++ b/tests/singfun/test_plus.m
@@ -76,7 +76,7 @@ pass(14) = norm(feval(h1, x) - feval(h2, x), inf) < tol;
 
 % Check that plus handles "small" results appropriately in the case of a
 % non-integer exponent difference.
-warnState = warning('off', 'CHEBFUN:SINGFUN:plus:exponentDiff');
+warnState = warning('off', 'CHEBFUN:SINGFUN:plus:exponentDiff'); lw = lastwarn;
 
 pref_fixed = pref;
 pref_fixed.fixedLength = 256;
@@ -87,7 +87,7 @@ g = singfun(op, [], pref_fixed);
 h = f - g;
 pass(15) = get(h, 'ishappy') && (length(h) < 1024);
 
-warning(warnState);
+warning(warnState); lastwarn(lw);
 
 end
 

--- a/tests/spherefun/test_Poisson.m
+++ b/tests/spherefun/test_Poisson.m
@@ -31,9 +31,9 @@ pass(4) = ( abs(mean2(u)) < tol );
 % Check that the code properly deals with a right hand side without a 
 % mean of zero.
 f = spherefun(@(x,y,z) 1 + x);
-warning('off','CHEBFUN:SPHEREFUN:POISSON:meanRHS');
+warning('off','CHEBFUN:SPHEREFUN:POISSON:meanRHS'); lw = lastwarn;
 u = spherefun.poisson(f, 0, 10);
-warning('on','CHEBFUN:SPHEREFUN:POISSON:meanRHS');
+warning('on','CHEBFUN:SPHEREFUN:POISSON:meanRHS'); lastwarn(lw);
 % This f - mean2(f)
 g = spherefun(@(x,y,z) x);
 % Solution with the mean of f set to zero

--- a/tests/unbndfun/test_innerProduct.m
+++ b/tests/unbndfun/test_innerProduct.m
@@ -36,9 +36,9 @@ opg = @(x) exp(-x);
 pref = chebfunpref();
 f = unbndfun(opf, struct('domain', dom, 'exponents', [0 1]), pref);
 g = unbndfun(opg, struct('domain', dom));
-warning('off', 'CHEBFUN:UNBNDFUN:sum:slowDecay');
+warning('off', 'CHEBFUN:UNBNDFUN:sum:slowDecay'); lw = lastwarn;
 I = innerProduct(f, g);
-warning('off', 'CHEBFUN:UNBNDFUN:sum:slowDecay');
+warning('off', 'CHEBFUN:UNBNDFUN:sum:slowDecay'); lastwarn(lw)
 IExact = 2*exp(-1);
 err = abs(I - IExact);
 pass(2) = err < 2e8*max(eps*get(f,'vscale'), ...


### PR DESCRIPTION
Suppress all verbose warning messages in chebtest but indicate which tests threw warnings. All warnings are deactivated at the start of chebtest and reset at the end.

For example
```
>> chebtest('chebfun3v')
Running tests in chebfun3v:
  Test #001: chebfun3v/test_arithmetic.m ...      passed in 1.0956s
  Test #002: chebfun3v/test_compose.m ...         passed in 2.0684s
  Test #003: chebfun3v/test_conj.m ...            passed in 1.0000s
  Test #004: chebfun3v/test_constructor.m ...     passed in 2.2719s
  Test #005: chebfun3v/test_constructor2.m ...    passed in 0.5461s
  Test #006: chebfun3v/test_cross.m ...           passed in 1.3107s
  Test #007: chebfun3v/test_curl.m ...            passed in 0.2230s
  Test #008: chebfun3v/test_divergence.m ...      passed in 0.6017s (with warnings)
  Test #009: chebfun3v/test_divgrad.m ...         passed in 0.2540s
  Test #010: chebfun3v/test_dot.m ...             passed in 1.2562s
  Test #011: chebfun3v/test_empty.m ...           passed in 0.0023s
  Test #012: chebfun3v/test_imag.m ...            passed in 1.2360s
  Test #013: chebfun3v/test_integral.m ...        passed in 0.4029s
  Test #014: chebfun3v/test_integral2.m ...       passed in 0.2569s
  Test #015: chebfun3v/test_isPeriodicTech.m ...  passed in 0.0786s
  Test #016: chebfun3v/test_isreal.m ...          passed in 0.2665s
  Test #017: chebfun3v/test_jacobian.m ...        passed in 0.3759s
  Test #018: chebfun3v/test_laplacian.m ...       passed in 0.6367s
  Test #019: chebfun3v/test_minandmax3est.m ...   passed in 0.0755s
  Test #020: chebfun3v/test_quiver3.m ...         passed in 0.1556s
  Test #021: chebfun3v/test_real.m ...            passed in 0.6900s
  Test #022: chebfun3v/test_root.m ...            passed in 0.4053s
  Test #023: chebfun3v/test_size.m ...            passed in 0.0926s
  Test #024: chebfun3v/test_subsref.m ...         passed in 2.0485s
  Test #025: chebfun3v/test_syntax.m ...          passed in 0.6620s
  Test #026: chebfun3v/test_threecomponents.m ... passed in 2.1396s
  Test #027: chebfun3v/test_times.m ...           passed in 0.7496s
  Test #028: chebfun3v/test_twocomponents.m ...   passed in 0.6153s
  Test #029: chebfun3v/test_vertcat.m ...         passed in 0.6483s
All chebfun3v tests passed in 22.1657s.

The following tests displayed unexpected warnings:
   chebfun3v/test_divergence.m WARNING
```

At the time of this commit, the only tests  returning 'unexpected' warning messages are 
```
   chebfun3/test_battery.m WARNING
   chebfun3/test_chebfun3f.m WARNING
   chebfun3/test_optimization.m WARNING
   chebfun3/test_techs.m WARNING
   chebfun3v/test_divergence.m WARNING
```
These all throw ```'MATLAB:singularMatrix'```.
