### PR TITLE
Add `is_octave` function to select Octave or Matlab specific code

### DIFF
--- a/@chebfun/dimCheck.m
+++ b/@chebfun/dimCheck.m
@@ -1,7 +1,7 @@
 function out = dimCheck(f, g, ~)
 %DIMCHECK   Check dimension compatibility of two CHEBFUN objects.
-%   The behaviour depends on whether "broadcasting" is suppported.
-%   Without broacasting (e.g., MATLAB <= 2016a) DIMCHECK(F, G) returns:
+%   The behaviour depends on whether "broadcasting" is supported.
+%   Without broadcasting (e.g., MATLAB <= 2016a) DIMCHECK(F, G) returns:
 %       1    if numColumns(F) == numColumns(G)
 %     error  otherwise.
 %

--- a/@chebfun/dimCheck.m
+++ b/@chebfun/dimCheck.m
@@ -1,10 +1,11 @@
 function out = dimCheck(f, g, ~)
 %DIMCHECK   Check dimension compatibility of two CHEBFUN objects.
-%   In MATLAB 2016a and below DIMCHECK(F, G) returns:
+%   The behaviour depends on whether "broadcasting" is suppported.
+%   Without broacasting (e.g., MATLAB <= 2016a) DIMCHECK(F, G) returns:
 %       1    if numColumns(F) == numColumns(G)
 %     error  otherwise.
 %
-%   In MATLAB 2016b and above DIMCHECK(F, G) returns:
+%   With brodcasting (e.g., MATLAB >= 2016b) DIMCHECK(F, G) returns:
 %       1    if numColumns(F) == numColumns(G)
 %      -1    if numColumns(F) == 1 or numColumns(G) == 1
 %     error  otherwise.
@@ -29,8 +30,8 @@ else
 end
 
 % Adjust for MATLAB version if out = -1:
-if ( (out == -1 ) && verLessThan('matlab', '9.1') )
-   out = 0; 
+if ( (out == -1) && ~is_octave() && verLessThan('matlab', '9.1') )
+   out = 0;
 end
 
 if ( out == 0 && nargin == 2 )

--- a/@chebfun/disp.m
+++ b/@chebfun/disp.m
@@ -7,7 +7,12 @@ function disp(f)
 % See http://www.chebfun.org/ for Chebfun information.
 
 % If the 'format loose' setting is enabled, we print additional linebreaks:
-loose = strcmp(get(0, 'FormatSpacing'), 'loose');
+if is_octave()
+    [fmt, spacing] = format();
+    loose = strcmp(spacing, 'loose');
+else
+    loose = strcmp(get(0, 'FormatSpacing'), 'loose');
+end
 
 s = '';
 

--- a/@chebfun/display.m
+++ b/@chebfun/display.m
@@ -13,7 +13,14 @@ function display(X)
 % Copyright 2017 by The University of Oxford and The Chebfun Developers. 
 % See http://www.chebfun.org/ for Chebfun information.
 
-if ( isequal(get(0, 'FormatSpacing'), 'compact') )
+if is_octave()
+    [fmt, spacing] = format();
+    compact = strcmp(spacing, 'compact');
+else
+    compact = strcmp(get(0, 'FormatSpacing'), 'compact');
+end
+
+if ( compact )
     disp([inputname(1), ' =']);
     disp(X);
 else

--- a/@chebfun/nextpow2.m
+++ b/@chebfun/nextpow2.m
@@ -25,7 +25,7 @@ end
 
 % NEXTPOW2 is not vectorized in versions of MATLAB prior to R2010a.  Vectorize
 % it manually if we're running on older platforms.
-if ( verLessThan('matlab', '7.10') )
+if ( ~is_octave() && verLessThan('matlab', '7.10') )
     mynextpow2 = @nextpow2Vectorized;
 else
     mynextpow2 = @nextpow2;

--- a/@chebfun/plot.m
+++ b/@chebfun/plot.m
@@ -302,8 +302,16 @@ end
 
 %% Plotting starts here:
 
+% For plotting, it's useful to know whether we're running in old or new
+% Matlab graphics mode
+if ( is_octave() || ~verLessThan('matlab', '8.4') )
+    newGraphicsMode = true;
+else
+    newGraphicsMode = false;
+end
+
 % Acquire initial color cycle if running R2014b+.
-if ( ~verLessThan('matlab', '8.4') )
+if ( newGraphicsMode )
     if ( ~holdState )
         set(gca, 'ColorOrderIndex', 1);
     end
@@ -318,7 +326,7 @@ set(h1, 'Marker', 'none', lineStyle{:})
 hold on
 
 % Get color cycle prior to point plot if running R2014b.
