### PR TITLE
diag scaling for AAA for ill-cond problems

### DIFF
--- a/tests/chebfun/test_aaa.m
+++ b/tests/chebfun/test_aaa.m
@@ -182,6 +182,12 @@ Z = linspace(-1,1,100); F = Z + 1./(Z-1.5);
 err = res(ii)-1;
 pass(41) = abs(err) < 1e-8;
 
+Z = logspace(-15,0,300)'; F = Z.^(1/2); 
+r = aaa(F, Z); % this test checks diag scaling is working
+ZZ = logspace(-15,0,500)';
+err = norm(r(ZZ)-sqrt(ZZ),inf);
+pass(42) = err < 1e-8;
+
 warning('on', 'AAA:Froissart');
 
 end


### PR DESCRIPTION
This aaa.m uses a diagonal scaling to normalize the columns of the Loewner matrix A(J,:), if (and only if) A(J,:) is numerically singular. Fei Xue has reported that this can improve the accuracy for problems where the aaa convergence used to stagnate. It seems to be at least as good as the previous aaa without such scaling, so we're introducing it here. 