### PR TITLE
Fix-chebfun-fred

### DIFF
--- a/@chebfun/chebfun.m
+++ b/@chebfun/chebfun.m
@@ -597,7 +597,14 @@ function [op, dom, data, pref, flags] = parseInputs(op, varargin)
             keywordPrefs.techPrefs.fixedLength = args{1};
             args(1) = [];
         elseif ( strcmpi(args{1}, 'splitting') )
-            keywordPrefs.splitting = strcmpi(args{2}, 'on');
+            if ( strcmpi(args{2}, 'on') )
+                keywordPrefs.splitting = true;
+            elseif ( strcmpi(args{2}, 'off') )
+                keywordPrefs.splitting = false;
+            else
+            error('CHEBFUN:CHEBFUN:parseInputs:badSplitting', ...
+                    'Invalid value for ''splitting'' option. Must be ''on'' or ''off''.')
+            end
             args(1:2) = [];
         elseif ( strcmpi(args{1}, 'minsamples') )
             % Translate "minsamples" --> "techPrefs.minSamples".
@@ -665,6 +672,9 @@ function [op, dom, data, pref, flags] = parseInputs(op, varargin)
                 keywordPrefs.techPrefs.refinementFunction = 'resampling';
             elseif ( strcmpi(args{2}, 'off') )
                 keywordPrefs.techPrefs.refinementFunction = 'nested';
+            else
+                error('CHEBFUN:CHEBFUN:parseInputs:badResampling', ...
+                    'Invalid value for ''resampling'' option. Must be ''on'' or ''off''.')
             end
             args(1:2) = [];
         elseif ( any(strcmpi(args{1}, 'eps')) )

--- a/@chebfun/fred.m
+++ b/@chebfun/fred.m
@@ -55,11 +55,11 @@ function F = fred_col(k, v, onevar)
     % because it corresponds to the refinementFunction tech preference, which
     % doesn't belong to the list of "abstract" preferences required of all
     % techs.  Do we really need to alter it here?
-    opt1 = {'resampling', false, 'splitting', 'on', 'blowup', 'off', ...
+    opt1 = {'resampling', 'on', 'splitting', 'on', 'blowup', 'off', ...
         'vscale', normv};
     int = @(x) sum(chebfun(@(y) feval(v,y).*k(x,y), d, opt1{:}));
 
-    opt2 = {'sampleTest', false, 'resampling', false, 'blowup', 'off', ...
+    opt2 = {'sampleTest', false, 'resampling', 'on', 'blowup', 'off', ...
         'vectorize', 'vscale', normv};
     F = chebfun(int, d, opt2{:});
 

--- a/@chebfun/fred.m
+++ b/@chebfun/fred.m
@@ -55,7 +55,7 @@ function F = fred_col(k, v, onevar)
     % because it corresponds to the refinementFunction tech preference, which
     % doesn't belong to the list of "abstract" preferences required of all
     % techs.  Do we really need to alter it here?
-    opt1 = {'resampling', false, 'splitting', true, 'blowup', 'off', ...
+    opt1 = {'resampling', false, 'splitting', 'on', 'blowup', 'off', ...
         'vscale', normv};
     int = @(x) sum(chebfun(@(y) feval(v,y).*k(x,y), d, opt1{:}));
 

--- a/tests/chebfun/test_splitting_abs.m
+++ b/tests/chebfun/test_splitting_abs.m
@@ -71,5 +71,15 @@ gExact = opAbs(x);
 err = gVals - gExact;
 pass(j+2,:) = norm(err, inf) < 1e6*eps*vscale(g);
 
+%%
+
+try 
+    % Valid options for 'splitting' are 'on' or 'off'. 
+    % The following should fail. See #2461.
+    f = chebfun(op, dom, 'splitting', 1);
+    pass(end+1,:) = false;
+catch
+    pass(end+1,:) = true;
+end
 
 end


### PR DESCRIPTION
`chebfun(@(x) abs(x), 'splitting', 1)` now throws an error.

Previously it would simply not perform splitting and henceresult in a `Warning: Function not resolved using 65537 pts.` error for this particular example. 

This was pointed out in #2461 as `@chebfun/fred' was calling the constructor in this way.