-if ( ~verLessThan('matlab', '8.4') )
+if ( newGraphicsMode )
     newColorOrder = get(gca, 'ColorOrderIndex');
     set(gca, 'ColorOrderIndex', originalColorOrder)
 end
@@ -333,7 +341,7 @@ if ( intervalIsSet )
 end
 
 % Reset color cycle prior to jump plot if running R2014b.
-if ( ~verLessThan('matlab', '8.4') )
+if ( newGraphicsMode )
     set(gca, 'ColorOrderIndex', originalColorOrder);
 end
 
@@ -366,7 +374,7 @@ if ( ~isempty(deltaStyle) )
 end    
 
 % Reset colors prior to legend data plot if running R2014b.
-if ( ~verLessThan('matlab', '8.4') )
+if ( newGraphicsMode )
     set(gca, 'ColorOrderIndex', originalColorOrder);
 end
 
@@ -387,7 +395,7 @@ if ( ~isempty(lineStyle) || ~isempty(pointStyle) )
 end
 
 % Reset colors prior to legend data plot if running R2014b.
-if ( ~verLessThan('matlab', '8.4') )
+if ( newGraphicsMode )
     set(gca, 'ColorOrderIndex', newColorOrder);
 end
 
@@ -445,15 +453,21 @@ function h = plotDeltas(deltaData)
 %PLOTDELTAS   Plots delta functions.
     h = [];
 
+    if ( is_octave() || ~verLessThan('matlab', '8.4') )
+        newGraphicsMode = true;
+    else
+        newGraphicsMode = false;
+    end
+
     % Get and save the current ColorOrder if running on R2014a or earlier.
-    if ( verLessThan('matlab', '8.4') )
+    if ( ~newGraphicsMode )
         originalColorOrder = get(gca, 'ColorOrder');
         colorOrder = circshift(originalColorOrder, 1);
     end
 
     for k = 1:1:numel(deltaData)
         % Set color for the next delta function plot.
-        if ( verLessThan('matlab', '8.4') )
+        if ( ~newGraphicsMode )
             % Manually manipulate the ColorOrder for R2014a or earlier.
             colorOrder = circshift(colorOrder, -1);
             set(gca, 'ColorOrder', colorOrder);
@@ -466,7 +480,7 @@ function h = plotDeltas(deltaData)
     end
 
     % Restore the ColorOrder if running on R2014a or earlier.
-    if ( verLessThan('matlab', '8.4') )
+    if ( ~newGraphicsMode )
         set(gca, 'ColorOrder', originalColorOrder);
     end
 end

--- a/@chebfun/why.m
+++ b/@chebfun/why.m
@@ -15,7 +15,7 @@ if ( nargin == 1 )
     r = ceil(n*rand);
 end
 
-if ( verLessThan('matlab', '7.9') )
+if ( ~is_octave() && verLessThan('matlab', '7.9') )
     simpleText = true;
 else
     simpleText = false;

--- a/@chebfun2/disp.m
+++ b/@chebfun2/disp.m
@@ -1,12 +1,17 @@
 function disp(F)
 %DISP   Display a CHEBFUN2 to the command line.
-% 
+%
 % See also DISPLAY.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-loose = strcmp( get(0, 'FormatSpacing'), 'loose' );
+if is_octave()
+    [fmt, spacing] = format();
+    loose = strcmp(spacing, 'loose');
+else
+    loose = strcmp(get(0, 'FormatSpacing'), 'loose');
+end
 
 % Get display style and remove trivial empty CHEBFUN2 case. 
 if ( isempty(F) )

--- a/@chebfun2/display.m
+++ b/@chebfun2/display.m
@@ -9,10 +9,17 @@ function display(X)
 %
 % See also DISP.
 
-% Copyright 2017 by The University of Oxford and The Chebfun Developers. 
+% Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-if ( isequal(get(0, 'FormatSpacing'), 'compact') )
+if is_octave()
+    [fmt, spacing] = format();
+    compact = strcmp(spacing, 'compact');
+else
+    compact = strcmp(get(0, 'FormatSpacing'), 'compact');
+end
+
+if ( compact )
 	disp([inputname(1), ' =']);
 	disp(X);
 else
@@ -23,5 +30,3 @@ else
 end
 
 end
-
-

--- a/@chebfun2v/disp.m
+++ b/@chebfun2v/disp.m
@@ -4,9 +4,14 @@ function disp(F)
 % See also DISPLAY.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
-% See http://www.chebfun.org/ for Chebfun information. 
+% See http://www.chebfun.org/ for Chebfun information.
 
