### PR TITLE
modified AAA residues calculation

### DIFF
--- a/aaa.m
+++ b/aaa.m
@@ -268,6 +268,14 @@ if ( deriv_deg >= 1 )
     r = r_output;
 end
 
+% Compute more accurate residues, if nargout > 2:
+if ( nargout > 2 )
+    deg = max(0, length(zer)-length(pol) );
+    A = [Z.^(0:deg) 1./(Z-pol.')];
+    c = A\F;
+    res = c(deg+2:end);
+end
+
 end % of AAA()
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%   PARSEINPUTS   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -674,6 +682,8 @@ pol = eig(E, B);
 pol = pol(~isinf(pol));
 
 % Compute residues via formula for res of quotient of analytic functions:
+% (This is not always accurate and starting in 2025 is overwritten in
+% the calling function by a least-squares computation of residues.)
 N = @(t) (1./(t-zj.')) * (fj.*wj);
 Ddiff = @(t) -((1./(t-zj.')).^2) * wj;
 res = N(pol)./Ddiff(pol);

--- a/tests/chebfun/test_aaa.m
+++ b/tests/chebfun/test_aaa.m
@@ -176,6 +176,12 @@ err = abs( norm(F-r(Z),inf) - 1.19e-11 ); pass(39) = abs(err) < 1e-12;
 rp = rr{2};
 pass(40) = abs(rp(1)+0.5) < 1e-6;
 
+Z = linspace(-1,1,100); F = Z + 1./(Z-1.5);
+[r,pol,res] = aaa(F, Z); % residual computation check
+[~,ii] = min(abs(pol-1.5));
+err = res(ii)-1;
+pass(41) = abs(err) < 1e-8;
+
 warning('on', 'AAA:Froissart');
 
 end


### PR DESCRIPTION
The `aaa.m` calculation of residues is inaccurate in the sense that much smaller residuals can often be achieved if we replace it by a residue calculation based on a least-squares fit.  This pull request does the replacement.

Approximation of functions with poles at infinity may be problematic.  We don't know everything about calculating residues!  See 
[rat385_residues.pdf](https://github.com/user-attachments/files/22011246/rat385_residues.pdf)
for information justifying (I hope) this change.