### PR TITLE
Align workflow trigger and license link with master branch

### DIFF
--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -6,11 +6,11 @@
 
 name: Matlab tests
 
-# Trigger on pushes to main and commits to pull requests.
+# Trigger on pushes to master and commits to pull requests.
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,4 +4,4 @@ CONTRIBUTING
 By contributing code to Chebfun, you agree to release it under the project's
 [license][1] and moreover certify that you have the right to do so.
 
-[1]: https://github.com/chebfun/chebfun/blob/development/LICENSE.txt
+[1]: https://github.com/chebfun/chebfun/blob/master/LICENSE.txt


### PR DESCRIPTION
## Summary

This PR aligns two branch references with the repository default branch, `master`:

- updates the MATLAB test workflow push trigger from `main` to `master`;
- updates the `CONTRIBUTING.md` license link from the non-existent `development` branch to `master`.

## Validation

- `git diff --check`
- `uvx codespell CONTRIBUTING.md .github/workflows/matlab.yml`

This only changes documentation and GitHub Actions branch metadata, so I did not run the MATLAB test suite locally.