-loose = strcmp(get(0,'FormatSpacing'),'loose');
+if is_octave()
+    [fmt, spacing] = format();
+    loose = strcmp(spacing, 'loose');
+else
+    loose = strcmp(get(0, 'FormatSpacing'), 'loose');
+end
 
 % Compact version
 if ( isempty( F ) )

--- a/@chebfun2v/display.m
+++ b/@chebfun2v/display.m
@@ -8,9 +8,16 @@ function display(X)
 %   statement that results in a CHEBFUN2V.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
-% See http://www.chebfun.org/ for Chebfun information. 
+% See http://www.chebfun.org/ for Chebfun information.
 
-if ( isequal(get(0, 'FormatSpacing'), 'compact') )
+if is_octave()
+    [fmt, spacing] = format();
+    compact = strcmp(spacing, 'compact');
+else
+    compact = strcmp(get(0, 'FormatSpacing'), 'compact');
+end
+
+if ( compact )
 	disp([inputname(1), ' =']);
 	disp(X);
 else

--- a/@chebfun3/disp.m
+++ b/@chebfun3/disp.m
@@ -1,12 +1,17 @@
 function disp(F)
 %DISP   Display a CHEBFUN3 to the command line.
-% 
+%
 % See also CHEBFUN3/DISPLAY.
 
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-loose = strcmp( get(0, 'FormatSpacing'), 'loose');
+if is_octave()
+    [fmt, spacing] = format();
+    loose = strcmp(spacing, 'loose');
+else
+    loose = strcmp(get(0, 'FormatSpacing'), 'loose');
+end
 
 % Get display style and remove trivial empty CHEBFUN3 case.
 if ( isempty(F) )

--- a/@chebfun3/display.m
+++ b/@chebfun3/display.m
@@ -12,7 +12,14 @@ function display(F)
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-if ( isequal(get(0, 'FormatSpacing'), 'compact') )
+if is_octave()
+    [fmt, spacing] = format();
+    compact = strcmp(spacing, 'compact');
+else
+    compact = strcmp(get(0, 'FormatSpacing'), 'compact');
+end
+
+if ( compact )
 	disp([inputname(1), ' =']);
 	disp(F);
 else

--- a/@chebfun3t/display.m
+++ b/@chebfun3t/display.m
@@ -4,7 +4,14 @@ function display(F)
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-if ( isequal(get(0, 'FormatSpacing'), 'compact') )
+if is_octave()
+    [fmt, spacing] = format();
+    loose = strcmp(spacing, 'loose');
+else
+    loose = strcmp(get(0, 'FormatSpacing'), 'loose');
+end
+
+if ( ~ loose )
 	disp([inputname(1), ' =']);
 else
 	disp(' ');
@@ -12,7 +19,6 @@ else
 	disp(' ');
 end
 
-loose = strcmp( get(0, 'FormatSpacing'), 'loose');
 
 % Get display style and remove trivial empty CHEBFUN3 case.
 if ( isempty(F) )

--- a/@chebfun3v/disp.m
+++ b/@chebfun3v/disp.m
@@ -6,7 +6,12 @@ function disp(F)
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-loose = strcmp(get(0, 'FormatSpacing'), 'loose');
+if is_octave()
+    [fmt, spacing] = format();
+    loose = strcmp(spacing, 'loose');
+else
+    loose = strcmp(get(0, 'FormatSpacing'), 'loose');
+end
 
 % Compact version
 if ( isempty(F) )

--- a/@chebfun3v/display.m
+++ b/@chebfun3v/display.m
@@ -12,7 +12,14 @@ function display(F)
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-if ( isequal(get(0, 'FormatSpacing'), 'compact') )
+if is_octave()
+    [fmt, spacing] = format();
+    compact = strcmp(spacing, 'compact');
+else
+    compact = strcmp(get(0, 'FormatSpacing'), 'compact');
+end
+
+if ( compact )
 	disp([inputname(1), ' =']);
 	disp(F);
 else

--- a/@separableApprox/waterfall.m
+++ b/@separableApprox/waterfall.m
@@ -37,7 +37,7 @@ plotOpts = {};
 
 % For plotting, it's useful to know whether we're running in old or new
 % Matlab graphics mode
-if ( ~verLessThan('matlab', '8.4') )
+if ( is_octave() || ~verLessThan('matlab', '8.4') )
     newMatlabVersion = true;
 else
     newMatlabVersion = false;

--- a/is_octave.m
+++ b/is_octave.m
@@ -1,0 +1,9 @@
+function tf = is_octave()
+  persistent cached_is_octave;
+
+  if isempty(cached_is_octave)
+    cached_is_octave = exist('OCTAVE_VERSION', 'builtin') ~= 0;
+  end
+
+  tf = cached_is_octave;
+end

--- a/seedRNG.m
+++ b/seedRNG.m
@@ -12,7 +12,7 @@ function seedRNG(s)
 % Copyright 2017 by The University of Oxford and The Chebfun Developers.
 % See http://www.chebfun.org/ for Chebfun information.
 
-if ( verLessThan('matlab', '7.12') )
+if ( ~is_octave() && verLessThan('matlab', '7.12') )
     % Before R2011a.
     rand('seed', s);
     randn('seed', s);

--- a/tests/chebfun/test_airy.m
+++ b/tests/chebfun/test_airy.m
@@ -28,7 +28,7 @@ for im = [0 1]
         for scale = 0
 
             % AIRY does not support the "scale" input prior to R2013a.
-            if ( verLessThan('matlab', '8.1') )
+            if ( ~is_octave() && verLessThan('matlab', '8.1') )
                 F = @(x) airy(K, (1+im*1i)*x);
             else
                 F = @(x) airy(K, (1+im*1i)*x, scale);

--- a/tests/chebfun/test_nextpow2.m
+++ b/tests/chebfun/test_nextpow2.m
@@ -12,7 +12,7 @@ x = 2 * rand(100, 1) - 1;
 
 % NEXTPOW2 is not vectorized in versions of MATLAB prior to R2010a.  Vectorize
 % it manually if we're running on older platforms.
-if ( verLessThan('matlab', '7.10') )
+if ( ~is_octave() && verLessThan('matlab', '7.10') )
     mynextpow2 = @nextpow2Vectorized;
 else
     mynextpow2 = @nextpow2;

--- a/tests/chebpref/test_chebfunpref.m
+++ b/tests/chebpref/test_chebfunpref.m
@@ -199,7 +199,7 @@ warning(warnStateT);
 end
 
 function out = isequalNaN(a, b)
-    if ( verLessThan('matlab', '7.14') )
+    if ( ~is_octave() && verLessThan('matlab', '7.14') )
         out = isequalwithequalnans(a, b);
     else
         out = isequaln(a, b);

--- a/tests/chebpref/test_cheboppref.m
+++ b/tests/chebpref/test_cheboppref.m
@@ -61,7 +61,7 @@ pass(10) = strcmp(pref.discretization, 'coeffs');
 end
 
 function out = isequalNaN(a, b)
-    if ( verLessThan('matlab', '7.14') )
+    if ( ~is_octave() && verLessThan('matlab', '7.14') )
         out = isequalwithequalnans(a, b);
     else
         out = isequaln(a, b);

--- a/tests/chebtech/test_compose.m
+++ b/tests/chebtech/test_compose.m
@@ -113,13 +113,13 @@ for n = 1:4
         f = testclass.make(@(x) [x x.^2]);
         g = testclass.make(@(x) sin(x));
         compose(f, @plus, g);
-        if ( verLessThan('matlab', '9.1') )
+        if ( ~is_octave() && verLessThan('matlab', '9.1') )
             pass(n, 11) = false;
         else
             pass(n, 11) = true;
         end
     catch ME
-        if ( verLessThan('matlab', '9.1') )
+        if ( ~is_octave() && verLessThan('matlab', '9.1') )
             pass(n, 11) = strcmp(ME.message, 'Matrix dimensions must agree.');
         else
             pass(n, 11) = false;

--- a/tests/chebtech/test_minus.m
+++ b/tests/chebtech/test_minus.m
@@ -72,20 +72,20 @@ for n = 1:2
     g = testclass.make(g_op, [], pref);
     pass(n, 16:17) = test_sub_function_and_function(f, f_op, g, g_op, x);
     
-    % This should fail with a dimension mismatch error.
-    % (Actually, we can do this in R2016a anda above!)
+    % This used to fail with a dimension mismatch error.
+    % (But we can do this in R2016a and later b/c of broadcasting)
     g_op = @(x) sin(x);
     g = testclass.make(g_op, [], pref);
-    try 
+    try
         h = f - g; %#ok<NASGU>
         pass(n, 18) = false;
-        if ( verLessThan('matlab', '9.1') )
+        if ( ~is_octave() && verLessThan('matlab', '9.1') )
             pass(n, 18) = false;
         else
             pass(n, 18) = true;
         end
     catch ME
-        if ( verLessThan('matlab', '9.1') )
+        if ( ~is_octave() && verLessThan('matlab', '9.1') )
             pass(n, 18) = strcmp(ME.identifier, 'MATLAB:dimagree');
         else
             pass(n, 18) = false;

--- a/tests/chebtech/test_plus.m
+++ b/tests/chebtech/test_plus.m
@@ -73,19 +73,19 @@ for n = 1:2
     g = testclass.make(g_op, [], pref);
     pass(n, 16:17) = test_add_function_to_function(f, f_op, g, g_op, x);
     
-    % This should fail with a dimension mismatch error.
+    % Used to fail with a dimension mismatch error before broadcasting was added
     g_op = @(x) sin(x);
     g = testclass.make(g_op, [], pref);
-    try 
+    try
         h = f + g; %#ok<NASGU>
         pass(n, 18) = false;
-        if ( verLessThan('matlab', '9.1') )
+        if ( ~is_octave() && verLessThan('matlab', '9.1') )
             pass(n, 18) = false;
         else
             pass(n, 18) = true;
         end
     catch ME
-        if ( verLessThan('matlab', '9.1') )
+        if ( ~is_octave() && verLessThan('matlab', '9.1') )
             pass(n, 18) = strcmp(ME.identifier, 'MATLAB:dimagree');
         else
             pass(n, 18) = false;

--- a/tests/classicfun/test_minus.m
+++ b/tests/classicfun/test_minus.m
@@ -70,13 +70,13 @@ g_op = @(x) sin(x);
 g = bndfun(g_op, data, pref);
 try
     h = f - g; %#ok<NASGU>
-    if ( verLessThan('matlab', '9.1') )
+    if ( ~is_octave() && verLessThan('matlab', '9.1') )
         pass(18) = false;
     else
         pass(18) = true;
     end
 catch ME
-    if ( verLessThan('matlab', '9.1') )
+    if ( ~is_octave() && verLessThan('matlab', '9.1') )
         pass(18) = strcmp(ME.message, 'Matrix dimensions must agree.');
     else
         pass(18) = false;

--- a/tests/classicfun/test_plus.m
+++ b/tests/classicfun/test_plus.m
@@ -73,13 +73,13 @@ g_op = @(x) sin(x);
 g = bndfun(g_op, data, pref);
 try
     h = f + g; %#ok<NASGU>
-    if ( verLessThan('matlab', '9.1') )
+    if ( ~is_octave() && verLessThan('matlab', '9.1') )
         pass(18) = false;
     else
         pass(18) = true;
     end
 catch ME
-    if ( verLessThan('matlab', '9.1') )
+    if ( ~is_octave() && verLessThan('matlab', '9.1') )
         pass(18) = strcmp(ME.message, 'Matrix dimensions must agree.');
     else
         pass(18) = false;

--- a/tests/trigtech/test_minus.m
+++ b/tests/trigtech/test_minus.m
@@ -68,13 +68,13 @@ g_op = @(x) sin(10*pi*x);
 g = testclass.make(g_op, [], pref);
 try
     h = f - g; %#ok<NASGU>
-    if ( verLessThan('matlab', '9.1') )
+    if ( ~is_octave() && verLessThan('matlab', '9.1') )
         pass(16) = false;
     else
         pass(16) = true;
     end
 catch ME
-    if ( verLessThan('matlab', '9.1') )
+    if ( ~is_octave() && verLessThan('matlab', '9.1') )
         pass(16) = strcmp(ME.message, 'Matrix dimensions must agree.');
     else
         pass(16) = false;

--- a/tests/trigtech/test_plus.m
+++ b/tests/trigtech/test_plus.m
@@ -76,13 +76,13 @@ g_op = @(x) sin(10*x);
 g = testclass.make(g_op, [], pref);
 try
     h = f + g; %#ok<NASGU>
-    if ( verLessThan('matlab', '9.1') )
+    if ( ~is_octave() && verLessThan('matlab', '9.1') )
         pass(18) = false;
     else
         pass(18) = true;
     end
 catch ME
-    if ( verLessThan('matlab', '9.1') )
+    if ( ~is_octave() && verLessThan('matlab', '9.1') )
         pass(18) = strcmp(ME.message, 'Matrix dimensions must agree.');
     else
         pass(18) = false;


### PR DESCRIPTION
  * checking for loose vs compact is done differently on Octave vs Matlab
  * Some places in Chebfun use `verLessThan('matlab', '7.10')` to use different code in different versions.

@kolmanthomas  and I added an `is_octave()` function which returns True on Octave and False on Matlab.

(So far, there are no Octave version-specific code because we can only run on the very latest version of Octave.)